### PR TITLE
openinference migration skill output for langchain

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/src/opentelemetry/instrumentation/genai/langchain/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/src/opentelemetry/instrumentation/genai/langchain/__init__.py
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Langchain instrumentation supporting `ChatOpenAI` and `ChatBedrock`, it can be enabled by
-using ``LangChainInstrumentor``. Other providers/LLMs may be supported in the future and telemetry for them is skipped for now.
+LangChain instrumentation for chat model, tool, retriever, workflow, and agent
+callbacks. It can be enabled by using ``LangChainInstrumentor``.
 
 Usage
 -----

--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/src/opentelemetry/instrumentation/genai/langchain/callback_handler.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/src/opentelemetry/instrumentation/genai/langchain/callback_handler.py
@@ -4,7 +4,9 @@
 from __future__ import annotations
 
 import json
-from typing import Any, Optional, cast
+from collections.abc import Mapping, Sequence
+from typing import Any, Optional
+from urllib.parse import urlparse
 from uuid import UUID
 
 from langchain_core.callbacks import BaseCallbackHandler
@@ -21,23 +23,58 @@ from opentelemetry.instrumentation.genai.langchain.operation_mapping import (
 )
 from opentelemetry.instrumentation.genai.langchain.utils import (
     make_input_message,
+    make_input_messages_from_messages,
     make_last_output_message,
+    make_output_messages_from_generations,
+    make_retrieval_document,
     prepare_tool_definitions,
+)
+from opentelemetry.semconv._incubating.attributes import (
+    gen_ai_attributes as GenAI,
 )
 from opentelemetry.util.genai.handler import TelemetryHandler
 from opentelemetry.util.genai.invocation import (
     AgentInvocation,
     InferenceInvocation,
+    RetrievalInvocation,
     ToolInvocation,
     WorkflowInvocation,
 )
-from opentelemetry.util.genai.types import (
-    InputMessage,
-    MessagePart,
-    OutputMessage,
-    Text,
-    ToolCallRequest,
-)
+
+_PROVIDER_NAME_MAP = {
+    "amazon_bedrock": GenAI.GenAiProviderNameValues.AWS_BEDROCK.value,
+    "anthropic": GenAI.GenAiProviderNameValues.ANTHROPIC.value,
+    "azure": GenAI.GenAiProviderNameValues.AZURE_AI_OPENAI.value,
+    "azure_ai": GenAI.GenAiProviderNameValues.AZURE_AI_INFERENCE.value,
+    "azure_openai": GenAI.GenAiProviderNameValues.AZURE_AI_OPENAI.value,
+    "bedrock": GenAI.GenAiProviderNameValues.AWS_BEDROCK.value,
+    "bedrock_converse": GenAI.GenAiProviderNameValues.AWS_BEDROCK.value,
+    "cohere": GenAI.GenAiProviderNameValues.COHERE.value,
+    "deepseek": GenAI.GenAiProviderNameValues.DEEPSEEK.value,
+    "google": GenAI.GenAiProviderNameValues.GCP_GEN_AI.value,
+    "google_genai": GenAI.GenAiProviderNameValues.GCP_GEN_AI.value,
+    "google_vertexai": GenAI.GenAiProviderNameValues.GCP_VERTEX_AI.value,
+    "groq": GenAI.GenAiProviderNameValues.GROQ.value,
+    "mistralai": GenAI.GenAiProviderNameValues.MISTRAL_AI.value,
+    "openai": GenAI.GenAiProviderNameValues.OPENAI.value,
+    "perplexity": GenAI.GenAiProviderNameValues.PERPLEXITY.value,
+    "vertex": GenAI.GenAiProviderNameValues.GCP_VERTEX_AI.value,
+    "vertexai": GenAI.GenAiProviderNameValues.GCP_VERTEX_AI.value,
+    "xai": GenAI.GenAiProviderNameValues.X_AI.value,
+}
+
+_SERVER_ADDRESS_MAP = {
+    "amazon_bedrock": "bedrock-runtime.amazonaws.com",
+    "bedrock": "bedrock-runtime.amazonaws.com",
+    "bedrock_converse": "bedrock-runtime.amazonaws.com",
+    "cohere": "api.cohere.ai",
+    "google": "generativelanguage.googleapis.com",
+    "google_genai": "generativelanguage.googleapis.com",
+    "google_vertexai": "aiplatform.googleapis.com",
+    "openai": "api.openai.com",
+    "vertex": "aiplatform.googleapis.com",
+    "vertexai": "aiplatform.googleapis.com",
+}
 
 
 class OpenTelemetryLangChainCallbackHandler(BaseCallbackHandler):
@@ -191,31 +228,11 @@ class OpenTelemetryLangChainCallbackHandler(BaseCallbackHandler):
         metadata: Optional[dict[str, Any]] = None,
         **kwargs: Any,
     ) -> None:
-        # Other providers/LLMs may be supported in the future and telemetry for them is skipped for now.
-        if serialized.get("name") not in ("ChatOpenAI", "ChatBedrock"):
-            return
+        params = _get_invocation_params(kwargs)
 
-        if "invocation_params" in kwargs:
-            params = (
-                kwargs["invocation_params"].get("params")
-                or kwargs["invocation_params"]
-            )
-        else:
-            params = kwargs
+        request_model = _get_request_model(params, metadata)
 
-        request_model = "unknown"
-        for model_tag in (
-            "model_name",  # ChatOpenAI
-            "model_id",  # ChatBedrock
-        ):
-            if (model := (params or {}).get(model_tag)) is not None:
-                request_model = model
-                break
-            elif (model := (metadata or {}).get(model_tag)) is not None:
-                request_model = model
-                break
-
-        # Skip telemetry for unsupported request models
+        # Skip telemetry when LangChain cannot provide a concrete model name.
         if request_model == "unknown":
             return
 
