### PR TITLE
opentelemetry-util-genai: remove import of typing_extensions

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/examples/workflow/main.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/examples/workflow/main.py
@@ -15,13 +15,12 @@ Steps:
 OpenTelemetry LangChain instrumentation traces both LLM calls.
 """
 
-from typing import Annotated
+from typing import Annotated, TypedDict
 
 from langchain_core.messages import HumanMessage, SystemMessage
 from langchain_openai import ChatOpenAI
 from langgraph.graph import END, START, StateGraph
 from langgraph.graph.message import add_messages
-from typing_extensions import TypedDict
 
 from opentelemetry import _logs, metrics, trace
 from opentelemetry.exporter.otlp.proto.grpc._log_exporter import (

--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/tests/conformance/workflow.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/tests/conformance/workflow.py
@@ -6,14 +6,13 @@
 from __future__ import annotations
 
 import os
-from typing import Annotated, Any
+from typing import Annotated, Any, TypedDict
 from unittest import mock
 
 from langchain_core.messages import HumanMessage, SystemMessage
 from langchain_openai import ChatOpenAI
 from langgraph.graph import END, START, StateGraph
 from langgraph.graph.message import add_messages
-from typing_extensions import TypedDict
 
 from opentelemetry.instrumentation.genai.langchain import LangChainInstrumentor
 from opentelemetry.sdk._logs import LoggerProvider

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_invocation.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_invocation.py
@@ -9,9 +9,7 @@ from contextlib import AbstractContextManager
 from contextvars import Token
 from dataclasses import asdict
 from types import TracebackType
-from typing import TYPE_CHECKING, Any, Sequence
-
-from typing_extensions import TypeAlias
+from typing import TYPE_CHECKING, Any, Sequence, TypeAlias
 
 from opentelemetry._logs import Logger, LogRecord
 from opentelemetry.context import Context, attach, detach


### PR DESCRIPTION
# Description

TypeAlias and TypeDict are both in the typing package as of Python 3.10, removing the import of typing_extensions.

## Type of change

Please delete options that are not relevant.

- [x] Small improvement

# How has this been tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. List any relevant details for your test
configuration.

- [x] Ran tests for package locally

# Checklist

See [CONTRIBUTING.md](https://github.com/open-telemetry/opentelemetry-python-genai/blob/main/CONTRIBUTING.md)
for the style guide, changelog guidance, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelog updated if the change requires an entry
