### PR TITLE
fix(openai-agents): record tool calls as structured tool_call parts

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-genai-openai-agents/.changelog/203.fixed
+++ b/instrumentation/opentelemetry-instrumentation-genai-openai-agents/.changelog/203.fixed
@@ -1,0 +1,1 @@
+Record OpenAI Agents tool calls as structured `tool_call` parts in `gen_ai.output.messages` instead of a stringified repr.

--- a/instrumentation/opentelemetry-instrumentation-genai-openai-agents/src/opentelemetry/instrumentation/genai/openai_agents/span_processor.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-openai-agents/src/opentelemetry/instrumentation/genai/openai_agents/span_processor.py
@@ -877,6 +877,27 @@ class GenAISemanticProcessor(TracingProcessor):
 
         return normalized
 
+    def _tool_call_part_from_output_item(self, item: Any) -> dict[str, Any]:
+        if isinstance(item, dict):
+            call_id = item.get("call_id") or item.get("id")
+            name = item.get("name")
+            arguments = item.get("arguments")
+        else:
+            call_id = getattr(item, "call_id", None) or getattr(
+                item, "id", None
+            )
+            name = getattr(item, "name", None)
+            arguments = getattr(item, "arguments", None)
+        part: dict[str, Any] = {
+            "type": "tool_call",
+            "id": call_id,
+            "name": name,
+        }
+        part["arguments"] = (
+            "readacted" if not self.include_sensitive_data else arguments
+        )
+        return part
+
     def _normalize_output_messages_to_role_parts(
         self, span_data: Any
     ) -> list[dict[str, Any]]:
@@ -909,9 +930,18 @@ class GenAISemanticProcessor(TracingProcessor):
                 output = getattr(response, "output", None)
                 if isinstance(output, Sequence):
                     for item in output:
+                        item_type = (
+                            item.get("type")
+                            if isinstance(item, dict)
+                            else getattr(item, "type", None)
+                        )
                         # ResponseOutputMessage may have a string representation
                         txt = getattr(item, "content", None)
-                        if isinstance(txt, str) and txt:
+                        if item_type == "function_call":
+                            parts.append(
+                                self._tool_call_part_from_output_item(item)
+                            )
+                        elif isinstance(txt, str) and txt:
                             parts.append(
                                 {
                                     "type": "text",

--- a/instrumentation/opentelemetry-instrumentation-genai-openai-agents/tests/test_z_span_processor_unit.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-openai-agents/tests/test_z_span_processor_unit.py
@@ -545,3 +545,62 @@ def test_chat_span_renamed_with_model(processor_setup):
 
     span_names = {span.name for span in exporter.get_finished_spans()}
     assert "chat gpt-4o" in span_names
+
+
+def test_response_output_function_call_becomes_tool_call_part(processor_setup):
+    processor, _ = processor_setup
+    tool_call = SimpleNamespace(
+        type="function_call",
+        name="get_weather",
+        arguments='{"city": "Barcelona"}',
+        call_id="call_123",
+        id="fc_1",
+        content=None,
+    )
+    span_data = SimpleNamespace(
+        response=SimpleNamespace(output_text=None, output=[tool_call]),
+        output=None,
+    )
+
+    messages = processor._normalize_output_messages_to_role_parts(span_data)
+
+    assert messages == [
+        {
+            "role": "assistant",
+            "parts": [
+                {
+                    "type": "tool_call",
+                    "id": "call_123",
+                    "name": "get_weather",
+                    "arguments": '{"city": "Barcelona"}',
+                }
+            ],
+        }
+    ]
+
+
+def test_response_output_function_call_redacted_when_sensitive_disabled(
+    processor_setup,
+):
+    processor, _ = processor_setup
+    processor.include_sensitive_data = False
+    tool_call = SimpleNamespace(
+        type="function_call",
+        name="get_weather",
+        arguments='{"city": "Barcelona"}',
+        call_id="call_123",
+        id="fc_1",
+        content=None,
+    )
+    span_data = SimpleNamespace(
+        response=SimpleNamespace(output_text=None, output=[tool_call]),
+        output=None,
+    )
+
+    parts = processor._normalize_output_messages_to_role_parts(span_data)[0][
+        "parts"
+    ]
+
+    assert parts[0]["type"] == "tool_call"
+    assert parts[0]["name"] == "get_weather"
+    assert parts[0]["arguments"] == "readacted"


### PR DESCRIPTION
## Description

Response output items that are function calls were serialized with `str(item)`, so `gen_ai.output.messages` contained the raw `ResponseFunctionToolCall(...)` repr instead of a structured part.

This emits a `tool_call` part with `id`, `name`, and `arguments` for `function_call` output items, matching the shape already used for input side tool calls and honoring `include_sensitive_data`.

Moved here from open-telemetry/opentelemetry-python-contrib#4776 at the request of @DylanRussell, since the openai-agents instrumentation now lives in this repo. Addresses the bug reported in open-telemetry/opentelemetry-python-contrib#4185.

## Type of change

Bug fix (non breaking change which fixes an issue)

## How Has This Been Tested?

Added unit tests in `test_z_span_processor_unit.py` covering the structured `tool_call` output and the redacted case. Ran the package test suite (105 passed) and ruff on the changed files.
