### PR TITLE
Add instrumentation for chat.completions.parse() (structured outputs)

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-openai-v2/.changelog/18.added
+++ b/instrumentation/opentelemetry-instrumentation-openai-v2/.changelog/18.added
@@ -1,0 +1,1 @@
+Add instrumentation for `chat.completions.parse()` structured outputs

--- a/instrumentation/opentelemetry-instrumentation-openai-v2/src/opentelemetry/instrumentation/openai_v2/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-openai-v2/src/opentelemetry/instrumentation/openai_v2/__init__.py
@@ -97,9 +97,25 @@ from .patch_responses import (
 )
 
 
+def _is_parse_supported():
+    """Check if the parse() method is available on the Completions class.
+
+    The parse() method for structured outputs was added in openai >= 1.40.0.
+    """
+    try:
+        from openai.resources.chat.completions import (  # pylint: disable=import-outside-toplevel  # noqa: PLC0415
+            Completions,
+        )
+
+        return hasattr(Completions, "parse")
+    except ImportError:
+        return False
+
+
 class OpenAIInstrumentor(BaseInstrumentor):
     def __init__(self):
         self._meter = None
+        self._parse_supported = False
 
     def instrumentation_dependencies(self) -> Collection[str]:
         return _instruments
@@ -181,6 +197,36 @@ class OpenAIInstrumentor(BaseInstrumentor):
             ),
         )
 
+        # parse() wraps create() internally in the OpenAI SDK and returns a
+        # ParsedChatCompletion. The telemetry-relevant fields (model, usage,
+        # choices, finish_reason) are identical to ChatCompletion, so the
+        # existing create() wrappers handle it correctly.
+        self._parse_supported = _is_parse_supported()
+        if self._parse_supported:
+            wrap_function_wrapper(
+                "openai.resources.chat.completions",
+                "Completions.parse",
+                (
+                    chat_completions_create_v_new(handler)
+                    if latest_experimental_enabled
+                    else chat_completions_create_v_old(
+                        tracer, logger, instruments, is_content_enabled()
+                    )
+                ),
+            )
+
+            wrap_function_wrapper(
+                "openai.resources.chat.completions",
+                "AsyncCompletions.parse",
+                (
+                    async_chat_completions_create_v_new(handler)
+                    if latest_experimental_enabled
+                    else async_chat_completions_create_v_old(
+                        tracer, logger, instruments, is_content_enabled()
+                    )
+                ),
+            )
+
         responses_module = _get_responses_module()
         # Responses instrumentation is intentionally limited to the latest
         # experimental semconv path. Unlike chat completions, we do not carry
@@ -201,6 +247,9 @@ class OpenAIInstrumentor(BaseInstrumentor):
         unwrap(openai.resources.chat.completions.AsyncCompletions, "create")
         unwrap(openai.resources.embeddings.Embeddings, "create")
         unwrap(openai.resources.embeddings.AsyncEmbeddings, "create")
+        if self._parse_supported:
+            unwrap(openai.resources.chat.completions.Completions, "parse")
+            unwrap(openai.resources.chat.completions.AsyncCompletions, "parse")
         responses_module = _get_responses_module()
         if responses_module is not None:
             unwrap(responses_module.Responses, "create")

--- a/instrumentation/opentelemetry-instrumentation-openai-v2/src/opentelemetry/instrumentation/openai_v2/utils.py
+++ b/instrumentation/opentelemetry-instrumentation-openai-v2/src/opentelemetry/instrumentation/openai_v2/utils.py
@@ -280,8 +280,18 @@ def get_llm_request_attributes(
             else GenAIAttributes.GEN_AI_OPENAI_REQUEST_RESPONSE_FORMAT
         )
         if (response_format := kwargs.get("response_format")) is not None:
-            # response_format may be string or object with a string in the `type` key
-            if isinstance(response_format, Mapping):
+            # response_format may be string, object with a string in the `type` key,
+            # or a type (e.g. Pydantic model class used with parse())
+            if isinstance(response_format, type):
+                if latest_experimental_enabled:
+                    attributes[request_response_format_attr_key] = (
+                        GenAIAttributes.GenAiOutputTypeValues.JSON.value
+                    )
+                else:
+                    attributes[request_response_format_attr_key] = (
+                        GenAIAttributes.GenAiOpenaiRequestResponseFormatValues.JSON_SCHEMA.value
+                    )
+            elif isinstance(response_format, Mapping):
                 if (
                     response_format_type := response_format.get("type")
                 ) is not None:
