### PR TITLE
fix: remove unnecessary type ignore in langchain callback handler

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/src/opentelemetry/instrumentation/genai/langchain/callback_handler.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/src/opentelemetry/instrumentation/genai/langchain/callback_handler.py
@@ -250,7 +250,7 @@ class OpenTelemetryLangChainCallbackHandler(BaseCallbackHandler):
         for sub_messages in messages:
             for message in sub_messages:
                 # Cast to Any to avoid type checking issues with LangChain's complex content type
-                raw_content: Any = message.content  # type: ignore[misc]
+                raw_content: Any = message.content
                 role = message.type
                 parts: list[Text] = []
 


### PR DESCRIPTION
## Summary

Removes a stale `# type: ignore[misc]` on `message.content` in the LangChain callback handler. Pyright now reports it as unnecessary, which fails `misc / typecheck` on `main`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- [x] `uv run tox -e typecheck` passes locally
- [x] Confirmed `uv run tox -e typecheck` fails on `upstream/main` before this change

## Checklist

- [x] Followed the style guidelines of this project
- [ ] Changelog updated if the change requires an entry
- [ ] Unit tests added
- [ ] Documentation updated