### PR TITLE
Suppress weaver finding via config instead of --include-unreferenced flag

### DIFF
--- a/.weaver.toml
+++ b/.weaver.toml
@@ -1,0 +1,12 @@
+#:schema https://raw.githubusercontent.com/open-telemetry/weaver/v0.23.0/schemas/weaver-config.json
+
+# OTel SDK resource attributes that don't belong to the genai registry — see
+# https://github.com/open-telemetry/weaver/issues/1456.
+[[live_check.finding_filters]]
+signal_type = "resource"
+exclude_samples = [
+  "service.name",
+  "telemetry.sdk.language",
+  "telemetry.sdk.name",
+  "telemetry.sdk.version",
+]

--- a/util/opentelemetry-test-util-genai/src/opentelemetry/test_util_genai/_setup_weaver.py
+++ b/util/opentelemetry-test-util-genai/src/opentelemetry/test_util_genai/_setup_weaver.py
@@ -294,3 +294,8 @@ def policies_dir() -> Path:
 def semconv_registry() -> Path:
     """Return the path to ``<semantic-conventions-genai>/model`` for the pinned ref."""
     return _provision_genai_root() / "model"
+
+
+def weaver_config_file() -> Path:
+    """Return the path to the workspace ``.weaver.toml``."""
+    return _workspace_root() / ".weaver.toml"

--- a/util/opentelemetry-test-util-genai/src/opentelemetry/test_util_genai/fixtures.py
+++ b/util/opentelemetry-test-util-genai/src/opentelemetry/test_util_genai/fixtures.py
@@ -66,6 +66,7 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
 from opentelemetry.test_util_genai._setup_weaver import (
     policies_dir,
     semconv_registry,
+    weaver_config_file,
 )
 from opentelemetry.util.genai.environment_variables import (
     OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT,
@@ -212,6 +213,6 @@ def weaver_live_check() -> Iterator[Any]:
     with WeaverLiveCheck(
         registry=registry,
         policies_dir=policies,
-        extra_args=["--include-unreferenced"],
+        extra_args=["--config", str(weaver_config_file())],
     ) as weaver:
         yield weaver


### PR DESCRIPTION
See https://github.com/open-telemetry/weaver/issues/1456 for the context.

`--include-unreferenced` is a hackery to avoid this issue, but it's going to go away since it creates a fair amount of complexity for federated semconv.

Replacing hackery with suppression for individual violations in config - this won't be necessary in the future once https://github.com/open-telemetry/weaver/issues/1456 is fixed properly.