@@ -369,8 +379,13 @@ def create_chat_invocation(
     if (
         response_format := get_value(kwargs.get("response_format"))
     ) is not None:
-        # response_format may be string or object with a string in the `type` key
-        if isinstance(response_format, Mapping):
+        # response_format may be string, object with a string in the `type` key,
+        # or a type (e.g. Pydantic model class used with parse())
+        if isinstance(response_format, type):
+            invocation.attributes[GenAIAttributes.GEN_AI_OUTPUT_TYPE] = (
+                GenAIAttributes.GenAiOutputTypeValues.JSON.value
+            )
+        elif isinstance(response_format, Mapping):
             if (
                 response_format_type := get_value(response_format.get("type"))
             ) is not None:

--- a/instrumentation/opentelemetry-instrumentation-openai-v2/tests/cassettes/test_async_structured_output_404.yaml
+++ b/instrumentation/opentelemetry-instrumentation-openai-v2/tests/cassettes/test_async_structured_output_404.yaml
@@ -1,0 +1,90 @@
+interactions:
+- request:
+    body: |-
+      {
+        "messages": [
+          {
+            "role": "user",
+            "content": "Extract the event information from: Team Meeting on 2024-01-15 with Alice and Bob"
+          }
+        ],
+        "model": "this-model-does-not-exist",
+        "response_format": {
+          "type": "json_schema",
+          "json_schema": {
+            "name": "CalendarEvent",
+            "strict": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "name": {"type": "string"},
+                "date": {"type": "string"},
+                "participants": {"items": {"type": "string"}, "type": "array"}
+              },
+              "required": ["name", "date", "participants"],
+              "additionalProperties": false
+            }
+          }
+        }
+      }
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - Bearer test_openai_api_key
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      user-agent:
+      - AsyncOpenAI/Python 1.54.3
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: |-
+        {
+          "error": {
+            "message": "The model `this-model-does-not-exist` does not exist or you do not have access to it.",
+            "type": "invalid_request_error",
+            "param": null,
+            "code": "model_not_found"
+          }
+        }
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 11 Nov 2024 23:43:52 GMT
+      Server:
+      - cloudflare
+      Set-Cookie: test_set_cookie
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      alt-svc:
+      - h3=":443"; ma=86400
+      openai-organization: test_openai_org_id
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      vary:
+      - Origin
+      x-request-id:
+      - req_structured_output_404_async
+    status:
+      code: 404
+      message: Not Found
+version: 1