@@ -232,54 +249,31 @@ class OpenTelemetryLangChainCallbackHandler(BaseCallbackHandler):
             top_p = params.get("top_p")
             frequency_penalty = params.get("frequency_penalty")
             presence_penalty = params.get("presence_penalty")
-            stop_sequences = params.get("stop")
+            stop_sequences = params.get("stop") or params.get(
+                "stop_sequences"
+            )
             seed = params.get("seed")
             temperature = params.get("temperature")
-            max_tokens = params.get("max_completion_tokens")
+            max_tokens = params.get("max_completion_tokens") or params.get(
+                "max_tokens"
+            )
 
-        provider = "unknown"
+        provider = _get_provider_name(metadata)
+
         if metadata is not None:
-            provider = metadata.get("ls_provider", "unknown")
-
             # Override with ChatBedrock values if present
             if "ls_temperature" in metadata:
                 temperature = metadata.get("ls_temperature")
             if "ls_max_tokens" in metadata:
                 max_tokens = metadata.get("ls_max_tokens")
 
-        input_messages: list[InputMessage] = []
-        for sub_messages in messages:
-            for message in sub_messages:
-                # Cast to Any to avoid type checking issues with LangChain's complex content type
-                raw_content: Any = message.content
-                role = message.type
-                parts: list[Text] = []
-
-                if isinstance(raw_content, str):
-                    parts = [Text(content=raw_content, type="text")]
-                elif isinstance(raw_content, list):
-                    for item in raw_content:  # type: ignore[misc]
-                        if isinstance(item, str):
-                            parts.append(Text(content=item, type="text"))
-                        elif isinstance(item, dict):
-                            # Safely extract text content from dict
-                            text_value = item.get("text")  # type: ignore[misc]
-                            if isinstance(text_value, str) and text_value:
-                                parts.append(
-                                    Text(content=text_value, type="text")
-                                )
-
-                input_messages.append(
-                    InputMessage(
-                        parts=cast(list[MessagePart], parts), role=role
-                    )
-                )
-
         llm_invocation = self._telemetry_handler.inference(
             provider,
             request_model=request_model,
         )
-        llm_invocation.input_messages = input_messages
+        llm_invocation.input_messages = make_input_messages_from_messages(
+            messages
+        )
         llm_invocation.top_p = top_p
         llm_invocation.frequency_penalty = frequency_penalty
         llm_invocation.presence_penalty = presence_penalty
@@ -314,77 +308,12 @@ class OpenTelemetryLangChainCallbackHandler(BaseCallbackHandler):
             # If the invocation does not exist, we cannot set attributes or end it
             return
 
-        output_messages: list[OutputMessage] = []
-        for generation in getattr(response, "generations", []):
-            for chat_generation in generation:
-                # Get finish reason
-                finish_reason = "unknown"  # Default value
-                generation_info = getattr(
-                    chat_generation, "generation_info", None
-                )
-                if generation_info is not None:
-                    finish_reason = generation_info.get(
-                        "finish_reason", "unknown"
-                    )
-
-                if chat_generation.message:
-                    # Get finish reason if generation_info is None above
-                    if (
-                        generation_info is None
-                        and chat_generation.message.response_metadata
-                    ):
-                        finish_reason = (
-                            chat_generation.message.response_metadata.get(
-                                "stopReason", "unknown"
-                            )
-                        )
-
-                    if finish_reason in ("tool_calls", "tool_use"):
-                        tool_calls: list[ToolCallRequest] = []
-                        for tool_call in chat_generation.message.tool_calls:
-                            tool_call_request = ToolCallRequest(
-                                name=tool_call["name"],
-                                id=tool_call["id"],
-                                arguments=tool_call["args"],
-                            )
-                            tool_calls.append(tool_call_request)
-                        output_message = OutputMessage(
-                            role=chat_generation.message.type,
-                            parts=cast(list[MessagePart], tool_calls),
-                            finish_reason=finish_reason,
-                        )
-                    else:
-                        parts = [
-                            Text(
-                                content=chat_generation.message.content,
-                                type="text",
-                            )
-                        ]
-                        role = chat_generation.message.type
-                        output_message = OutputMessage(
-                            role=role,
-                            parts=cast(list[MessagePart], parts),
-                            finish_reason=finish_reason,
-                        )
-                    output_messages.append(output_message)
-
-                    # Get token usage if available
-                    if chat_generation.message.usage_metadata:
-                        input_tokens = (
-                            chat_generation.message.usage_metadata.get(
-                                "input_tokens", 0
-                            )
-                        )
-                        llm_invocation.input_tokens = input_tokens
-
-                        output_tokens = (
-                            chat_generation.message.usage_metadata.get(
-                                "output_tokens", 0
-                            )
-                        )
-                        llm_invocation.output_tokens = output_tokens
+        output_messages = make_output_messages_from_generations(
+            getattr(response, "generations", [])
+        )
 
         llm_invocation.output_messages = output_messages
+        _set_usage_tokens(llm_invocation, response)
 
         llm_output = getattr(response, "llm_output", None)
         if llm_output is not None:
@@ -488,6 +417,69 @@ class OpenTelemetryLangChainCallbackHandler(BaseCallbackHandler):
         if not tool_invocation.span.is_recording():
             self._invocation_manager.delete_invocation_state(run_id=run_id)
 
