### PR TITLE
Drop the semconv / OTEL_SEMCONV_STABILITY_OPT_IN plumbing from the shared test helper

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/conformance/inference.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/conformance/inference.py
@@ -45,7 +45,6 @@ class InferenceScenario(Scenario):
                 tracer_provider=tracer_provider,
                 logger_provider=logger_provider,
                 meter_provider=meter_provider,
-                semconv="gen_ai_latest_experimental",
                 content_capture="SPAN_ONLY",
             ):
                 with vcr.use_cassette("inference_conformance.yaml"):

--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/conformance/tool_calling.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/conformance/tool_calling.py
@@ -45,7 +45,6 @@ class ToolCallingScenario(Scenario):
                 tracer_provider=tracer_provider,
                 logger_provider=logger_provider,
                 meter_provider=meter_provider,
-                semconv="gen_ai_latest_experimental",
                 content_capture="SPAN_ONLY",
             ):
                 with vcr.use_cassette("tool_calling_conformance.yaml"):

--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/conftest.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/conftest.py
@@ -60,13 +60,12 @@ def vcr_config():
 
 @pytest.fixture
 def instrument_no_content(tracer_provider, logger_provider, meter_provider):
-    """Instrument Anthropic without content capture (stable semconv mode)."""
+    """Instrument Anthropic without content capture."""
     with instrument(
         AnthropicInstrumentor(),
         tracer_provider=tracer_provider,
         logger_provider=logger_provider,
         meter_provider=meter_provider,
-        semconv="stable",
         content_capture="NO_CONTENT",
     ) as instrumentor:
         yield instrumentor
@@ -80,7 +79,6 @@ def instrument_with_content(tracer_provider, logger_provider, meter_provider):
         tracer_provider=tracer_provider,
         logger_provider=logger_provider,
         meter_provider=meter_provider,
-        semconv="gen_ai_latest_experimental",
         content_capture="SPAN_ONLY",
     ) as instrumentor:
         yield instrumentor
@@ -94,7 +92,6 @@ def instrument_event_only(tracer_provider, logger_provider, meter_provider):
         tracer_provider=tracer_provider,
         logger_provider=logger_provider,
         meter_provider=meter_provider,
-        semconv="gen_ai_latest_experimental",
         content_capture="EVENT_ONLY",
         emit_event=True,
     ) as instrumentor:

--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/tests/conformance/agent.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/tests/conformance/agent.py
@@ -73,7 +73,6 @@ class AgentScenario(Scenario):
                 tracer_provider=tracer_provider,
                 logger_provider=logger_provider,
                 meter_provider=meter_provider,
-                semconv="gen_ai_latest_experimental",
                 content_capture="SPAN_ONLY",
             ):
                 llm = ChatOpenAI(

--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/tests/conformance/inference.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/tests/conformance/inference.py
@@ -56,7 +56,6 @@ class InferenceScenario(Scenario):
                 tracer_provider=tracer_provider,
                 logger_provider=logger_provider,
                 meter_provider=meter_provider,
-                semconv="gen_ai_latest_experimental",
                 content_capture="SPAN_ONLY",
             ):
                 llm = ChatOpenAI(

--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/tests/conformance/tool_calling.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/tests/conformance/tool_calling.py
@@ -108,7 +108,6 @@ class ToolCallingScenario(Scenario):
                 tracer_provider=tracer_provider,
                 logger_provider=logger_provider,
                 meter_provider=meter_provider,
-                semconv="gen_ai_latest_experimental",
                 content_capture="SPAN_ONLY",
             ):
                 llm = ChatOpenAI(

--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/tests/conformance/workflow.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/tests/conformance/workflow.py
@@ -64,7 +64,6 @@ class WorkflowScenario(Scenario):
                 tracer_provider=tracer_provider,
                 logger_provider=logger_provider,
                 meter_provider=meter_provider,
-                semconv="gen_ai_latest_experimental",
                 content_capture="SPAN_ONLY",
             ):
                 llm = ChatOpenAI(

--- a/instrumentation/opentelemetry-instrumentation-genai-openai-agents/tests/conformance/orchestration.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-openai-agents/tests/conformance/orchestration.py
@@ -91,7 +91,6 @@ class OrchestrationScenario(Scenario):
                 tracer_provider=tracer_provider,
                 logger_provider=logger_provider,
                 meter_provider=meter_provider,
-                semconv="gen_ai_latest_experimental",
                 content_capture="SPAN_ONLY",
             ):
                 with vcr.use_cassette("orchestration_conformance.yaml"):

