### PR TITLE
convert unreleased sections in changelogs to towncrier

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/.changelog/+async-stream-wrappers.added
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/.changelog/+async-stream-wrappers.added
@@ -1,0 +1,3 @@
+Add async Anthropic message stream wrappers and manager wrappers, with wrapper tests ([#4346](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4346))
+  - `AsyncMessagesStreamWrapper` for async message stream telemetry
+  - `AsyncMessagesStreamManagerWrapper` for async `Messages.stream()` telemetry

--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/.changelog/+initial-implementation.added
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/.changelog/+initial-implementation.added
@@ -1,0 +1,1 @@
+Initial implementation of Anthropic instrumentation ([#3978](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3978))

--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/.changelog/+messages-stream-helper.added
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/.changelog/+messages-stream-helper.added
@@ -1,0 +1,1 @@
+Add instrumentation for Anthropic `Messages.stream()` helper method ([#4499](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4499))

--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/.changelog/+sync-messages-create.added
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/.changelog/+sync-messages-create.added
@@ -1,0 +1,5 @@
+Implement sync `Messages.create` instrumentation with GenAI semantic convention attributes ([#4034](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4034))
+  - Captures request attributes: `gen_ai.request.model`, `gen_ai.request.max_tokens`, `gen_ai.request.temperature`, `gen_ai.request.top_p`, `gen_ai.request.top_k`, `gen_ai.request.stop_sequences`
+  - Captures response attributes: `gen_ai.response.id`, `gen_ai.response.model`, `gen_ai.response.finish_reasons`, `gen_ai.usage.input_tokens`, `gen_ai.usage.output_tokens`
+  - Error handling with `error.type` attribute
+  - Minimum supported anthropic version is 0.16.0 (SDK uses modern `anthropic.resources.messages` module structure introduced in this version)

--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/.changelog/+sync-streaming-support.added
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/.changelog/+sync-streaming-support.added
@@ -1,0 +1,4 @@
+Add sync streaming support for `Messages.create(stream=True)` and `Messages.stream()` ([#4155](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4155))
+  - `StreamWrapper` for handling `Messages.create(stream=True)` telemetry
+  - `MessageStreamManagerWrapper` for handling `Messages.stream()` telemetry
+  - `MessageWrapper` for non-streaming response telemetry extraction

--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/.changelog/+util-genai-dependency-range.changed
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/.changelog/+util-genai-dependency-range.changed
@@ -1,0 +1,1 @@
+Update `opentelemetry-util-genai` dependency range to `>= 0.4b0.dev, <0.5b0` ([#4520](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4520))

--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/.changelog/+wrapt-2-compat.fixed
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/.changelog/+wrapt-2-compat.fixed
@@ -1,0 +1,1 @@
+Fix compatibility with wrapt 2.x by using positional arguments in `wrap_function_wrapper()` calls ([#4445](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4445))

--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/CHANGELOG.md
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/CHANGELOG.md
@@ -10,39 +10,7 @@ Do *NOT* add changelog entries here!
 
 This changelog is managed by towncrier and is compiled at release time.
 
-The static "## Unreleased" section below pre-dates towncrier; its entries
-must be folded into the first towncrier-generated release manually.
-
 See https://github.com/open-telemetry/opentelemetry-python-genai/blob/main/CONTRIBUTING.md#changelog for details.
 -->
 
 <!-- changelog start -->
-
-## Unreleased
-
-- Update `opentelemetry-util-genai` dependency range to `>= 0.4b0.dev, <0.5b0`
-  ([#4520](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4520))
-- Fix compatibility with wrapt 2.x by using positional arguments in `wrap_function_wrapper()` calls
-  ([#4445](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4445))
-
-### Added
-
-- Add instrumentation for Anthropic `Messages.stream()` helper method
-  ([#4499](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4499))
-- Add async Anthropic message stream wrappers and manager wrappers, with wrapper
-  tests ([#4346](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4346))
-  - `AsyncMessagesStreamWrapper` for async message stream telemetry
-  - `AsyncMessagesStreamManagerWrapper` for async `Messages.stream()` telemetry
-- Add sync streaming support for `Messages.create(stream=True)` and `Messages.stream()`
-  ([#4155](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4155))
-  - `StreamWrapper` for handling `Messages.create(stream=True)` telemetry
-  - `MessageStreamManagerWrapper` for handling `Messages.stream()` telemetry
-  - `MessageWrapper` for non-streaming response telemetry extraction
-- Initial implementation of Anthropic instrumentation
-  ([#3978](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3978))
-- Implement sync `Messages.create` instrumentation with GenAI semantic convention attributes
-  ([#4034](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4034))
-  - Captures request attributes: `gen_ai.request.model`, `gen_ai.request.max_tokens`, `gen_ai.request.temperature`, `gen_ai.request.top_p`, `gen_ai.request.top_k`, `gen_ai.request.stop_sequences`
-  - Captures response attributes: `gen_ai.response.id`, `gen_ai.response.model`, `gen_ai.response.finish_reasons`, `gen_ai.usage.input_tokens`, `gen_ai.usage.output_tokens`
-  - Error handling with `error.type` attribute
-  - Minimum supported anthropic version is 0.16.0 (SDK uses modern `anthropic.resources.messages` module structure introduced in this version)

--- a/instrumentation/opentelemetry-instrumentation-genai-claude-agent-sdk/.changelog/+util-genai-dependency-range.changed
+++ b/instrumentation/opentelemetry-instrumentation-genai-claude-agent-sdk/.changelog/+util-genai-dependency-range.changed
@@ -1,0 +1,1 @@
+Update `opentelemetry-util-genai` dependency range to `>= 0.4b0.dev, <0.5b0` ([#4520](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4520))

--- a/instrumentation/opentelemetry-instrumentation-genai-claude-agent-sdk/CHANGELOG.md
+++ b/instrumentation/opentelemetry-instrumentation-genai-claude-agent-sdk/CHANGELOG.md
@@ -10,18 +10,8 @@ Do *NOT* add changelog entries here!
 
 This changelog is managed by towncrier and is compiled at release time.
 
-The static "## Unreleased" section below pre-dates towncrier; its entries
-must be folded into the first towncrier-generated release manually.
-
 See https://github.com/open-telemetry/opentelemetry-python-genai/blob/main/CONTRIBUTING.md#changelog for details.
 -->
 
 <!-- changelog start -->
-
-## Unreleased
-
-- Update `opentelemetry-util-genai` dependency range to `>= 0.4b0.dev, <0.5b0`
-  ([#4520](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4520))
-
-### Added
 

--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/.changelog/+genai-utils-handler.added
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/.changelog/+genai-utils-handler.added
@@ -1,0 +1,1 @@
+Added support to call genai utils handler for langchain LLM invocations. ([#3889](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3889))

--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/.changelog/+llm-invocation-span-support.added
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/.changelog/+llm-invocation-span-support.added
@@ -1,0 +1,1 @@
+Added span support for genAI langchain llm invocation. ([#3665](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3665))

--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/.changelog/+log-metrics-provider.added
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/.changelog/+log-metrics-provider.added
@@ -1,0 +1,1 @@
+Added log and metrics provider to langchain genai utils handler ([#4214](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4214))

--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/.changelog/+wrapt-2-compat.fixed
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/.changelog/+wrapt-2-compat.fixed
@@ -1,0 +1,1 @@
+Fix compatibility with wrapt 2.x by using positional arguments in `wrap_function_wrapper()` calls ([#4445](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4445))

--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/CHANGELOG.md
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/CHANGELOG.md
@@ -10,21 +10,7 @@ Do *NOT* add changelog entries here!
 
 This changelog is managed by towncrier and is compiled at release time.
 
-The static "## Unreleased" section below pre-dates towncrier; its entries
-must be folded into the first towncrier-generated release manually.
-
 See https://github.com/open-telemetry/opentelemetry-python-genai/blob/main/CONTRIBUTING.md#changelog for details.
 -->
 
 <!-- changelog start -->
-
-## Unreleased
-
-- Fix compatibility with wrapt 2.x by using positional arguments in `wrap_function_wrapper()` calls
-  ([#4445](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4445))
-- Added span support for genAI langchain llm invocation.
-  ([#3665](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3665))
-- Added support to call genai utils handler for langchain LLM invocations.
-  ([#3889](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3889))
-- Added log and metrics provider to langchain genai utils handler
-  ([#4214](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4214))

--- a/instrumentation/opentelemetry-instrumentation-genai-openai-agents/.changelog/+align-agentspandata-stubs.changed
+++ b/instrumentation/opentelemetry-instrumentation-genai-openai-agents/.changelog/+align-agentspandata-stubs.changed
@@ -1,0 +1,1 @@
+Align AgentSpanData test stubs and span processor with real OpenAI Agents SDK; remove non-existent `operation`, `description`, `agent_id`, and `model` fields. ([#4229](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4229))

--- a/instrumentation/opentelemetry-instrumentation-genai-openai-agents/.changelog/+package-metadata-readme.added
+++ b/instrumentation/opentelemetry-instrumentation-genai-openai-agents/.changelog/+package-metadata-readme.added
@@ -1,0 +1,1 @@
+Document official package metadata and README for the OpenAI Agents instrumentation. ([#3859](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3859))

--- a/instrumentation/opentelemetry-instrumentation-genai-openai-agents/.changelog/+populate-instructions-tool-definitions.added
+++ b/instrumentation/opentelemetry-instrumentation-genai-openai-agents/.changelog/+populate-instructions-tool-definitions.added
@@ -1,0 +1,1 @@
+Populate instructions and tool definitions from Response obj. ([#4196](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4196))

--- a/instrumentation/opentelemetry-instrumentation-genai-openai-agents/CHANGELOG.md
+++ b/instrumentation/opentelemetry-instrumentation-genai-openai-agents/CHANGELOG.md
@@ -10,22 +10,10 @@ Do *NOT* add changelog entries here!
 
 This changelog is managed by towncrier and is compiled at release time.
 
-The static "## Unreleased" section below pre-dates towncrier; its entries
-must be folded into the first towncrier-generated release manually.
-
 See https://github.com/open-telemetry/opentelemetry-python-genai/blob/main/CONTRIBUTING.md#changelog for details.
 -->
 
 <!-- changelog start -->
-
-## Unreleased
-- Align AgentSpanData test stubs and span processor with real OpenAI Agents SDK;
-  remove non-existent `operation`, `description`, `agent_id`, and `model` fields.
-  ([#4229](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4229))
-- Document official package metadata and README for the OpenAI Agents instrumentation.
-  ([#3859](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3859))
-- Populate instructions and tool definitions from Response obj.
-  ([#4196](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4196))
 
 ## Version 0.1.0 (2025-10-15)
 

--- a/instrumentation/opentelemetry-instrumentation-genai-openai/.changelog/+refactor-stream-wrappers.changed
+++ b/instrumentation/opentelemetry-instrumentation-genai-openai/.changelog/+refactor-stream-wrappers.changed
@@ -1,0 +1,1 @@
+Refactor chat completion stream wrappers to use shared GenAI stream lifecycle helpers. ([#4500](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4500))

--- a/instrumentation/opentelemetry-instrumentation-genai-openai/.changelog/+tool-definitions-span-attr.added
+++ b/instrumentation/opentelemetry-instrumentation-genai-openai/.changelog/+tool-definitions-span-attr.added
@@ -1,0 +1,1 @@
+Pass tool definitions from `tools` kwarg to `InferenceInvocation.tool_definitions` so `gen_ai.tool.definitions` span attribute is populated on chat completion spans ([#4554](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4554))

--- a/instrumentation/opentelemetry-instrumentation-genai-openai/CHANGELOG.md
+++ b/instrumentation/opentelemetry-instrumentation-genai-openai/CHANGELOG.md
@@ -10,21 +10,10 @@ Do *NOT* add changelog entries here!
 
 This changelog is managed by towncrier and is compiled at release time.
 
-The static "## Unreleased" section below pre-dates towncrier; its entries
-must be folded into the first towncrier-generated release manually.
-
 See https://github.com/open-telemetry/opentelemetry-python-genai/blob/main/CONTRIBUTING.md#changelog for details.
 -->
 
 <!-- changelog start -->
-
-## Unreleased
-
-- Refactor chat completion stream wrappers to use shared GenAI stream lifecycle helpers.
-  ([#4500](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4500))
-- Pass tool definitions from `tools` kwarg to `InferenceInvocation.tool_definitions`
-  so `gen_ai.tool.definitions` span attribute is populated on chat completion spans
-  ([#4554](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4554))
 
 ## Version 2.4b0 (2026-05-01)
 

--- a/instrumentation/opentelemetry-instrumentation-genai-weaviate-client/CHANGELOG.md
+++ b/instrumentation/opentelemetry-instrumentation-genai-weaviate-client/CHANGELOG.md
@@ -10,12 +10,7 @@ Do *NOT* add changelog entries here!
 
 This changelog is managed by towncrier and is compiled at release time.
 
-The static "## Unreleased" section below pre-dates towncrier; its entries
-must be folded into the first towncrier-generated release manually.
-
 See https://github.com/open-telemetry/opentelemetry-python-genai/blob/main/CONTRIBUTING.md#changelog for details.
 -->
 
 <!-- changelog start -->
-
-## Unreleased

--- a/instrumentation/opentelemetry-instrumentation-google-genai/.changelog/+cache-read-input-tokens-attr.added
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/.changelog/+cache-read-input-tokens-attr.added
@@ -1,0 +1,1 @@
+Add `gen_ai.usage.cache_read.input_tokens` attribute to capture cached tokens on spans/events when the experimental sem conv flag is set. ([#4313](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4313))

--- a/instrumentation/opentelemetry-instrumentation-google-genai/.changelog/+reasoning-output-tokens-attr.added
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/.changelog/+reasoning-output-tokens-attr.added
@@ -1,0 +1,1 @@
+Add `gen_ai.usage.reasoning.output_tokens` attribute to capture thinking tokens on spans/events when the experimental sem conv flag is set. Add thinking tokens to output tokens. ([#4313](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4313))

--- a/instrumentation/opentelemetry-instrumentation-google-genai/CHANGELOG.md
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/CHANGELOG.md
@@ -10,18 +10,10 @@ Do *NOT* add changelog entries here!
 
 This changelog is managed by towncrier and is compiled at release time.
 
-The static "## Unreleased" section below pre-dates towncrier; its entries
-must be folded into the first towncrier-generated release manually.
-
 See https://github.com/open-telemetry/opentelemetry-python-genai/blob/main/CONTRIBUTING.md#changelog for details.
 -->
 
 <!-- changelog start -->
-
-## Unreleased
-
--Add `gen_ai.usage.reasoning.output_tokens` attribute to capture thinking tokens on spans/events when the experimental sem conv flag is set. Add thinking tokens to output tokens. ([#4313](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4313))
--Add `gen_ai.usage.cache_read.input_tokens` attribute to capture cached tokens on spans/events when the experimental sem conv flag is set. ([#4313](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4313))
 
 ## Version 0.7b0 (2026-02-20)
 - Fix bug in how tokens are counted when using the streaming `generateContent` method.  ([#4152](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4152)).

--- a/scripts/changelog_template.j2
+++ b/scripts/changelog_template.j2
@@ -10,12 +10,12 @@
 {% for text, values in sections[section][category].items() %}
 {% if "\n  - " in text or '\n  * ' in text %}
 {%- set main_text, sub_items = text.split('\n', 1) %}
-- {{ main_text }} ({{ values|join(', ') }})
+- {{ main_text }}{% if values %} ({{ values|join(', ') }}){% endif +%}
 {% if sub_items %}
   {{- sub_items }}
 {% endif %}
 {% else %}
-- {{ text }} ({{ values|join(', ') }})
+- {{ text }}{% if values %} ({{ values|join(', ') }}){% endif +%}
 {% endif %}
 {% endfor %}
 

--- a/util/opentelemetry-util-genai/.changelog/+google-genai-migration-prep.changed
+++ b/util/opentelemetry-util-genai/.changelog/+google-genai-migration-prep.changed
@@ -1,0 +1,1 @@
+Minor code cleanup and changes in preparation of moving google's GenAI instrumentation library to use this util library ([#4556](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4556))

--- a/util/opentelemetry-util-genai/.changelog/+inference-invocation-base-params.changed
+++ b/util/opentelemetry-util-genai/.changelog/+inference-invocation-base-params.changed
@@ -1,0 +1,1 @@
+Change `InferenceInvocation` init params to only accept base params

--- a/util/opentelemetry-util-genai/.changelog/+sampling-attribute-on-instantiation.changed
+++ b/util/opentelemetry-util-genai/.changelog/+sampling-attribute-on-instantiation.changed
@@ -1,0 +1,1 @@
+Apply attribute for sampling on instantiation of all invocation types. ([#4553](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4553))

--- a/util/opentelemetry-util-genai/.changelog/+sampling-attributes-on-start.changed
+++ b/util/opentelemetry-util-genai/.changelog/+sampling-attributes-on-start.changed
@@ -1,0 +1,1 @@
+Pass in `attributes` on invocation `_start` so samplers have access to attributes. ([#4538](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4538))

--- a/util/opentelemetry-util-genai/.changelog/+stream-wrapper-base-classes.added
+++ b/util/opentelemetry-util-genai/.changelog/+stream-wrapper-base-classes.added
@@ -1,0 +1,1 @@
+Add shared sync and async stream wrapper base classes for GenAI instrumentations. ([#4500](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4500))

--- a/util/opentelemetry-util-genai/CHANGELOG.md
+++ b/util/opentelemetry-util-genai/CHANGELOG.md
@@ -10,25 +10,10 @@ Do *NOT* add changelog entries here!
 
 This changelog is managed by towncrier and is compiled at release time.
 
-The static "## Unreleased" section below pre-dates towncrier; its entries
-must be folded into the first towncrier-generated release manually.
-
 See https://github.com/open-telemetry/opentelemetry-python-genai/blob/main/CONTRIBUTING.md#changelog for details.
 -->
 
 <!-- changelog start -->
-
-## Unreleased
-
-- Add shared sync and async stream wrapper base classes for GenAI instrumentations.
-  ([#4500](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4500))
-- Change `InferenceInvocation` init params to only accept base params
-- Pass in `attributes` on invocation `_start` so samplers have access to attributes.
-  ([#4538](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4538))
-- Apply attribute for sampling on instantiation of all invocation types.
-  ([#4553](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4553))
-- Minor code cleanup and changes in preparation of moving google's GenAI instrumentation
-  library to use this util library ([#4556](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4556))
 
 ## Version 0.4b0 (2026-05-01)
 


### PR DESCRIPTION
- Fragments use towncrier **orphan** naming (`+<slug>.<type>`) — these entries reference old `opentelemetry-python-contrib` PRs, so the auto-appended genai-repo link would be wrong. Orphans disable that link; the original contrib PR link is kept inline in the body.
- Small `changelog_template.j2` tweak so orphan fragments don't render a stray `()` (no-op for normal numbered fragments).