+    def on_retriever_start(
+        self,
+        serialized: dict[str, Any],
+        query: str,
+        *,
+        run_id: UUID,
+        parent_run_id: Optional[UUID] = None,
+        tags: Optional[list[str]] = None,
+        metadata: Optional[dict[str, Any]] = None,
+        **kwargs: Any,
+    ) -> None:
+        retrieval = self._telemetry_handler.retrieval(
+            data_source_id=_get_retriever_name(serialized, kwargs, metadata),
+            provider=_get_provider_name(metadata),
+            request_model=_get_request_model(None, metadata),
+            server_address=_get_server_address(metadata),
+        )
+        retrieval.query_text = query
+        self._invocation_manager.add_invocation_state(
+            run_id, parent_run_id, retrieval
+        )
+
+    def on_retriever_end(
+        self,
+        documents: Sequence[Any],
+        *,
+        run_id: UUID,
+        parent_run_id: Optional[UUID] = None,
+        **kwargs: Any,
+    ) -> None:
+        retrieval = self._invocation_manager.get_invocation(run_id)
+        if not isinstance(retrieval, RetrievalInvocation):
+            self._invocation_manager.delete_invocation_state(run_id)
+            return
+
+        retrieval.documents = [
+            document
+            for document in (
+                make_retrieval_document(document) for document in documents
+            )
+            if document
+        ]
+        retrieval.stop()
+        if not retrieval.span.is_recording():
+            self._invocation_manager.delete_invocation_state(run_id=run_id)
+
+    def on_retriever_error(
+        self,
+        error: BaseException,
+        *,
+        run_id: UUID,
+        parent_run_id: Optional[UUID] = None,
+        **kwargs: Any,
+    ) -> None:
+        retrieval = self._invocation_manager.get_invocation(run_id)
+        if not isinstance(retrieval, RetrievalInvocation):
+            self._invocation_manager.delete_invocation_state(run_id)
+            return
+
+        retrieval.fail(error)
+        if not retrieval.span.is_recording():
+            self._invocation_manager.delete_invocation_state(run_id=run_id)
+
     def _find_nearest_agent(
         self, run_id: Optional[UUID]
     ) -> Optional[AgentInvocation]:
@@ -500,3 +492,165 @@ class OpenTelemetryLangChainCallbackHandler(BaseCallbackHandler):
                 return entity
             current = self._invocation_manager.get_parent_run_id(current)
         return None
+
+
+def _get_invocation_params(kwargs: dict[str, Any]) -> Mapping[str, Any] | None:
+    invocation_params = kwargs.get("invocation_params")
+    if isinstance(invocation_params, Mapping):
+        params = invocation_params.get("params") or invocation_params
+        if isinstance(params, Mapping):
+            return params
+    return kwargs
+
+
+def _get_request_model(
+    params: Mapping[str, Any] | None,
+    metadata: Optional[dict[str, Any]],
+) -> str:
+    for source in (params, metadata):
+        if not source:
+            continue
+        for model_tag in (
+            "model_name",
+            "model",
+            "model_id",
+            "ls_model_name",
+        ):
+            if (model := source.get(model_tag)) is not None:
+                return str(model)
+    return "unknown"
+
+
+def _get_provider_name(metadata: Optional[dict[str, Any]]) -> str:
+    if not metadata:
+        return "unknown"
+    raw_provider = str(metadata.get("ls_provider", "unknown")).lower()
+    return _PROVIDER_NAME_MAP.get(raw_provider, raw_provider)
+
+
+def _get_server_address(metadata: Optional[dict[str, Any]]) -> str | None:
+    if not metadata:
+        return None
+
+    for key in ("ls_server_address", "server_address", "base_url", "endpoint"):
+        if (value := metadata.get(key)) is not None:
+            parsed = urlparse(str(value))
+            return parsed.hostname or str(value)
+
+    raw_provider = str(metadata.get("ls_provider", "")).lower()
+    return _SERVER_ADDRESS_MAP.get(raw_provider)
+
+
+def _set_usage_tokens(
+    invocation: InferenceInvocation, response: LLMResult
+) -> None:
+    usage = _find_usage_mapping(response)
+    if usage is None:
+        return
+
+    if (
+        input_tokens := _get_first_int(
+            usage,
+            ("prompt_tokens", "input_tokens", "prompt_token_count"),
+        )
+    ) is not None:
+        invocation.input_tokens = input_tokens
+    if (
+        output_tokens := _get_first_int(
+            usage,
+            (
+                "completion_tokens",
+                "output_tokens",
+                "candidates_token_count",
+            ),
+        )
+    ) is not None:
+        invocation.output_tokens = output_tokens
+
+    prompt_details = usage.get("prompt_tokens_details")
+    input_details = usage.get("input_token_details")
+    completion_details = usage.get("completion_tokens_details")
+    output_details = usage.get("output_token_details")
+
+    cache_creation = _first_not_none_int(
+        _get_first_int(usage, ("cache_creation_input_tokens",)),
+        _get_first_int(input_details, ("cache_creation",)),
+    )
+    if cache_creation is not None:
+        invocation.cache_creation_input_tokens = cache_creation
+    cache_read = _first_not_none_int(
+        _get_first_int(usage, ("cache_read_input_tokens",)),
+        _get_first_int(prompt_details, ("cached_tokens",)),
+        _get_first_int(input_details, ("cache_read",)),
+    )
+    if cache_read is not None:
+        invocation.cache_read_input_tokens = cache_read
+    thinking = _first_not_none_int(
+        _get_first_int(completion_details, ("reasoning_tokens",)),
+        _get_first_int(output_details, ("reasoning",)),
+    )
+    if thinking is not None:
+        invocation.thinking_tokens = thinking
+
+
+def _find_usage_mapping(response: LLMResult) -> Mapping[str, Any] | None:
+    llm_output = getattr(response, "llm_output", None)
+    if isinstance(llm_output, Mapping):
+        for key in ("token_usage", "usage"):
+            if isinstance(usage := llm_output.get(key), Mapping):
+                return usage
+
+    for generation in getattr(response, "generations", []):
+        for chat_generation in generation:
+            message = getattr(chat_generation, "message", None)
+            usage_metadata = getattr(message, "usage_metadata", None)
+            if isinstance(usage_metadata, Mapping):
+                return usage_metadata
+
+            response_metadata = getattr(message, "response_metadata", None)
+            if isinstance(response_metadata, Mapping):
+                for key in ("token_usage", "usage"):
+                    if isinstance(usage := response_metadata.get(key), Mapping):
+                        return usage
+
+            generation_info = getattr(chat_generation, "generation_info", None)
+            if isinstance(generation_info, Mapping):
+                usage = generation_info.get("usage_metadata")
+                if isinstance(usage, Mapping):
+                    return usage
+    return None
+
+
+def _get_first_int(
+    mapping: Mapping[str, Any] | None,
+    keys: tuple[str, ...],
+) -> int | None:
+    if not isinstance(mapping, Mapping):
+        return None
+    for key in keys:
+        value = mapping.get(key)
+        if isinstance(value, int):
+            return value
+    return None
+
+
+def _first_not_none_int(*values: int | None) -> int | None:
+    for value in values:
+        if value is not None:
+            return value
+    return None
+
+
+def _get_retriever_name(
+    serialized: dict[str, Any],
+    kwargs: dict[str, Any],
+    metadata: Optional[dict[str, Any]],
+) -> str | None:
+    for source in (kwargs, metadata, serialized):
+        if source and (name := source.get("name")):
+            return str(name)
+    if (serialized_id := serialized.get("id")) and isinstance(
+        serialized_id, list
+    ):
+        return str(serialized_id[-1])
+    return None