--- a/instrumentation/opentelemetry-instrumentation-openai-v2/tests/cassettes/test_async_structured_output_no_content.yaml
+++ b/instrumentation/opentelemetry-instrumentation-openai-v2/tests/cassettes/test_async_structured_output_no_content.yaml
@@ -1,0 +1,116 @@
+interactions:
+- request:
+    body: |-
+      {
+        "messages": [
+          {
+            "role": "user",
+            "content": "Extract the event information from: Team Meeting on 2024-01-15 with Alice and Bob"
+          }
+        ],
+        "model": "gpt-4o-mini",
+        "response_format": {
+          "type": "json_schema",
+          "json_schema": {
+            "name": "CalendarEvent",
+            "strict": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "name": {"type": "string"},
+                "date": {"type": "string"},
+                "participants": {"items": {"type": "string"}, "type": "array"}
+              },
+              "required": ["name", "date", "participants"],
+              "additionalProperties": false
+            }
+          }
+        }
+      }
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - Bearer test_openai_api_key
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      user-agent:
+      - OpenAI/Python 1.54.3
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: |-
+        {
+          "id": "chatcmpl-structured-test-004",
+          "object": "chat.completion",
+          "created": 1731368630,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "role": "assistant",
+                "content": "{\"name\": \"Team Meeting\", \"date\": \"2024-01-15\", \"participants\": [\"Alice\", \"Bob\"]}",
+                "refusal": null
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 50,
+            "completion_tokens": 30,
+            "total_tokens": 80,
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            },
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "audio_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0
+            }
+          },
+          "system_fingerprint": "fp_0ba0d124f1"
+        }
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 11 Nov 2024 23:43:50 GMT
+      Server:
+      - cloudflare
+      Set-Cookie: test_set_cookie
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      content-length:
+      - '800'
+      openai-organization: test_openai_org_id
+      openai-processing-ms:
+      - '350'
+      openai-version:
+      - '2020-10-01'
+      x-request-id:
+      - req_structured_test_004
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/instrumentation/opentelemetry-instrumentation-openai-v2/tests/cassettes/test_async_structured_output_with_content.yaml
+++ b/instrumentation/opentelemetry-instrumentation-openai-v2/tests/cassettes/test_async_structured_output_with_content.yaml
@@ -1,0 +1,116 @@
+interactions:
+- request:
+    body: |-
+      {
+        "messages": [
+          {
+            "role": "user",
+            "content": "Extract the event information from: Team Meeting on 2024-01-15 with Alice and Bob"
+          }
+        ],
+        "model": "gpt-4o-mini",
+        "response_format": {
+          "type": "json_schema",
+          "json_schema": {
+            "name": "CalendarEvent",
+            "strict": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "name": {"type": "string"},
+                "date": {"type": "string"},
+                "participants": {"items": {"type": "string"}, "type": "array"}
+              },
+              "required": ["name", "date", "participants"],
+              "additionalProperties": false
+            }
+          }
+        }
+      }
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - Bearer test_openai_api_key
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      user-agent:
+      - OpenAI/Python 1.54.3
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: |-
+        {
+          "id": "chatcmpl-structured-test-003",
+          "object": "chat.completion",
+          "created": 1731368630,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "role": "assistant",
+                "content": "{\"name\": \"Team Meeting\", \"date\": \"2024-01-15\", \"participants\": [\"Alice\", \"Bob\"]}",
+                "refusal": null
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 50,
+            "completion_tokens": 30,
+            "total_tokens": 80,
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            },
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "audio_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0
+            }
+          },
+          "system_fingerprint": "fp_0ba0d124f1"
+        }
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 11 Nov 2024 23:43:50 GMT
+      Server:
+      - cloudflare
+      Set-Cookie: test_set_cookie
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      content-length:
+      - '800'
+      openai-organization: test_openai_org_id
+      openai-processing-ms:
+      - '350'
+      openai-version:
+      - '2020-10-01'
+      x-request-id:
+      - req_structured_test_003
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/instrumentation/opentelemetry-instrumentation-openai-v2/tests/cassettes/test_structured_output_404.yaml
+++ b/instrumentation/opentelemetry-instrumentation-openai-v2/tests/cassettes/test_structured_output_404.yaml
@@ -1,0 +1,90 @@
+interactions:
+- request:
+    body: |-
+      {
+        "messages": [
+          {
+            "role": "user",
+            "content": "Extract the event information from: Team Meeting on 2024-01-15 with Alice and Bob"
+          }
+        ],
+        "model": "this-model-does-not-exist",
+        "response_format": {
+          "type": "json_schema",
+          "json_schema": {
+            "name": "CalendarEvent",
+            "strict": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "name": {"type": "string"},
+                "date": {"type": "string"},
+                "participants": {"items": {"type": "string"}, "type": "array"}
+              },
+              "required": ["name", "date", "participants"],
+              "additionalProperties": false
+            }
+          }
+        }
+      }
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - Bearer test_openai_api_key
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      user-agent:
+      - OpenAI/Python 1.54.3
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: |-
+        {
+          "error": {
+            "message": "The model `this-model-does-not-exist` does not exist or you do not have access to it.",
+            "type": "invalid_request_error",
+            "param": null,
+            "code": "model_not_found"
+          }
+        }
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 11 Nov 2024 23:43:52 GMT
+      Server:
+      - cloudflare
+      Set-Cookie: test_set_cookie
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      alt-svc:
+      - h3=":443"; ma=86400
+      openai-organization: test_openai_org_id
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      vary:
+      - Origin
+      x-request-id:
+      - req_structured_output_404_sync
+    status:
+      code: 404
+      message: Not Found
+version: 1

