### PR TITLE
pytest.ini: drop python-contrib relic

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,4 +2,3 @@
 addopts = -rs -v
 log_cli = true
 log_cli_level = warning
-testpaths = instrumentation/opentelemetry-instrumentation-falcon/tests/


### PR DESCRIPTION
Not sure if that line does anything but looks odd enough to be removed.