--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/src/opentelemetry/instrumentation/genai/langchain/utils.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/src/opentelemetry/instrumentation/genai/langchain/utils.py
@@ -1,18 +1,33 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
+import hashlib
 import json
+from collections.abc import Iterable, Mapping, Sequence
 from typing import Any, Optional, cast
 
-from langchain_core.messages import AIMessage
+from langchain_core.messages import BaseMessage
 
 from opentelemetry.util.genai.types import (
+    File,
     FunctionToolDefinition,
+    GenericPart,
     InputMessage,
+    MessagePart,
     OutputMessage,
     Text,
+    ToolCallRequest,
+    ToolCallResponse,
     ToolDefinition,
+    Uri,
 )
+
+_ROLE_MAP = {
+    "human": "user",
+    "ai": "assistant",
+}
 
 
 def _get_property_value(obj: Any, property_name: str) -> Any:
@@ -47,21 +62,16 @@ def prepare_tool_definitions(tools: list[Any]) -> list[ToolDefinition] | None:
 
 
 def make_input_message(data: Any) -> list[InputMessage]:
-    """Create structured input message with full data as JSON."""
+    """Create structured input messages from LangChain chain input data."""
     if not isinstance(data, dict):
         return []
     data_dict = cast(dict[str, Any], data)
-    input_messages: list[InputMessage] = []
     messages: Any = data_dict.get("messages")
     if messages is not None:
-        for msg in messages:
-            content: Any = getattr(msg, "content", "")
-            if content and isinstance(content, str):
-                input_message = InputMessage(
-                    role="user", parts=[Text(content)]
-                )
-                input_messages.append(input_message)
-        return input_messages
+        return make_input_messages_from_messages(
+            messages, normalize_roles=True
+        )
+
     # Fallback: serialize non-message state fields as input.
     # Common in LangGraph where nodes use structured state fields
     # (e.g., user_query) rather than a message list.
@@ -75,26 +85,72 @@ def make_input_message(data: Any) -> list[InputMessage]:
         serialized = serialize(input_data)
         if serialized:
             return [InputMessage(role="user", parts=[Text(serialized)])]
+    return []
+
+
+def make_input_messages_from_messages(
+    messages: Any, *, normalize_roles: bool = False
+) -> list[InputMessage]:
+    """Convert LangChain message objects and raw dict messages to GenAI input messages."""
+    input_messages: list[InputMessage] = []
+    for message in _iter_messages(messages):
+        genai_message = _message_to_input_message(
+            message, normalize_roles=normalize_roles
+        )
+        if genai_message is not None:
+            input_messages.append(genai_message)
     return input_messages
 
 
 def make_output_message(data: Any) -> list[OutputMessage]:
-    """Create structured output message with full data as JSON."""
+    """Create structured output messages from LangChain chain output data."""
     if not isinstance(data, dict):
         return []
     data_dict = cast(dict[str, Any], data)
-    output_messages: list[OutputMessage] = []
     messages: list[Any] | None = data_dict.get("messages")
     if messages is None:
         return []