--- a/instrumentation/opentelemetry-instrumentation-openai-v2/tests/cassettes/test_structured_output_no_content.yaml
+++ b/instrumentation/opentelemetry-instrumentation-openai-v2/tests/cassettes/test_structured_output_no_content.yaml
@@ -1,0 +1,116 @@
+interactions:
+- request:
+    body: |-
+      {
+        "messages": [
+          {
+            "role": "user",
+            "content": "Extract the event information from: Team Meeting on 2024-01-15 with Alice and Bob"
+          }
+        ],
+        "model": "gpt-4o-mini",
+        "response_format": {
+          "type": "json_schema",
+          "json_schema": {
+            "name": "CalendarEvent",
+            "strict": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "name": {"type": "string"},
+                "date": {"type": "string"},
+                "participants": {"items": {"type": "string"}, "type": "array"}
+              },
+              "required": ["name", "date", "participants"],
+              "additionalProperties": false
+            }
+          }
+        }
+      }
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - Bearer test_openai_api_key
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      user-agent:
+      - OpenAI/Python 1.54.3
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: |-
+        {
+          "id": "chatcmpl-structured-test-002",
+          "object": "chat.completion",
+          "created": 1731368630,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "role": "assistant",
+                "content": "{\"name\": \"Team Meeting\", \"date\": \"2024-01-15\", \"participants\": [\"Alice\", \"Bob\"]}",
+                "refusal": null
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 50,
+            "completion_tokens": 30,
+            "total_tokens": 80,
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            },
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "audio_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0
+            }
+          },
+          "system_fingerprint": "fp_0ba0d124f1"
+        }
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 11 Nov 2024 23:43:50 GMT
+      Server:
+      - cloudflare
+      Set-Cookie: test_set_cookie
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      content-length:
+      - '800'
+      openai-organization: test_openai_org_id
+      openai-processing-ms:
+      - '350'
+      openai-version:
+      - '2020-10-01'
+      x-request-id:
+      - req_structured_test_002
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/instrumentation/opentelemetry-instrumentation-openai-v2/tests/cassettes/test_structured_output_with_content.yaml
+++ b/instrumentation/opentelemetry-instrumentation-openai-v2/tests/cassettes/test_structured_output_with_content.yaml
@@ -1,0 +1,116 @@
+interactions:
+- request:
+    body: |-
+      {
+        "messages": [
+          {
+            "role": "user",
+            "content": "Extract the event information from: Team Meeting on 2024-01-15 with Alice and Bob"
+          }
+        ],
+        "model": "gpt-4o-mini",
+        "response_format": {
+          "type": "json_schema",
+          "json_schema": {
+            "name": "CalendarEvent",
+            "strict": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "name": {"type": "string"},
+                "date": {"type": "string"},
+                "participants": {"items": {"type": "string"}, "type": "array"}
+              },
+              "required": ["name", "date", "participants"],
+              "additionalProperties": false
+            }
+          }
+        }
+      }
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - Bearer test_openai_api_key
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      user-agent:
+      - OpenAI/Python 1.54.3
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: |-
+        {
+          "id": "chatcmpl-structured-test-001",
+          "object": "chat.completion",
+          "created": 1731368630,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "role": "assistant",
+                "content": "{\"name\": \"Team Meeting\", \"date\": \"2024-01-15\", \"participants\": [\"Alice\", \"Bob\"]}",
+                "refusal": null
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 50,
+            "completion_tokens": 30,
+            "total_tokens": 80,
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            },
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "audio_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0
+            }
+          },
+          "system_fingerprint": "fp_0ba0d124f1"
+        }
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 11 Nov 2024 23:43:50 GMT
+      Server:
+      - cloudflare
+      Set-Cookie: test_set_cookie
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      content-length:
+      - '800'
+      openai-organization: test_openai_org_id
+      openai-processing-ms:
+      - '350'
+      openai-version:
+      - '2020-10-01'
+      x-request-id:
+      - req_structured_test_001
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/instrumentation/opentelemetry-instrumentation-openai-v2/tests/structured_outputs_utils.py
+++ b/instrumentation/opentelemetry-instrumentation-openai-v2/tests/structured_outputs_utils.py
@@ -1,0 +1,32 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared test definitions for structured outputs (parse) tests."""
+
+from pydantic import BaseModel
+
+
+class CalendarEvent(BaseModel):
+    name: str
+    date: str
+    participants: list[str]
+
+
+STRUCTURED_OUTPUT_PROMPT = [
+    {
+        "role": "user",
+        "content": "Extract the event information from: Team Meeting on 2024-01-15 with Alice and Bob",
+    }
+]
+
+STRUCTURED_OUTPUT_EXPECTED_INPUT_MESSAGES = [
+    {
+        "role": "user",
+        "parts": [
+            {
+                "type": "text",
+                "content": STRUCTURED_OUTPUT_PROMPT[0]["content"],
+            }
+        ],
+    }
+]

--- a/instrumentation/opentelemetry-instrumentation-openai-v2/tests/test_async_structured_outputs.py
+++ b/instrumentation/opentelemetry-instrumentation-openai-v2/tests/test_async_structured_outputs.py
@@ -1,0 +1,163 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for async OpenAI structured outputs (chat.completions.parse) instrumentation."""
+
+import pytest
+from openai.resources.chat.completions import Completions
+
+from opentelemetry.semconv._incubating.attributes import (
+    gen_ai_attributes as GenAIAttributes,
+)
+from opentelemetry.util.genai.utils import is_experimental_mode
+
+from .structured_outputs_utils import (
+    STRUCTURED_OUTPUT_EXPECTED_INPUT_MESSAGES,
+    STRUCTURED_OUTPUT_PROMPT,
+    CalendarEvent,
+)
+from .test_utils import (
+    DEFAULT_MODEL,
+    assert_all_attributes,
+    assert_message_in_logs,
+    assert_messages_attribute,
+    format_simple_expected_output_message,
+)
+
+pytestmark = pytest.mark.skipif(
+    not hasattr(Completions, "parse"),
+    reason="parse() requires openai >= 1.40.0",
+)
+
+
+@pytest.mark.asyncio()
+async def test_async_structured_output_with_content(
+    span_exporter,
+    log_exporter,
+    async_openai_client,
+    instrument_with_content,
+    vcr,
+):
+    latest_experimental_enabled = is_experimental_mode()
+
+    with vcr.use_cassette("test_async_structured_output_with_content.yaml"):
+        response = await async_openai_client.chat.completions.parse(
+            messages=STRUCTURED_OUTPUT_PROMPT,
+            model=DEFAULT_MODEL,
+            response_format=CalendarEvent,
+        )
+
+    # Verify wrapper doesn't interfere with parse() return
+    assert response.choices[0].message.parsed is not None
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert_all_attributes(
+        spans[0],
+        DEFAULT_MODEL,
+        latest_experimental_enabled,
+        response.id,
+        response.model,
+        response.usage.prompt_tokens,
+        response.usage.completion_tokens,
+    )
+
+    output_type_attr_key = (
+        GenAIAttributes.GEN_AI_OUTPUT_TYPE
+        if latest_experimental_enabled
+        else GenAIAttributes.GEN_AI_OPENAI_REQUEST_RESPONSE_FORMAT
+    )
+    expected_value = "json" if latest_experimental_enabled else "json_schema"
+    assert spans[0].attributes[output_type_attr_key] == expected_value
+
+    if latest_experimental_enabled:
+        assert_messages_attribute(
+            spans[0].attributes["gen_ai.input.messages"],
+            STRUCTURED_OUTPUT_EXPECTED_INPUT_MESSAGES,
+        )
+        assert_messages_attribute(
+            spans[0].attributes["gen_ai.output.messages"],
+            format_simple_expected_output_message(
+                response.choices[0].message.content
+            ),
+        )
+    else:
+        logs = log_exporter.get_finished_logs()
+        assert len(logs) == 2
+
+        user_message = {"content": STRUCTURED_OUTPUT_PROMPT[0]["content"]}
+        assert_message_in_logs(
+            logs[0], "gen_ai.user.message", user_message, spans[0]
+        )
+
+        choice_event = {
+            "index": 0,
+            "finish_reason": "stop",
+            "message": {
+                "role": "assistant",
+                "content": response.choices[0].message.content,
+            },
+        }
+        assert_message_in_logs(
+            logs[1], "gen_ai.choice", choice_event, spans[0]
+        )
+
+
+@pytest.mark.asyncio()
+async def test_async_structured_output_no_content(
+    span_exporter,
+    log_exporter,
+    async_openai_client,
+    instrument_no_content,
+    vcr,
+):
+    latest_experimental_enabled = is_experimental_mode()
+
+    with vcr.use_cassette("test_async_structured_output_no_content.yaml"):
+        response = await async_openai_client.chat.completions.parse(
+            messages=STRUCTURED_OUTPUT_PROMPT,
+            model=DEFAULT_MODEL,
+            response_format=CalendarEvent,
+        )
+
+    # Verify wrapper doesn't interfere with parse() return
+    assert response.choices[0].message.parsed is not None
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert_all_attributes(
+        spans[0],
+        DEFAULT_MODEL,
+        latest_experimental_enabled,
+        response.id,
+        response.model,
+        response.usage.prompt_tokens,
+        response.usage.completion_tokens,
+    )
+
+    output_type_attr_key = (
+        GenAIAttributes.GEN_AI_OUTPUT_TYPE
+        if latest_experimental_enabled
+        else GenAIAttributes.GEN_AI_OPENAI_REQUEST_RESPONSE_FORMAT
+    )
+    expected_value = "json" if latest_experimental_enabled else "json_schema"
+    assert spans[0].attributes[output_type_attr_key] == expected_value
+
+    logs = log_exporter.get_finished_logs()
+    if latest_experimental_enabled:
+        assert len(logs) == 0
+        assert "gen_ai.input.messages" not in spans[0].attributes
+        assert "gen_ai.output.messages" not in spans[0].attributes
+    else:
+        assert len(logs) == 2
+
+        assert_message_in_logs(logs[0], "gen_ai.user.message", None, spans[0])
+
+        choice_event = {
+            "index": 0,
+            "finish_reason": "stop",
+            "message": {"role": "assistant"},
+        }
+        assert_message_in_logs(
+            logs[1], "gen_ai.choice", choice_event, spans[0]
+        )