--- a/instrumentation/opentelemetry-instrumentation-genai-openai/tests/conformance/embedding.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-openai/tests/conformance/embedding.py
@@ -37,7 +37,6 @@ class EmbeddingScenario(Scenario):
             tracer_provider=tracer_provider,
             logger_provider=logger_provider,
             meter_provider=meter_provider,
-            semconv="gen_ai_latest_experimental",
             content_capture="SPAN_ONLY",
         ):
             with vcr.use_cassette("embedding_conformance.yaml"):

--- a/instrumentation/opentelemetry-instrumentation-genai-openai/tests/conformance/inference.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-openai/tests/conformance/inference.py
@@ -37,7 +37,6 @@ class InferenceScenario(Scenario):
             tracer_provider=tracer_provider,
             logger_provider=logger_provider,
             meter_provider=meter_provider,
-            semconv="gen_ai_latest_experimental",
             content_capture="SPAN_ONLY",
         ):
             with vcr.use_cassette("inference_conformance.yaml"):

--- a/instrumentation/opentelemetry-instrumentation-genai-openai/tests/conformance/responses_conversation.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-openai/tests/conformance/responses_conversation.py
@@ -40,7 +40,6 @@ class ResponsesConversationScenario(Scenario):
             tracer_provider=tracer_provider,
             logger_provider=logger_provider,
             meter_provider=meter_provider,
-            semconv="gen_ai_latest_experimental",
             content_capture="SPAN_ONLY",
         ):
             with vcr.use_cassette("responses_conversation_conformance.yaml"):

--- a/instrumentation/opentelemetry-instrumentation-genai-openai/tests/conformance/responses_stream.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-openai/tests/conformance/responses_stream.py
@@ -41,7 +41,6 @@ class ResponsesStreamScenario(Scenario):
             tracer_provider=tracer_provider,
             logger_provider=logger_provider,
             meter_provider=meter_provider,
-            semconv="gen_ai_latest_experimental",
             content_capture="SPAN_ONLY",
         ):
             with vcr.use_cassette("responses_stream_conformance.yaml"):

--- a/instrumentation/opentelemetry-instrumentation-genai-openai/tests/conformance/tool_calling.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-openai/tests/conformance/tool_calling.py
@@ -79,7 +79,6 @@ class ToolCallingScenario(Scenario):
             tracer_provider=tracer_provider,
             logger_provider=logger_provider,
             meter_provider=meter_provider,
-            semconv="gen_ai_latest_experimental",
             content_capture="SPAN_ONLY",
         ):
             with vcr.use_cassette("tool_calling_conformance.yaml"):

--- a/instrumentation/opentelemetry-instrumentation-genai-openai/tests/conftest.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-openai/tests/conftest.py
@@ -72,11 +72,6 @@ def fixture_content_mode(request):
     return request.param
 
 
-def _semconv_from_content_mode(content_mode) -> str:
-    latest_experimental_enabled, _ = content_mode
-    return "gen_ai_latest_experimental" if latest_experimental_enabled else ""
-
-
 @pytest.fixture(scope="function")
 def instrument_no_content(
     tracer_provider,
@@ -89,7 +84,6 @@ def instrument_no_content(
         tracer_provider=tracer_provider,
         logger_provider=logger_provider,
         meter_provider=meter_provider,
-        semconv=_semconv_from_content_mode(content_mode),
     ) as instrumentor:
         yield instrumentor
 
@@ -104,7 +98,6 @@ def instrument_with_content(
         tracer_provider=tracer_provider,
         logger_provider=logger_provider,
         meter_provider=meter_provider,
-        semconv=_semconv_from_content_mode(content_mode),
         content_capture=content_mode_value,
     ) as instrumentor:
         yield instrumentor
@@ -122,7 +115,6 @@ def instrument_with_content_unsampled(
         tracer_provider=tracer_provider,
         logger_provider=logger_provider,
         meter_provider=meter_provider,
-        semconv=_semconv_from_content_mode(content_mode),
         content_capture=content_mode_value,
     ) as instrumentor:
         yield instrumentor
@@ -135,7 +127,6 @@ def instrument_event_only(tracer_provider, logger_provider, meter_provider):
         tracer_provider=tracer_provider,
         logger_provider=logger_provider,
         meter_provider=meter_provider,
-        semconv="gen_ai_latest_experimental",
         content_capture="event_only",
     ) as instrumentor:
         yield instrumentor