-    for msg in messages:
-        content: Any = getattr(msg, "content", "")
-        if content and isinstance(msg, AIMessage) and isinstance(content, str):
-            output_message = OutputMessage(
-                role="assistant",
-                parts=[Text(content)],
+    return [
+        message
+        for raw_message in messages
+        if (
+            message := _message_to_output_message(
+                raw_message,
                 finish_reason="stop",
+                normalize_roles=True,
+                assistant_only=True,
             )
+        )
+        is not None
+    ]
+
+
+def make_output_messages_from_generations(
+    generations: Any,
+) -> list[OutputMessage]:
+    """Convert LangChain LLMResult generations to GenAI output messages."""
+    output_messages: list[OutputMessage] = []
+    for generation in _iter_generation_items(generations):
+        message = _get_value(generation, "message")
+        if message is None:
+            text = _get_value(generation, "text")
+            if isinstance(text, str) and text:
+                output_messages.append(
+                    OutputMessage(
+                        role="assistant",
+                        parts=[Text(text)],
+                        finish_reason=_get_finish_reason(generation),
+                    )
+                )
+            continue
+
+        output_message = _message_to_output_message(
+            message,
+            finish_reason=_get_finish_reason(generation),
+            normalize_roles=False,
+            assistant_only=False,
+        )
+        if output_message is not None:
             output_messages.append(output_message)
     return output_messages
 
@@ -112,6 +168,54 @@ def make_last_output_message(data: Any) -> list[OutputMessage]:
     return []
 
 
+def make_retrieval_document(document: Any) -> dict[str, Any]:
+    """Convert a LangChain document into a semconv retrieval document object."""
+    result: dict[str, Any] = {}
+    metadata = _get_value(document, "metadata")
+    page_content = _get_value(document, "page_content")
+    document_id = _get_retrieval_document_id(document, metadata, page_content)
+    if document_id is not None:
+        result["id"] = document_id
+    result["score"] = _get_retrieval_document_score(document, metadata)
+    if page_content is not None:
+        result["content"] = str(page_content)
+    if metadata is not None:
+        result["metadata"] = metadata
+    return result
+
+
+def _get_retrieval_document_id(
+    document: Any, metadata: Any, page_content: Any
+) -> str | None:
+    if (document_id := _get_value(document, "id")) is not None:
+        return str(document_id)
+
+    if isinstance(metadata, Mapping):
+        for metadata_key in ("id", "document_id", "source"):
+            if (document_id := metadata.get(metadata_key)) is not None:
+                return str(document_id)
+
+    serialized = serialize({"content": page_content, "metadata": metadata})
+    if serialized:
+        return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
+    return None
+
+
+def _get_retrieval_document_score(document: Any, metadata: Any) -> float:
+    for score_source in (document, metadata):
+        if score_source is None:
+            continue
+        for score_key in ("score", "relevance_score", "similarity_score"):
+            score = _get_value(score_source, score_key)
+            if score is None:
+                continue
+            try:
+                return float(score)
+            except (TypeError, ValueError):
+                continue
+    return 1.0
+
+
 def serialize(obj: Any) -> Optional[str]:
     """Serialize object to JSON string.
 
@@ -125,3 +229,251 @@ def serialize(obj: Any) -> Optional[str]:
         return json.dumps(obj, ensure_ascii=False, default=str)
     except (TypeError, ValueError):
         return None
+
+
+def _message_to_input_message(
+    message: Any, *, normalize_roles: bool
+) -> InputMessage | None:
+    role = _message_role(message, normalize=normalize_roles)
+    parts = _message_parts(message)
+    if not parts:
+        return None
+    return InputMessage(role=role, parts=parts)
+
+
+def _message_to_output_message(
+    message: Any,
+    *,
+    finish_reason: str,
+    normalize_roles: bool,
+    assistant_only: bool,
+) -> OutputMessage | None:
+    role = _message_role(message, normalize=normalize_roles)
+    if assistant_only and role not in ("assistant", "ai"):
+        return None
+    parts = _message_parts(message)
+    if not parts:
+        return None
+    return OutputMessage(
+        role=role,
+        parts=parts,
+        finish_reason=finish_reason,
+    )
+
+
+def _message_parts(message: Any) -> list[MessagePart]:
+    role = _message_role(message, normalize=True)
+    content = _message_content(message)
+    if role in ("tool", "function"):
+        return [
+            ToolCallResponse(
+                id=_string_or_none(_get_value(message, "tool_call_id")),
+                response=content,
+            )
+        ]
+
+    parts = _content_to_parts(content)
+    if role == "assistant":
+        parts.extend(_tool_call_parts(message))
+    return parts
+
+
+def _content_to_parts(content: Any) -> list[MessagePart]:
+    if content is None or content == "":
+        return []
+    if isinstance(content, str):
+        return [Text(content)]
+    if isinstance(content, Mapping):
+        return [_content_mapping_to_part(content)]
+    if isinstance(content, Iterable) and not isinstance(content, (bytes, str)):
+        parts: list[MessagePart] = []
+        for item in content:
+            if item is None or item == "":
+                continue
+            if isinstance(item, str):
+                parts.append(Text(item))
+            elif isinstance(item, Mapping):
+                parts.append(_content_mapping_to_part(item))
+            else:
+                parts.append(GenericPart(value=item))
+        return parts
+    return [GenericPart(value=content)]
+
+
+def _content_mapping_to_part(content: Mapping[str, Any]) -> MessagePart:
+    content_type = content.get("type")
+    if content_type in ("text", "input_text", "output_text") or (
+        content_type is None and isinstance(content.get("text"), str)
+    ):
+        return Text(str(content.get("text") or content.get("content") or ""))
+
+    if content_type == "image_url":
+        image_url = content.get("image_url")
+        uri = image_url.get("url") if isinstance(image_url, Mapping) else image_url
+        if isinstance(uri, str):
+            return Uri(
+                mime_type=_mime_type_from_uri(uri),
+                modality="image",
+                uri=uri,
+            )
+
+    if content_type in ("image", "audio", "video", "file"):
+        file_id = content.get("file_id")
+        if isinstance(file_id, str):
+            return File(
+                mime_type=_string_or_none(content.get("mime_type")),
+                modality=str(content_type),
+                file_id=file_id,
+            )
+
+    return GenericPart(value=dict(content))
+
+
+def _tool_call_parts(message: Any) -> list[ToolCallRequest]:
+    parts: list[ToolCallRequest] = []
+    for tool_call in _message_tool_calls(message):
+        if part := _tool_call_part(tool_call):
+            parts.append(part)
+
+    additional_kwargs = _get_value(message, "additional_kwargs")
+    if isinstance(additional_kwargs, Mapping):
+        function_call = additional_kwargs.get("function_call")
+        if isinstance(function_call, Mapping):
+            parts.append(
+                ToolCallRequest(
+                    id=None,
+                    name=str(function_call.get("name") or ""),
+                    arguments=_tool_arguments(
+                        function_call.get("arguments")
+                    ),
+                )
+            )
+    return parts
+
+
+def _message_tool_calls(message: Any) -> list[Any]:
+    tool_calls = _get_value(message, "tool_calls")
+    if tool_calls:
+        return list(tool_calls)
+    additional_kwargs = _get_value(message, "additional_kwargs")
+    if isinstance(additional_kwargs, Mapping) and additional_kwargs.get(
+        "tool_calls"
+    ):
+        return list(additional_kwargs["tool_calls"])
+    return []
+
+
+def _tool_call_part(tool_call: Any) -> ToolCallRequest | None:
+    function = _get_value(tool_call, "function")
+    if function is not None:
+        name = _get_value(function, "name") or ""
+        arguments = _get_value(function, "arguments")
+    else:
+        name = _get_value(tool_call, "name") or ""
+        arguments = (
+            _get_value(tool_call, "args")
+            if _get_value(tool_call, "args") is not None
+            else _get_value(tool_call, "arguments")
+        )
+    return ToolCallRequest(
+        id=_string_or_none(_get_value(tool_call, "id")),
+        name=str(name),
+        arguments=_tool_arguments(arguments),
+    )
+
+
+def _tool_arguments(arguments: Any) -> Any:
+    if not isinstance(arguments, str):
+        return arguments
+    try:
+        return json.loads(arguments)
+    except json.JSONDecodeError:
+        return arguments
+
+
+def _iter_messages(messages: Any) -> Iterable[Any]:
+    if isinstance(messages, (str, bytes)) or isinstance(messages, Mapping):
+        yield messages
+        return
+    if isinstance(messages, Sequence):
+        if len(messages) == 2 and isinstance(messages[0], str):
+            yield {"role": messages[0], "content": messages[1]}
+            return
+        for item in messages:
+            yield from _iter_messages(item)
+        return
+    yield messages
+
+
+def _iter_generation_items(generations: Any) -> Iterable[Any]:
+    if not generations:
+        return
+    for generation in generations:
+        if isinstance(generation, Iterable) and not isinstance(
+            generation, (Mapping, str, bytes)
+        ):
+            yield from generation
+        else:
+            yield generation
+
+
+def _message_role(message: Any, *, normalize: bool) -> str:
+    role = _get_value(message, "role") or _get_value(message, "type")
+    if role is None and isinstance(message, BaseMessage):
+        role = message.type
+    if role is None:
+        role = "user"
+    role_str = str(role)
+    if normalize:
+        return _ROLE_MAP.get(role_str, role_str)
+    return role_str
+
+
+def _message_content(message: Any) -> Any:
+    if isinstance(message, Mapping):
+        if "content" in message:
+            return message.get("content")
+        kwargs = message.get("kwargs")
+        if isinstance(kwargs, Mapping):
+            return kwargs.get("content")
+    return getattr(message, "content", None)
+
+
+def _get_value(obj: Any, key: str) -> Any:
+    if isinstance(obj, Mapping):
+        if key in obj:
+            return obj.get(key)
+        kwargs = obj.get("kwargs")
+        if isinstance(kwargs, Mapping) and key in kwargs:
+            return kwargs.get(key)
+    return getattr(obj, key, None)
+
+
+def _get_finish_reason(generation: Any) -> str:
+    generation_info = _get_value(generation, "generation_info")
+    if isinstance(generation_info, Mapping):
+        finish_reason = generation_info.get("finish_reason")
+        if finish_reason is not None:
+            return str(finish_reason)
+
+    message = _get_value(generation, "message")
+    response_metadata = _get_value(message, "response_metadata")
+    if isinstance(response_metadata, Mapping):
+        for key in ("finish_reason", "stopReason"):
+            finish_reason = response_metadata.get(key)
+            if finish_reason is not None:
+                return str(finish_reason)
+    return "unknown"
+
+
+def _mime_type_from_uri(uri: str) -> str | None:
+    if uri.startswith("data:") and "," in uri:
+        header = uri.split(",", 1)[0]
+        return header[5:].split(";", 1)[0] or None
+    return None
+
+
+def _string_or_none(value: Any) -> str | None:
+    if value is None:
+        return None
+    return str(value)

--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/tests/conformance/retrieval.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/tests/conformance/retrieval.py
@@ -1,0 +1,68 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Conformance scenario: langchain retriever callback."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from langchain_core.callbacks import CallbackManagerForRetrieverRun
+from langchain_core.documents import Document
+from langchain_core.retrievers import BaseRetriever
+
+from opentelemetry.instrumentation.genai.langchain import LangChainInstrumentor
+from opentelemetry.sdk._logs import LoggerProvider
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.test_util_genai.conformance import Scenario
+from opentelemetry.test_util_genai.instrumentor import instrument
+
+
+class StaticRetriever(BaseRetriever):
+    documents: list[Document]
+
+    def _get_relevant_documents(
+        self, query: str, *, run_manager: CallbackManagerForRetrieverRun
+    ) -> list[Document]:
+        return self.documents
+
+
+class RetrievalScenario(Scenario):
+    expected_spans = ("retrieval",)
+    expected_metrics = ("gen_ai.client.operation.duration",)
+
+    def run(
+        self,
+        *,
+        tracer_provider: TracerProvider,
+        meter_provider: MeterProvider,
+        logger_provider: LoggerProvider,
+        vcr: Any,
+    ) -> None:
+        with instrument(
+            LangChainInstrumentor(),
+            tracer_provider=tracer_provider,
+            logger_provider=logger_provider,
+            meter_provider=meter_provider,
+            semconv="gen_ai_latest_experimental",
+            content_capture="SPAN_ONLY",
+        ):
+            retriever = StaticRetriever(
+                documents=[
+                    Document(
+                        page_content="Paris is the capital of France.",
+                        metadata={"source": "encyclopedia"},
+                    )
+                ]
+            ).with_config(
+                {
+                    "run_name": "city_docs",
+                    "metadata": {
+                        "ls_provider": "openai",
+                        "ls_model_name": "text-embedding-3-small",
+                    },
+                }
+            )
+
+            retriever.invoke("capital of France")

--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/tests/test_callback_handler.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/tests/test_callback_handler.py
@@ -9,6 +9,7 @@ the callback-handler logic and the invocation-manager bookkeeping.
 """
 
 import uuid
+from types import SimpleNamespace
 from unittest import mock
 
 from langchain_core.messages import AIMessage, HumanMessage
@@ -19,6 +20,7 @@ from opentelemetry.instrumentation.genai.langchain.callback_handler import (
 )
 from opentelemetry.instrumentation.genai.langchain.utils import (
     make_input_message,
+    make_input_messages_from_messages,
     make_last_output_message,
     make_output_message,
     serialize,
@@ -26,6 +28,7 @@ from opentelemetry.instrumentation.genai.langchain.utils import (
 from opentelemetry.util.genai.invocation import (
     AgentInvocation,
     InferenceInvocation,
+    RetrievalInvocation,
     WorkflowInvocation,
 )
 from opentelemetry.util.genai.types import (
@@ -33,6 +36,8 @@ from opentelemetry.util.genai.types import (
     OutputMessage,
     Text,
     ToolCallRequest,
+    ToolCallResponse,
+    Uri,
 )
 
 # ---------------------------------------------------------------------------
@@ -78,6 +83,16 @@ def _make_handler():
     telemetry.invoke_local_agent.side_effect = (
         _make_invoke_local_agent_side_effect(agent_inv)
     )
+
+    inference_inv = mock.MagicMock(spec=InferenceInvocation)
+    inference_inv.span = mock.MagicMock()
+    inference_inv.span.is_recording.return_value = False
+    telemetry.inference.return_value = inference_inv
+
+    retrieval_inv = mock.MagicMock(spec=RetrievalInvocation)
+    retrieval_inv.span = mock.MagicMock()
+    retrieval_inv.span.is_recording.return_value = False
+    telemetry.retrieval.return_value = retrieval_inv
 
     handler = OpenTelemetryLangChainCallbackHandler(telemetry)
     return handler, telemetry, workflow_inv, agent_inv
@@ -600,6 +615,143 @@ class TestFindNearestAgent:
 
 
 # ---------------------------------------------------------------------------
+# on_chat_model_start / provider parsing
+# ---------------------------------------------------------------------------
+
+
+class TestChatModelCallbacks:
+    def test_chat_model_start_supports_google_genai_provider(self):
+        handler, telemetry, _, _ = _make_handler()
+        run_id = _run_id()
+
+        handler.on_chat_model_start(
+            serialized={"name": "ChatGoogleGenerativeAI"},
+            messages=[[HumanMessage(content="Hello")]],
+            run_id=run_id,
+            metadata={
+                "ls_provider": "google_genai",
+                "ls_model_name": "gemini-2.5-pro",
+            },
+            invocation_params={"model": "gemini-2.5-pro"},
+        )
+
+        telemetry.inference.assert_called_once_with(
+            "gcp.gen_ai",
+            request_model="gemini-2.5-pro",
+        )
+        assigned = telemetry.inference.return_value.input_messages
+        assert len(assigned) == 1
+        assert assigned[0].role == "human"
+        assert assigned[0].parts[0].content == "Hello"
+
+    def test_llm_end_extracts_usage_details(self):
+        handler, telemetry, _, _ = _make_handler()
+        run_id = _run_id()
+        handler.on_chat_model_start(
+            serialized={"name": "ChatOpenAI"},
+            messages=[[HumanMessage(content="Weather?")]],
+            run_id=run_id,
+            metadata={"ls_provider": "openai", "ls_model_name": "gpt-4o"},
+        )
+
+        message = SimpleNamespace(
+            type="ai",
+            content="Done",
+            tool_calls=[],
+            additional_kwargs={},
+            response_metadata={},
+            usage_metadata=None,
+        )
+        generation = SimpleNamespace(
+            message=message, generation_info={"finish_reason": "stop"}
+        )
+        response = SimpleNamespace(
+            generations=[[generation]],
+            llm_output={
+                "model_name": "gpt-4o-2024-08-06",
+                "id": "resp_123",
+                "token_usage": {
+                    "prompt_tokens": 10,
+                    "completion_tokens": 4,
+                    "prompt_tokens_details": {"cached_tokens": 3},
+                    "completion_tokens_details": {"reasoning_tokens": 2},
+                },
+            },
+        )
+
+        handler.on_llm_end(response=response, run_id=run_id)
+
+        invocation = telemetry.inference.return_value
+        assert invocation.input_tokens == 10
+        assert invocation.output_tokens == 4
+        assert invocation.cache_read_input_tokens == 3
+        assert invocation.thinking_tokens == 2
+        assert invocation.response_model_name == "gpt-4o-2024-08-06"
+        assert invocation.response_id == "resp_123"
+        invocation.stop.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# on_retriever_*
+# ---------------------------------------------------------------------------
+
+
+class TestRetrieverCallbacks:
+    def test_retrieval_invocation_stopped_on_retriever_end(self):
+        handler, telemetry, _, _ = _make_handler()
+        run_id = _run_id()
+
+        document = mock.Mock()
+        document.id = None
+        document.page_content = "Paris is the capital of France."
+        document.metadata = {"source": "wiki"}
+
+        handler.on_retriever_start(
+            serialized={"name": "city_docs"},
+            query="capital of France",
+            run_id=run_id,
+            metadata={
+                "ls_provider": "openai",
+                "ls_model_name": "text-embedding-3-small",
+            },
+        )
+        handler.on_retriever_end(documents=[document], run_id=run_id)
+
+        telemetry.retrieval.assert_called_once_with(
+            data_source_id="city_docs",
+            provider="openai",
+            request_model="text-embedding-3-small",
+            server_address="api.openai.com",
+        )
+        retrieval = telemetry.retrieval.return_value
+        assert retrieval.query_text == "capital of France"
+        assert retrieval.documents == [
+            {
+                "id": "wiki",
+                "score": 1.0,
+                "content": "Paris is the capital of France.",
+                "metadata": {"source": "wiki"},
+            }
+        ]
+        retrieval.stop.assert_called_once()
+        assert run_id not in handler._invocation_manager._invocations
+
+    def test_retrieval_invocation_failed_on_retriever_error(self):
+        handler, telemetry, _, _ = _make_handler()
+        run_id = _run_id()
+        error = TimeoutError("timeout")
+
+        handler.on_retriever_start(
+            serialized={"name": "city_docs"},
+            query="capital of France",
+            run_id=run_id,
+        )
+        handler.on_retriever_error(error=error, run_id=run_id)
+
+        telemetry.retrieval.return_value.fail.assert_called_once_with(error)
+
+
+# ---------------------------------------------------------------------------
 # utils.make_input_message
 # ---------------------------------------------------------------------------
 
@@ -698,6 +850,84 @@ class TestMakeInputMessage:
         # messages key present but empty → return empty list (no fallback)
         result = make_input_message({"messages": [], "user_query": "ignored"})
         assert result == []
+
+    def test_raw_dict_message_role_and_content(self):
+        result = make_input_message(
+            {"messages": [{"role": "user", "content": "Hi"}]}
+        )
+
+        assert len(result) == 1
+        assert result[0].role == "user"
+        assert result[0].parts[0].content == "Hi"
+
+    def test_multi_part_image_message(self):
+        image_url = "data:image/jpeg;base64,abc123"
+        result = make_input_messages_from_messages(
+            [
+                HumanMessage(
+                    content=[
+                        {"type": "text", "text": "What is shown?"},
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": image_url},
+                        },
+                    ]
+                )
+            ],
+            normalize_roles=True,
+        )
+
+        assert len(result) == 1
+        assert result[0].role == "user"
+        assert result[0].parts[0].content == "What is shown?"
+        image_part = result[0].parts[1]
+        assert isinstance(image_part, Uri)
+        assert image_part.modality == "image"
+        assert image_part.mime_type == "image/jpeg"
+        assert image_part.uri == image_url
+
+    def test_assistant_tool_call_message(self):
+        result = make_input_messages_from_messages(
+            [
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "name": "get_weather",
+                            "args": {"city": "San Francisco"},
+                            "id": "call_1",
+                        }
+                    ],
+                }
+            ],
+            normalize_roles=True,
+        )
+
+        assert len(result) == 1
+        tool_call = result[0].parts[0]
+        assert isinstance(tool_call, ToolCallRequest)
+        assert tool_call.id == "call_1"
+        assert tool_call.name == "get_weather"
+        assert tool_call.arguments == {"city": "San Francisco"}
+
+    def test_tool_response_message(self):
+        result = make_input_messages_from_messages(
+            [
+                {
+                    "role": "tool",
+                    "content": "Sunny",
+                    "tool_call_id": "call_1",
+                }
+            ],
+            normalize_roles=True,
+        )
+
+        assert len(result) == 1
+        tool_response = result[0].parts[0]
+        assert isinstance(tool_response, ToolCallResponse)
+        assert tool_response.id == "call_1"
+        assert tool_response.response == "Sunny"
 
 
 # ---------------------------------------------------------------------------