--- a/instrumentation/opentelemetry-instrumentation-openai-v2/tests/test_async_structured_outputs.py
+++ b/instrumentation/opentelemetry-instrumentation-openai-v2/tests/test_async_structured_outputs.py
@@ -4,8 +4,12 @@
 """Tests for async OpenAI structured outputs (chat.completions.parse) instrumentation."""
 
 import pytest
+from openai import NotFoundError
 from openai.resources.chat.completions import Completions
 
+from opentelemetry.semconv._incubating.attributes import (
+    error_attributes as ErrorAttributes,
+)
 from opentelemetry.semconv._incubating.attributes import (
     gen_ai_attributes as GenAIAttributes,
 )
@@ -161,3 +165,26 @@ async def test_async_structured_output_no_content(
         assert_message_in_logs(
             logs[1], "gen_ai.choice", choice_event, spans[0]
         )
+
+
+@pytest.mark.asyncio()
+async def test_async_structured_output_404(
+    span_exporter, async_openai_client, instrument_no_content, vcr
+):
+    latest_experimental_enabled = is_experimental_mode()
+    llm_model_value = "this-model-does-not-exist"
+
+    with vcr.use_cassette("test_async_structured_output_404.yaml"):
+        with pytest.raises(NotFoundError):
+            await async_openai_client.chat.completions.parse(
+                messages=STRUCTURED_OUTPUT_PROMPT,
+                model=llm_model_value,
+                response_format=CalendarEvent,
+            )
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert_all_attributes(
+        spans[0], llm_model_value, latest_experimental_enabled
+    )
+    assert "NotFoundError" == spans[0].attributes[ErrorAttributes.ERROR_TYPE]

--- a/instrumentation/opentelemetry-instrumentation-openai-v2/tests/test_structured_outputs.py
+++ b/instrumentation/opentelemetry-instrumentation-openai-v2/tests/test_structured_outputs.py
@@ -1,0 +1,153 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for OpenAI structured outputs (chat.completions.parse) instrumentation."""
+
+import pytest
+from openai.resources.chat.completions import Completions
+
+from opentelemetry.semconv._incubating.attributes import (
+    gen_ai_attributes as GenAIAttributes,
+)
+from opentelemetry.util.genai.utils import is_experimental_mode
+
+from .structured_outputs_utils import (
+    STRUCTURED_OUTPUT_EXPECTED_INPUT_MESSAGES,
+    STRUCTURED_OUTPUT_PROMPT,
+    CalendarEvent,
+)
+from .test_utils import (
+    DEFAULT_MODEL,
+    assert_all_attributes,
+    assert_message_in_logs,
+    assert_messages_attribute,
+    format_simple_expected_output_message,
+)
+
+pytestmark = pytest.mark.skipif(
+    not hasattr(Completions, "parse"),
+    reason="parse() requires openai >= 1.40.0",
+)
+
+
+def test_structured_output_with_content(
+    span_exporter, log_exporter, openai_client, instrument_with_content, vcr
+):
+    latest_experimental_enabled = is_experimental_mode()
+
+    with vcr.use_cassette("test_structured_output_with_content.yaml"):
+        response = openai_client.chat.completions.parse(
+            messages=STRUCTURED_OUTPUT_PROMPT,
+            model=DEFAULT_MODEL,
+            response_format=CalendarEvent,
+        )
+
+    # Verify wrapper doesn't interfere with parse() return
+    assert response.choices[0].message.parsed is not None
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert_all_attributes(
+        spans[0],
+        DEFAULT_MODEL,
+        latest_experimental_enabled,
+        response.id,
+        response.model,
+        response.usage.prompt_tokens,
+        response.usage.completion_tokens,
+    )
+
+    output_type_attr_key = (
+        GenAIAttributes.GEN_AI_OUTPUT_TYPE
+        if latest_experimental_enabled
+        else GenAIAttributes.GEN_AI_OPENAI_REQUEST_RESPONSE_FORMAT
+    )
+    expected_value = "json" if latest_experimental_enabled else "json_schema"
+    assert spans[0].attributes[output_type_attr_key] == expected_value
+
+    if latest_experimental_enabled:
+        assert_messages_attribute(
+            spans[0].attributes["gen_ai.input.messages"],
+            STRUCTURED_OUTPUT_EXPECTED_INPUT_MESSAGES,
+        )
+        assert_messages_attribute(
+            spans[0].attributes["gen_ai.output.messages"],
+            format_simple_expected_output_message(
+                response.choices[0].message.content
+            ),
+        )
+    else:
+        logs = log_exporter.get_finished_logs()
+        assert len(logs) == 2
+
+        user_message = {"content": STRUCTURED_OUTPUT_PROMPT[0]["content"]}
+        assert_message_in_logs(
+            logs[0], "gen_ai.user.message", user_message, spans[0]
+        )
+
+        choice_event = {
+            "index": 0,
+            "finish_reason": "stop",
+            "message": {
+                "role": "assistant",
+                "content": response.choices[0].message.content,
+            },
+        }
+        assert_message_in_logs(
+            logs[1], "gen_ai.choice", choice_event, spans[0]
+        )
+
+
+def test_structured_output_no_content(
+    span_exporter, log_exporter, openai_client, instrument_no_content, vcr
+):
+    latest_experimental_enabled = is_experimental_mode()
+
+    with vcr.use_cassette("test_structured_output_no_content.yaml"):
+        response = openai_client.chat.completions.parse(
+            messages=STRUCTURED_OUTPUT_PROMPT,
+            model=DEFAULT_MODEL,
+            response_format=CalendarEvent,
+        )
+
+    # Verify wrapper doesn't interfere with parse() return
+    assert response.choices[0].message.parsed is not None
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert_all_attributes(
+        spans[0],
+        DEFAULT_MODEL,
+        latest_experimental_enabled,
+        response.id,
+        response.model,
+        response.usage.prompt_tokens,
+        response.usage.completion_tokens,
+    )
+
+    output_type_attr_key = (
+        GenAIAttributes.GEN_AI_OUTPUT_TYPE
+        if latest_experimental_enabled
+        else GenAIAttributes.GEN_AI_OPENAI_REQUEST_RESPONSE_FORMAT
+    )
+    expected_value = "json" if latest_experimental_enabled else "json_schema"
+    assert spans[0].attributes[output_type_attr_key] == expected_value
+
+    logs = log_exporter.get_finished_logs()
+    if latest_experimental_enabled:
+        assert len(logs) == 0
+        assert "gen_ai.input.messages" not in spans[0].attributes
+        assert "gen_ai.output.messages" not in spans[0].attributes
+    else:
+        assert len(logs) == 2
+
+        assert_message_in_logs(logs[0], "gen_ai.user.message", None, spans[0])
+
+        choice_event = {
+            "index": 0,
+            "finish_reason": "stop",
+            "message": {"role": "assistant"},
+        }
+        assert_message_in_logs(
+            logs[1], "gen_ai.choice", choice_event, spans[0]
+        )

--- a/instrumentation/opentelemetry-instrumentation-openai-v2/tests/test_structured_outputs.py
+++ b/instrumentation/opentelemetry-instrumentation-openai-v2/tests/test_structured_outputs.py
@@ -4,8 +4,12 @@
 """Tests for OpenAI structured outputs (chat.completions.parse) instrumentation."""
 
 import pytest
+from openai import NotFoundError
 from openai.resources.chat.completions import Completions
 
+from opentelemetry.semconv._incubating.attributes import (
+    error_attributes as ErrorAttributes,
+)
 from opentelemetry.semconv._incubating.attributes import (
     gen_ai_attributes as GenAIAttributes,
 )
@@ -151,3 +155,25 @@ def test_structured_output_no_content(
         assert_message_in_logs(
             logs[1], "gen_ai.choice", choice_event, spans[0]
         )
+
+
+def test_structured_output_404(
+    span_exporter, openai_client, instrument_no_content, vcr
+):
+    latest_experimental_enabled = is_experimental_mode()
+    llm_model_value = "this-model-does-not-exist"
+
+    with vcr.use_cassette("test_structured_output_404.yaml"):
+        with pytest.raises(NotFoundError):
+            openai_client.chat.completions.parse(
+                messages=STRUCTURED_OUTPUT_PROMPT,
+                model=llm_model_value,
+                response_format=CalendarEvent,
+            )
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert_all_attributes(
+        spans[0], llm_model_value, latest_experimental_enabled
+    )
+    assert "NotFoundError" == spans[0].attributes[ErrorAttributes.ERROR_TYPE]


### PR DESCRIPTION
Closes open-telemetry/opentelemetry-python-contrib#12

## Background

Originally tracked in [opentelemetry-python-contrib#3449](https://github.com/open-telemetry/opentelemetry-python-genai/issues/394) with a previous implementation I created in [opentelemetry-python-contrib#4416](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4416), which was approved by @lmolkova and @lzchen. That PR was closed when the GenAI instrumentations moved to this repository. This PR ports the same approach to the new repo, aligned with its current structure.

## Changes

Adds telemetry coverage for OpenAI's `chat.completions.parse()` method, which powers [structured outputs](https://platform.openai.com/docs/guides/structured-outputs). The `parse()` method was introduced in openai SDK 1.40.0 and returns a `ParsedChatCompletion` that extends `ChatCompletion` with a typed `.parsed` field on each choice message.

### Instrumentation (`__init__.py`)

- Added `_is_parse_supported()` version guard that checks for `hasattr(Completions, "parse")`. On openai < 1.40.0 the wrapping is skipped entirely (the repo pins openai >= 1.26.0).
- `Completions.parse` and `AsyncCompletions.parse` are wrapped with the same telemetry functions used for `create()`. Since `ParsedChatCompletion` inherits from `ChatCompletion`, the existing wrapper logic (span attributes, metrics, content capture) handles it without changes.
- Corresponding `unwrap()` calls added to `_uninstrument()`.

### response_format type handling (`utils.py`)

When `parse()` is called with `response_format=SomePydanticModel`, the SDK sends a bare Python type rather than a dict or string. Both attribute extraction paths now handle this:

- Legacy path (`get_llm_request_attributes`): `isinstance(response_format, type)` branch sets `gen_ai.openai.request.response_format = "json_schema"` via the `GenAiOpenaiRequestResponseFormatValues.JSON_SCHEMA` semconv constant.
- Experimental path (`create_chat_invocation`): same check sets `gen_ai.output.type = "json"` via the `GenAiOutputTypeValues.JSON` semconv constant.

### Tests

- `test_structured_outputs.py` / `test_async_structured_outputs.py`: sync and async tests covering both content-capture and no-content modes.
- Tests verify the wrapper preserves `response.choices[0].message.parsed` (the structured output field).
- Tests assert the correct `gen_ai.output.type` / `gen_ai.openai.request.response_format` attribute based on semconv mode.
- All tests use VCR cassettes and are skipped on openai < 1.40.0 via `pytestmark`.

### CHANGELOG

Adds an entry under `## Unreleased` referencing this PR.

## Acceptance criteria (from open-telemetry/opentelemetry-python-contrib#12)

- [x] Sync and async parse calls produce spans with the same attributes as `create()` calls
- [x] `gen_ai.output.type` is set to `json` when `response_format` is a Pydantic model class
- [x] No telemetry regression for existing `create()` calls
- [x] Tests pass on both old and new semconv paths

## What's not changed

- No changes to the stream wrappers, metrics, or util layer. Structured outputs via `parse()` are non-streaming only.
- No changes to the Responses API path.