### PR TITLE
Fix links and make references sections in instrumentation readmes consistent

### DIFF
--- a/.github/workflows/check_links_config.json
+++ b/.github/workflows/check_links_config.json
@@ -8,6 +8,9 @@
     },
     {
       "pattern": "http(s)?://example.com"
+    },
+    {
+      "pattern": "http(s)?://x\\.ai"
     }
   ],
   "aliveStatusCodes": [429, 200]

--- a/.github/workflows/check_links_config.json
+++ b/.github/workflows/check_links_config.json
@@ -10,7 +10,7 @@
       "pattern": "http(s)?://example.com"
     },
     {
-      "pattern": "http(s)?://x\\.ai"
+      "pattern": "http(s)?://x.ai"
     }
   ],
   "aliveStatusCodes": [429, 200]

--- a/instrumentation/opentelemetry-instrumentation-anthropic/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-anthropic/README.rst
@@ -64,5 +64,7 @@ References
 ----------
 
 * `OpenTelemetry Project <https://opentelemetry.io/>`_
+* `OpenTelemetry GenAI semantic conventions <https://opentelemetry.io/docs/specs/semconv/gen-ai/>`_
+* `Anthropic SDK (Python) <https://github.com/anthropics/anthropic-sdk-python>`_
 * `Anthropic Documentation <https://docs.anthropic.com/>`_
 

--- a/instrumentation/opentelemetry-instrumentation-claude-agent-sdk/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-claude-agent-sdk/README.rst
@@ -80,5 +80,6 @@ References
 ----------
 
 * `OpenTelemetry Project <https://opentelemetry.io/>`_
+* `OpenTelemetry GenAI semantic conventions <https://opentelemetry.io/docs/specs/semconv/gen-ai/>`_
 * `Claude Agent SDK (Python) <https://github.com/anthropics/claude-agent-sdk-python>`_
 * `Anthropic Documentation <https://docs.anthropic.com/>`_

--- a/instrumentation/opentelemetry-instrumentation-google-genai/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/README.rst
@@ -125,8 +125,8 @@ To uninstrument clients, call the uninstrument method:
 
 References
 ----------
+* `OpenTelemetry Project <https://opentelemetry.io/>`_
+* `OpenTelemetry GenAI semantic conventions <https://opentelemetry.io/docs/specs/semconv/gen-ai/>`_
 * `Google Gen AI SDK Documentation <https://ai.google.dev/gemini-api/docs/sdks>`_
 * `Google Gen AI SDK on GitHub <https://github.com/googleapis/python-genai>`_
 * `Using Vertex AI with Google Gen AI SDK <https://cloud.google.com/vertex-ai/generative-ai/docs/sdks/overview>`_
-* `OpenTelemetry Project <https://opentelemetry.io/>`_
-* `OpenTelemetry Python Examples <https://github.com/open-telemetry/opentelemetry-python/tree/main/docs/examples>`_

--- a/instrumentation/opentelemetry-instrumentation-google-genai/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/README.rst
@@ -125,8 +125,9 @@ To uninstrument clients, call the uninstrument method:
 
 References
 ----------
+
 * `OpenTelemetry Project <https://opentelemetry.io/>`_
 * `OpenTelemetry GenAI semantic conventions <https://opentelemetry.io/docs/specs/semconv/gen-ai/>`_
+* `Google Gen AI SDK (Python) <https://github.com/googleapis/python-genai>`_
 * `Google Gen AI SDK Documentation <https://ai.google.dev/gemini-api/docs/sdks>`_
-* `Google Gen AI SDK on GitHub <https://github.com/googleapis/python-genai>`_
 * `Using Vertex AI with Google Gen AI SDK <https://cloud.google.com/vertex-ai/generative-ai/docs/sdks/overview>`_

--- a/instrumentation/opentelemetry-instrumentation-openai-agents-v2/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-openai-agents-v2/README.rst
@@ -107,4 +107,4 @@ References
 * `OpenTelemetry Project <https://opentelemetry.io/>`_
 * `OpenTelemetry GenAI semantic conventions <https://opentelemetry.io/docs/specs/semconv/gen-ai/>`_
 * `OpenAI Agents SDK (Python) <https://github.com/openai/openai-agents-python>`_
-* `OpenAI Documentation <https://platform.openai.com/docs>`_
+* `OpenAI Documentation <https://developers.openai.com/api/docs>`_