--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/tests/test_conformance.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/tests/test_conformance.py
@@ -22,6 +22,7 @@ from opentelemetry.test_util_genai.conformance import (  # noqa: E402
 
 from .conformance.agent import AgentScenario
 from .conformance.inference import InferenceScenario
+from .conformance.retrieval import RetrievalScenario
 from .conformance.tool_calling import ToolCallingScenario
 from .conformance.workflow import WorkflowScenario
 
@@ -32,6 +33,7 @@ from .conformance.workflow import WorkflowScenario
         InferenceScenario(),
         AgentScenario(),
         ToolCallingScenario(),
+        RetrievalScenario(),
         WorkflowScenario(),
     ],
     ids=lambda s: type(s).__name__,

--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/tests/test_llm_call.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/tests/test_llm_call.py
@@ -195,7 +195,21 @@ def test_gemini(span_exporter, start_instrumentation, gemini):
 
     # verify spans
     spans = span_exporter.get_finished_spans()
-    assert len(spans) == 0  # No spans should be created for gemini as of now
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.name == "chat gemini-2.5-pro"
+    assert (
+        span.attributes[gen_ai_attributes.GEN_AI_OPERATION_NAME]
+        == gen_ai_attributes.GenAiOperationNameValues.CHAT.value
+    )
+    assert (
+        span.attributes[gen_ai_attributes.GEN_AI_REQUEST_MODEL]
+        == "gemini-2.5-pro"
+    )
+    assert (
+        span.attributes[gen_ai_attributes.GEN_AI_PROVIDER_NAME]
+        == gen_ai_attributes.GenAiProviderNameValues.GCP_GEN_AI.value
+    )
 
 
 def assert_openai_completion_attributes(
@@ -324,7 +338,10 @@ def assert_bedrock_completion_attributes(
         == "us.amazon.nova-lite-v1:0"
     )
 
-    assert span.attributes["gen_ai.provider.name"] == "amazon_bedrock"
+    assert (
+        span.attributes[gen_ai_attributes.GEN_AI_PROVIDER_NAME]
+        == gen_ai_attributes.GenAiProviderNameValues.AWS_BEDROCK.value
+    )
     assert span.attributes[gen_ai_attributes.GEN_AI_REQUEST_MAX_TOKENS] == 100
     assert span.attributes[gen_ai_attributes.GEN_AI_REQUEST_TEMPERATURE] == 0.1
 


### PR DESCRIPTION
# Description

Augments the LangChain GenAI instrumentation with coverage from the OpenInference migration work.

This expands chat model handling beyond the previous OpenAI/Bedrock-only path by using LangChain metadata to resolve provider and model names, normalizing known provider values, and improving request/response message parsing for raw dict messages, multimodal content, tool calls, and tool responses.

It also adds LangChain retriever callback support using `TelemetryHandler.retrieval()`, including retrieval query text, data source id, provider/model/server metadata, retrieved document mapping, and a retrieval conformance scenario.

Related to #124.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How has this been tested?

- [x] `uv run tox -e py312-test-instrumentation-genai-langchain -- -q`
- [x] `uv run tox -e py312-test-instrumentation-genai-langchain-conformance -- -q`
- [x] `uv run --python 3.12 tox -e lint-instrumentation-genai-langchain`
- [x] `git diff --check`

# Checklist

See [CONTRIBUTING.md](https://github.com/open-telemetry/opentelemetry-python-genai/blob/main/CONTRIBUTING.md)
for the style guide, changelog guidance, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelog updated if the change requires an entry
- [x] Unit tests added
- [ ] Documentation updated
