### PR TITLE
[`opentelemetry-instrumentation-google-genai`]: record response model attribute on inference span/event

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-google-genai/.changelog/205.added
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/.changelog/205.added
@@ -1,0 +1,1 @@
+Record response model (`gen_ai.response.model`) attribute on inference span.

--- a/instrumentation/opentelemetry-instrumentation-google-genai/src/opentelemetry/instrumentation/google_genai/generate_content.py
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/src/opentelemetry/instrumentation/google_genai/generate_content.py
@@ -358,6 +358,7 @@ def _apply_response_attributes(
     invocation: InferenceInvocation,
 ):
     invocation.response_id = response.response_id
+    invocation.response_model_name = response.model_version
     for candidate in response.candidates or []:
         if candidate.finish_reason:
             finish_reasons.append(candidate.finish_reason.value.lower())

--- a/instrumentation/opentelemetry-instrumentation-google-genai/src/opentelemetry/instrumentation/google_genai/generate_content.py
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/src/opentelemetry/instrumentation/google_genai/generate_content.py
@@ -357,8 +357,10 @@ def _apply_response_attributes(
     finish_reasons: list[str],
     invocation: InferenceInvocation,
 ):
-    invocation.response_id = response.response_id
-    invocation.response_model_name = response.model_version
+    if response.response_id:
+        invocation.response_id = response.response_id
+    if response.model_version:
+        invocation.response_model_name = response.model_version
     for candidate in response.candidates or []:
         if candidate.finish_reason:
             finish_reasons.append(candidate.finish_reason.value.lower())

--- a/instrumentation/opentelemetry-instrumentation-google-genai/tests/generate_content/nonstreaming_base.py
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/tests/generate_content/nonstreaming_base.py
@@ -317,6 +317,15 @@ class NonStreamingTestCase(TestCase):
         self.assertEqual(
             span.attributes["gen_ai.response.model"], "gemini-2.0-flash-001"
         )
+        self.otel.assert_has_event_named(
+            "gen_ai.client.inference.operation.details"
+        )
+        event = self.otel.get_event_named(
+            "gen_ai.client.inference.operation.details"
+        )
+        self.assertEqual(
+            event.attributes["gen_ai.response.model"], "gemini-2.0-flash-001"
+        )
 
     @patch.dict(
         "os.environ",

--- a/instrumentation/opentelemetry-instrumentation-google-genai/tests/generate_content/nonstreaming_base.py
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/tests/generate_content/nonstreaming_base.py
@@ -310,6 +310,14 @@ class NonStreamingTestCase(TestCase):
             span.attributes["gen_ai.usage.reasoning.output_tokens"], 17
         )
 
+    def test_generated_span_records_response_model(self):
+        self.configure_valid_response(model_version="gemini-2.0-flash-001")
+        self.generate_content(model="gemini-2.0-flash", contents="Some input")
+        span = self.otel.get_span_named("generate_content gemini-2.0-flash")
+        self.assertEqual(
+            span.attributes["gen_ai.response.model"], "gemini-2.0-flash-001"
+        )
+
     @patch.dict(
         "os.environ",
         {


### PR DESCRIPTION
# Description

Add response model on inference span/event

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ x] New feature (non-breaking change which adds functionality)

# How has this been tested?

Unit tests

# Checklist

See [CONTRIBUTING.md](https://github.com/open-telemetry/opentelemetry-python-genai/blob/main/CONTRIBUTING.md)
for the style guide, changelog guidance, and more.

- [x ] Followed the style guidelines of this project
- [ x] Changelog updated if the change requires an entry
- [x ] Unit tests added
- [x ] Documentation updated