--- a/instrumentation/opentelemetry-instrumentation-openai-agents-v2/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-openai-agents-v2/README.rst
@@ -104,6 +104,7 @@ The :mod:`examples` directory contains runnable scenarios, including:
 References
 ----------
 
-* `OpenTelemetry Python Contrib <https://github.com/open-telemetry/opentelemetry-python-contrib>`_
-* `OpenTelemetry GenAI semantic conventions <https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/>`_
-* `OpenAI Agents SDK <https://github.com/openai/openai-agents-python>`_
+* `OpenTelemetry Project <https://opentelemetry.io/>`_
+* `OpenTelemetry GenAI semantic conventions <https://opentelemetry.io/docs/specs/semconv/gen-ai/>`_
+* `OpenAI Agents SDK (Python) <https://github.com/openai/openai-agents-python>`_
+* `OpenAI Documentation <https://platform.openai.com/docs>`_

--- a/instrumentation/opentelemetry-instrumentation-openai-agents-v2/src/opentelemetry/instrumentation/openai_agents/span_processor.py
+++ b/instrumentation/opentelemetry-instrumentation-openai-agents-v2/src/opentelemetry/instrumentation/openai_agents/span_processor.py
@@ -11,7 +11,7 @@ generative AI operations using iterator-based attribute extraction.
 
 References:
 - OpenTelemetry GenAI Semantic Conventions:
-    https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/
+    https://opentelemetry.io/docs/specs/semconv/gen-ai/
 - OpenInference Pattern: https://github.com/Arize-ai/openinference
 """
 

--- a/instrumentation/opentelemetry-instrumentation-openai-v2/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-openai-v2/README.rst
@@ -22,7 +22,7 @@ Many LLM platforms support the OpenAI SDK. This means systems such as the follow
      - ``azure.ai.openai``
    * - `Gemini <https://developers.googleblog.com/en/gemini-is-now-accessible-from-the-openai-library/>`_
      - ``gemini``
-   * - `Perplexity <https://docs.perplexity.ai/api-reference/chat-completions>`_
+   * - `Perplexity <https://docs.perplexity.ai/api-reference/>`_
      - ``perplexity``
    * - `xAI <https://x.ai/api>`_ (Compatible with Anthropic)
      - ``xai``

--- a/instrumentation/opentelemetry-instrumentation-openai-v2/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-openai-v2/README.rst
@@ -144,7 +144,8 @@ To uninstrument clients, call the uninstrument method:
 
 References
 ----------
-* `OpenTelemetry OpenAI Instrumentation <https://opentelemetry-python-genai.readthedocs.io/en/latest/instrumentation/openai.html>`_
-* `OpenTelemetry Project <https://opentelemetry.io/>`_
-* `OpenTelemetry Python Examples <https://github.com/open-telemetry/opentelemetry-python/tree/main/docs/examples>`_
 
+* `OpenTelemetry Project <https://opentelemetry.io/>`_
+* `OpenTelemetry GenAI semantic conventions <https://opentelemetry.io/docs/specs/semconv/gen-ai/>`_
+* `OpenAI SDK (Python) <https://github.com/openai/openai-python>`_
+* `OpenAI Documentation <https://platform.openai.com/docs>`_

--- a/instrumentation/opentelemetry-instrumentation-openai-v2/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-openai-v2/README.rst
@@ -148,4 +148,4 @@ References
 * `OpenTelemetry Project <https://opentelemetry.io/>`_
 * `OpenTelemetry GenAI semantic conventions <https://opentelemetry.io/docs/specs/semconv/gen-ai/>`_
 * `OpenAI SDK (Python) <https://github.com/openai/openai-python>`_
-* `OpenAI Documentation <https://platform.openai.com/docs>`_
+* `OpenAI Documentation <https://developers.openai.com/api/docs>`_

--- a/util/opentelemetry-util-genai/README.rst
+++ b/util/opentelemetry-util-genai/README.rst
@@ -147,3 +147,4 @@ References
 ----------
 
 * `OpenTelemetry Project <https://opentelemetry.io/>`_
+* `OpenTelemetry GenAI semantic conventions <https://opentelemetry.io/docs/specs/semconv/gen-ai/>`_


### PR DESCRIPTION
Fix failing link check

  81 links checked.

-  [✖] https://docs.perplexity.ai/api-reference/chat-completions → Status: 404
    replaced with https://docs.perplexity.ai/api-reference
-  [✖] https://opentelemetry-python-genai.readthedocs.io/en/latest/instrumentation/openai.html → Status: 404
    blocked on #61 
-  [✖] https://x.ai/api → Status: 403
    excluded from check

