### PR TITLE
code scanning report: bump versions, make renovate update all req.txt

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -39,6 +39,13 @@
   ],
   "packageRules": [
     {
+      // requirements.oldest.txt is intentionally excluded via the
+      // top-level ignorePaths, and pyproject.toml floors (pep621 manager)
+      // stay on the default strategy so published packages keep wide ranges.
+      "matchManagers": ["pip_requirements"],
+      "rangeStrategy": "bump"
+    },
+    {
       "groupName": "all patch versions",
       "matchUpdateTypes": ["patch"],
       "schedule": ["before 8am every weekday"]

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -7,10 +7,10 @@ fsspec>=2025.9.0
 wrapt>=1.0.0,<3.0.0
 
 # Required by instrumentation packages
-anthropic>=0.51.0
-claude-agent-sdk>=0.1.14
-google-genai>=1.32.0
-langchain>=0.3.30
-openai>=1.26.0
-openai-agents>=0.3.3
-weaviate-client>=3.0
+anthropic>=0.116.0
+claude-agent-sdk>=0.2.113
+google-genai>=2.10.0
+langchain>=1.3.11
+openai>=2.44.0
+openai-agents>=0.17.8
+weaviate-client>=4.22.0

--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/examples/agent/requirements.txt
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/examples/agent/requirements.txt
@@ -1,5 +1,5 @@
 langchain>=1.3.11
-langchain_openai>=1.3.3
+langchain-openai>=1.3.3
 langgraph>=1.2.8
 opentelemetry-sdk>=1.42.0
 opentelemetry-exporter-otlp-proto-grpc>=1.42.0

--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/examples/agent/requirements.txt
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/examples/agent/requirements.txt
@@ -1,5 +1,5 @@
-langchain
-langchain_openai
-langgraph
+langchain>=1.3.11
+langchain_openai>=1.3.3
+langgraph>=1.2.8
 opentelemetry-sdk>=1.42.0
 opentelemetry-exporter-otlp-proto-grpc>=1.42.0

--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/examples/manual/requirements.txt
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/examples/manual/requirements.txt
@@ -1,5 +1,5 @@
 langchain==1.3.11
-langchain_openai
+langchain_openai>=1.3.3
 opentelemetry-sdk>=1.31.0
 opentelemetry-exporter-otlp-proto-grpc>=1.31.0
 

--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/examples/manual/requirements.txt
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/examples/manual/requirements.txt
@@ -1,5 +1,5 @@
 langchain==1.3.11
-langchain_openai>=1.3.3
+langchain-openai>=1.3.3
 opentelemetry-sdk>=1.31.0
 opentelemetry-exporter-otlp-proto-grpc>=1.31.0
 

--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/examples/tools/requirements.txt
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/examples/tools/requirements.txt
@@ -1,5 +1,5 @@
 langchain==1.3.11
-langchain_openai>=1.3.3
+langchain-openai>=1.3.3
 langgraph>=1.2.8
 opentelemetry-sdk>=1.31.0
 opentelemetry-exporter-otlp-proto-grpc>=1.31.0

--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/examples/tools/requirements.txt
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/examples/tools/requirements.txt
@@ -1,5 +1,5 @@
 langchain==1.3.11
-langchain_openai
-langgraph
+langchain_openai>=1.3.3
+langgraph>=1.2.8
 opentelemetry-sdk>=1.31.0
 opentelemetry-exporter-otlp-proto-grpc>=1.31.0

--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/examples/workflow/requirements.txt
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/examples/workflow/requirements.txt
@@ -1,5 +1,5 @@
 langchain>=1.3.11
-langchain_openai>=1.3.3
+langchain-openai>=1.3.3
 langgraph>=1.2.8
 opentelemetry-sdk>=1.42.0
 opentelemetry-exporter-otlp-proto-grpc>=1.42.0

--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/examples/workflow/requirements.txt
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/examples/workflow/requirements.txt
@@ -1,5 +1,5 @@
-langchain
-langchain_openai
-langgraph
+langchain>=1.3.11
+langchain_openai>=1.3.3
+langgraph>=1.2.8
 opentelemetry-sdk>=1.42.0
 opentelemetry-exporter-otlp-proto-grpc>=1.42.0

--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/examples/zero-code/requirements.txt
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/examples/zero-code/requirements.txt
@@ -1,5 +1,5 @@
 langchain==1.3.11
-langchain_openai
+langchain_openai>=1.3.3
 opentelemetry-sdk>=1.31.0
 opentelemetry-exporter-otlp-proto-grpc>=1.31.0
 opentelemetry-distro~=0.51b0

--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/examples/zero-code/requirements.txt
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/examples/zero-code/requirements.txt
@@ -1,5 +1,5 @@
 langchain==1.3.11
-langchain_openai>=1.3.3
+langchain-openai>=1.3.3
 opentelemetry-sdk>=1.31.0
 opentelemetry-exporter-otlp-proto-grpc>=1.31.0
 opentelemetry-distro~=0.51b0

--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/tests/requirements.txt
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/tests/requirements.txt
@@ -15,10 +15,10 @@
 # Single pinned requirements for langchain unit tests.
 # TODO: split into oldest/latest once the version matrix is defined.
 
-langchain-openai>=1.1.14
-langchain-aws
-langchain-google-genai
-boto3
+langchain-openai>=1.3.3
+langchain-aws>=1.6.2
+langchain-google-genai>=4.2.7
+boto3>=1.43.42
 
 -e util/opentelemetry-util-genai
 -e instrumentation/opentelemetry-instrumentation-genai-langchain[instruments]

--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/tests/requirements.txt
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/tests/requirements.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Single pinned requirements for langchain unit tests.
+# Single minimum-version requirements for langchain unit tests.
 # TODO: split into oldest/latest once the version matrix is defined.
 
 langchain-openai>=1.3.3


### PR DESCRIPTION
Another attempt to fix issues detected by https://github.com/open-telemetry/opentelemetry-python-genai/security/code-scanning

- add versions for all unversioned dependencies
- make renovate match all requirement.txt files except test oldest deps ones