--- a/util/opentelemetry-test-util-genai/src/opentelemetry/test_util_genai/instrumentor.py
+++ b/util/opentelemetry-test-util-genai/src/opentelemetry/test_util_genai/instrumentor.py
@@ -33,7 +33,6 @@ from contextlib import contextmanager
 from typing import Any
 
 from opentelemetry.instrumentation._semconv import (
-    OTEL_SEMCONV_STABILITY_OPT_IN,
     _OpenTelemetrySemanticConventionStability,
 )
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
@@ -50,7 +49,6 @@ def instrument(
     tracer_provider: Any,
     logger_provider: Any,
     meter_provider: Any,
-    semconv: str | None = None,
     content_capture: str | None = None,
     emit_event: bool = False,
     extra_env: Mapping[str, str] | None = None,
@@ -68,23 +66,19 @@ def instrument(
                 tracer_provider=tracer_provider,
                 logger_provider=logger_provider,
                 meter_provider=meter_provider,
-                semconv="gen_ai_latest_experimental",
                 content_capture="SPAN_ONLY",
             ) as instrumentor:
                 yield instrumentor
 
-    ``semconv`` is forwarded to ``OTEL_SEMCONV_STABILITY_OPT_IN``;
-    ``content_capture`` to ``OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT``;
+    ``content_capture`` is forwarded to
+    ``OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT`` and
     ``emit_event=True`` sets ``OTEL_INSTRUMENTATION_GENAI_EMIT_EVENT`` to
-    ``"true"``. Pass ``extra_env`` for anything else. ``None`` leaves the
-    variable untouched; an empty string clears the value (matches the
-    ``""`` form some tests use to express "experimental opt-in disabled").
+    ``"true"``; both default to leaving their variable untouched. Pass
+    ``extra_env`` for anything else.
 
     Previous values are restored on exit so tests stay isolated.
     """
     overrides: dict[str, str] = {}
-    if semconv is not None:
-        overrides[OTEL_SEMCONV_STABILITY_OPT_IN] = semconv
     if content_capture is not None:
         overrides[OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT] = (
             content_capture


### PR DESCRIPTION
Closes #200.

`OTEL_SEMCONV_STABILITY_OPT_IN` is no longer read anywhere — the code behind it was removed from `opentelemetry-util-genai` and `opentelemetry-instrumentation-google-genai`, and the experimental conventions are now the default and only behavior. So the shared test helper's `semconv` parameter (which only forwarded to that env var) is now a no-op.

This drops the `semconv` parameter and its `OTEL_SEMCONV_STABILITY_OPT_IN` mapping from `opentelemetry.test_util_genai.instrumentor.instrument()`, and removes the now-dead `semconv=` arguments at every call site, including the `anthropic` package's `stable`-mode fixture.

The `openai` `content_mode` fixture keeps its tuple shape on purpose: its parametrize id is what the VCR cassette filenames key off, so reshaping it would orphan the recorded cassettes. Its now-unused first element (and the leftover `OTEL_SEMCONV_STABILITY_OPT_IN` setenvs in the langchain/openai tests) are dead too and could be cleaned up in a follow-up.

All test and lint CI jobs for the touched packages (anthropic, openai, langchain, openai-agents) pass. The only failing check is the changelog gate — this is a test-only change to a `Private :: Do Not Upload` package, so it needs either a fragment or the `Skip Changelog` label; happy to add a fragment if you'd prefer.
