### PR TITLE
fix: add vcr cassette name fixture for enhanced test recording in google genai.

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-google-genai/.changelog/133.fixed
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/.changelog/133.fixed
@@ -1,0 +1,1 @@
+Fix VCR cassette lookup for Google GenAI upload hook tests under newer pytest versions.

--- a/instrumentation/opentelemetry-instrumentation-google-genai/tests/generate_content/test_e2e.py
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/tests/generate_content/test_e2e.py
@@ -344,6 +344,7 @@ def fixture_setup_content_recording(request):
     os.environ[OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT] = (
         request.param
     )
+    return request.param
 
 
 @pytest.fixture(name="vcr_record_mode")
@@ -459,6 +460,27 @@ def fixture_is_async(request):
 @pytest.fixture(name="model", params=["gemini-2.5-flash"])
 def fixture_model(request):
     return request.param
+
+
+@pytest.fixture(name="vcr_cassette_name")
+def fixture_vcr_cassette_name(
+    request,
+    setup_content_recording,
+    model,
+    genai_sdk_backend,
+    is_async,
+    enable_completion_hook,
+):
+    node_name = getattr(request.node, "originalname", request.node.name)
+    if node_name != "test_upload_hook_non_streaming":
+        return request.node.name
+
+    async_label = "async" if is_async else "sync"
+    return (
+        "test_upload_hook_non_streaming"
+        f"[{setup_content_recording}-{model}-{genai_sdk_backend}-"
+        f"{async_label}-{enable_completion_hook}]"
+    )
 
 
 @pytest.fixture(name="generate_content")


### PR DESCRIPTION
# Description

The failure was caused by relying on pytest’s autogenerated parametrized test IDs as VCR cassette filenames.

pytest-vcr chooses a cassette filename from the pytest test node name. For this test, the node name includes all parametrized fixture values, such as:

SPAN_AND_EVENT
gemini-2.5-flash
vertexaiapi
sync
enable_completion_hook

The committed cassette files were recorded/named in this order:

test_upload_hook_non_streaming[SPAN_AND_EVENT-gemini-2.5-flash-vertexaiapi-sync-enable_completion_hook].yaml

With current pytest 9.x, pytest now generates the parametrized ID in a different order:

test_upload_hook_non_streaming[SPAN_AND_EVENT-vertexaiapi-sync-gemini-2.5-flash-enable_completion_hook].yaml

So VCR looked for a cassette with the pytest-9-generated filename, did not find one, and then refused to record a new one because the test command uses:

--vcr-record=none

That is why the error said it could not overwrite or find a matching cassette. The request itself was not meaningfully different; VCR was simply opening the wrong cassette filename.

I verified the root cause by collecting the same test at the same commit with two pytest versions:

pytest 7.4.4:
test_upload_hook_non_streaming[SPAN_AND_EVENT-gemini-2.5-flash-vertexaiapi-sync-enable_completion_hook]

pytest 9.1.0:
test_upload_hook_non_streaming[SPAN_AND_EVENT-vertexaiapi-sync-gemini-2.5-flash-enable_completion_hook]

The google-genai tox env installs pytest without a version pin, so a newer pytest changed the autogenerated ID ordering underneath the test. The fix makes the cassette name explicit for this test, so it no longer depends on pytest’s internal parametrization ordering.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. List any relevant details for your test
configuration.

- [ ] Test A

# Checklist

See [CONTRIBUTING.md](https://github.com/open-telemetry/opentelemetry-python-genai/blob/main/CONTRIBUTING.md)
for the style guide, changelog guidance, and more.

- [ ] Followed the style guidelines of this project
- [ ] Changelog updated if the change requires an entry
- [ ] Unit tests added
- [ ] Documentation updated
