### PR TITLE
Remove residual OTEL_SEMCONV_STABILITY_OPT_IN references from docs and tests

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/tests/test_llm_call.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/tests/test_llm_call.py
@@ -33,9 +33,6 @@ def test_chat_openai_gpt_3_5_turbo_model_llm_call(
     vcr,
 ):
     monkeypatch.setenv(
-        "OTEL_SEMCONV_STABILITY_OPT_IN", "gen_ai_latest_experimental"
-    )
-    monkeypatch.setenv(
         "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT", capture_content
     )
 
@@ -103,9 +100,6 @@ def test_chat_openai_gpt_3_5_turbo_model_llm_call_with_error(
     capture_content,
     vcr,
 ):
-    monkeypatch.setenv(
-        "OTEL_SEMCONV_STABILITY_OPT_IN", "gen_ai_latest_experimental"
-    )
     monkeypatch.setenv(
         "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT", capture_content
     )

--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/tests/test_tools.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/tests/test_tools.py
@@ -54,13 +54,6 @@ def reset_semconv_stability():
     _OpenTelemetrySemanticConventionStability._OTEL_SEMCONV_STABILITY_SIGNAL_MAPPING = {}
 
 
-def _enable_experimental_mode():
-    """Call after setting OTEL_SEMCONV_STABILITY_OPT_IN env var to activate it."""
-    _OpenTelemetrySemanticConventionStability._initialized = False
-    _OpenTelemetrySemanticConventionStability._OTEL_SEMCONV_STABILITY_SIGNAL_MAPPING = {}
-    _OpenTelemetrySemanticConventionStability._initialize()
-
-
 # ---------------------------------------------------------------------------
 # Unit tests for _get_property_value
 # ---------------------------------------------------------------------------
@@ -246,12 +239,8 @@ _OPENAI_METADATA: dict[str, Any] = {"ls_provider": "openai"}
 
 def test_on_tool_start_and_end_creates_span(monkeypatch):
     monkeypatch.setenv(
-        "OTEL_SEMCONV_STABILITY_OPT_IN", "gen_ai_latest_experimental"
-    )
-    monkeypatch.setenv(
         "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT", "SPAN_ONLY"
     )
-    _enable_experimental_mode()
     tracer_provider, span_exporter, logger_provider, meter_provider = (
         _make_providers()
     )
@@ -290,12 +279,8 @@ def test_on_tool_start_and_end_creates_span(monkeypatch):
 
 def test_on_tool_start_with_string_input(monkeypatch):
     monkeypatch.setenv(
-        "OTEL_SEMCONV_STABILITY_OPT_IN", "gen_ai_latest_experimental"
-    )
-    monkeypatch.setenv(
         "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT", "SPAN_ONLY"
     )
-    _enable_experimental_mode()
     tracer_provider, span_exporter, logger_provider, meter_provider = (
         _make_providers()
     )
@@ -325,10 +310,6 @@ def test_on_tool_start_with_string_input(monkeypatch):
 
 def test_on_tool_start_with_no_serialized(monkeypatch):
     """on_tool_start with serialized=None falls back to name='unknown'."""
-    monkeypatch.setenv(
-        "OTEL_SEMCONV_STABILITY_OPT_IN", "gen_ai_latest_experimental"
-    )
-    _enable_experimental_mode()
     tracer_provider, span_exporter, logger_provider, meter_provider = (
         _make_providers()
     )
@@ -354,10 +335,6 @@ def test_on_tool_start_with_no_serialized(monkeypatch):
 
 
 def test_on_tool_error_records_error_type(monkeypatch):
-    monkeypatch.setenv(
-        "OTEL_SEMCONV_STABILITY_OPT_IN", "gen_ai_latest_experimental"
-    )
-    _enable_experimental_mode()
     tracer_provider, span_exporter, logger_provider, meter_provider = (
         _make_providers()
     )
@@ -389,12 +366,8 @@ def test_on_tool_error_records_error_type(monkeypatch):
 def test_on_chat_model_start_with_tools_sets_definitions(monkeypatch):
     """Tool definitions passed via invocation_params are captured on the span."""
     monkeypatch.setenv(
-        "OTEL_SEMCONV_STABILITY_OPT_IN", "gen_ai_latest_experimental"
-    )
-    monkeypatch.setenv(
         "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT", "SPAN_ONLY"
     )
-    _enable_experimental_mode()
     tracer_provider, span_exporter, logger_provider, meter_provider = (
         _make_providers()
     )
@@ -461,12 +434,8 @@ def _build_tool_call_llm_result(
 def test_on_llm_end_with_tool_calls_records_tool_call_requests(monkeypatch):
     """When finish_reason is tool_calls the output message parts are ToolCallRequests."""
     monkeypatch.setenv(
-        "OTEL_SEMCONV_STABILITY_OPT_IN", "gen_ai_latest_experimental"
-    )
-    monkeypatch.setenv(
         "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT", "SPAN_ONLY"
     )
-    _enable_experimental_mode()
     tracer_provider, span_exporter, logger_provider, meter_provider = (
         _make_providers()
     )
@@ -499,12 +468,8 @@ def test_on_llm_end_with_tool_calls_records_tool_call_requests(monkeypatch):
 
 def test_on_llm_end_with_multiple_tool_calls(monkeypatch):
     monkeypatch.setenv(
-        "OTEL_SEMCONV_STABILITY_OPT_IN", "gen_ai_latest_experimental"
-    )
-    monkeypatch.setenv(
         "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT", "SPAN_ONLY"
     )
-    _enable_experimental_mode()
     tracer_provider, span_exporter, logger_provider, meter_provider = (
         _make_providers()
     )
@@ -555,12 +520,8 @@ def test_on_llm_end_with_bedrock_tool_use_records_tool_call_requests(
     output message parts must be ToolCallRequests, same as for OpenAI's
     'tool_calls' finish reason."""
     monkeypatch.setenv(
-        "OTEL_SEMCONV_STABILITY_OPT_IN", "gen_ai_latest_experimental"
-    )
-    monkeypatch.setenv(
         "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT", "SPAN_ONLY"
     )
-    _enable_experimental_mode()
     tracer_provider, span_exporter, logger_provider, meter_provider = (
         _make_providers()
     )
@@ -609,10 +570,6 @@ def test_on_llm_end_with_bedrock_tool_use_records_tool_call_requests(
 
 def test_tool_span_created_via_instrumentor(monkeypatch):
     """Using LangChainInstrumentor, on_tool_start/end produces an execute_tool span."""
-    monkeypatch.setenv(
-        "OTEL_SEMCONV_STABILITY_OPT_IN", "gen_ai_latest_experimental"
-    )
-    _enable_experimental_mode()
 
     span_exporter = InMemorySpanExporter()
     tracer_provider = TracerProvider()
@@ -663,10 +620,6 @@ def test_on_tool_start_and_end_no_content_capture_suppresses_arguments(
     monkeypatch,
 ):
     """Without content capture, arguments and result are absent from the span."""
-    monkeypatch.setenv(
-        "OTEL_SEMCONV_STABILITY_OPT_IN", "gen_ai_latest_experimental"
-    )
-    _enable_experimental_mode()
     # OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT intentionally not set
     tracer_provider, span_exporter, logger_provider, meter_provider = (
         _make_providers()
@@ -698,12 +651,8 @@ def test_on_tool_start_and_end_no_content_capture_suppresses_arguments(
 def test_on_tool_end_captures_result_with_span_only_mode(monkeypatch):
     """tool_result is set on the span when content capture is SPAN_ONLY."""
     monkeypatch.setenv(
-        "OTEL_SEMCONV_STABILITY_OPT_IN", "gen_ai_latest_experimental"
-    )
-    monkeypatch.setenv(
         "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT", "SPAN_ONLY"
     )
-    _enable_experimental_mode()
     tracer_provider, span_exporter, logger_provider, meter_provider = (
         _make_providers()
     )
@@ -735,10 +684,6 @@ def test_on_tool_end_captures_result_with_span_only_mode(monkeypatch):
 
 def test_on_tool_end_sets_tool_call_id_attribute(monkeypatch):
     """tool_call_id from the output object is set on the span."""
-    monkeypatch.setenv(
-        "OTEL_SEMCONV_STABILITY_OPT_IN", "gen_ai_latest_experimental"
-    )
-    _enable_experimental_mode()
     tracer_provider, span_exporter, logger_provider, meter_provider = (
         _make_providers()
     )
@@ -765,10 +710,6 @@ def test_on_tool_end_sets_tool_call_id_attribute(monkeypatch):
 
 def test_on_tool_end_with_none_tool_call_id_omits_attribute(monkeypatch):
     """tool_call_id is absent when the output carries no call id."""
-    monkeypatch.setenv(
-        "OTEL_SEMCONV_STABILITY_OPT_IN", "gen_ai_latest_experimental"
-    )
-    _enable_experimental_mode()
     tracer_provider, span_exporter, logger_provider, meter_provider = (
         _make_providers()
     )
@@ -801,12 +742,8 @@ def test_on_tool_end_with_none_tool_call_id_omits_attribute(monkeypatch):
 def test_on_tool_start_with_complex_inputs_serializes_to_json(monkeypatch):
     """Complex dict inputs are serialized to a compact JSON string on the span."""
     monkeypatch.setenv(
-        "OTEL_SEMCONV_STABILITY_OPT_IN", "gen_ai_latest_experimental"
-    )
-    monkeypatch.setenv(
         "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT", "SPAN_ONLY"
     )
-    _enable_experimental_mode()
     tracer_provider, span_exporter, logger_provider, meter_provider = (
         _make_providers()
     )
@@ -843,12 +780,8 @@ def test_on_tool_start_with_complex_inputs_serializes_to_json(monkeypatch):
 def test_on_tool_end_with_complex_result_serializes_to_json(monkeypatch):
     """Complex dict/list tool results are serialized to a JSON string on the span."""
     monkeypatch.setenv(
-        "OTEL_SEMCONV_STABILITY_OPT_IN", "gen_ai_latest_experimental"
-    )
-    monkeypatch.setenv(
         "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT", "SPAN_ONLY"
     )
-    _enable_experimental_mode()
     tracer_provider, span_exporter, logger_provider, meter_provider = (
         _make_providers()
     )
@@ -884,12 +817,8 @@ def test_on_tool_end_with_complex_result_serializes_to_json(monkeypatch):
 def test_on_tool_end_with_list_result_serializes_to_json(monkeypatch):
     """List tool results are serialized to a JSON string on the span."""
     monkeypatch.setenv(
-        "OTEL_SEMCONV_STABILITY_OPT_IN", "gen_ai_latest_experimental"
-    )
-    monkeypatch.setenv(
         "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT", "SPAN_ONLY"
     )
-    _enable_experimental_mode()
     tracer_provider, span_exporter, logger_provider, meter_provider = (
         _make_providers()
     )
@@ -925,10 +854,6 @@ def test_on_tool_end_with_list_result_serializes_to_json(monkeypatch):
 
 
 def test_on_tool_end_unknown_run_id_does_not_raise(monkeypatch):
-    monkeypatch.setenv(
-        "OTEL_SEMCONV_STABILITY_OPT_IN", "gen_ai_latest_experimental"
-    )
-    _enable_experimental_mode()
     tracer_provider, span_exporter, logger_provider, meter_provider = (
         _make_providers()
     )
@@ -946,10 +871,6 @@ def test_on_tool_end_unknown_run_id_does_not_raise(monkeypatch):
 
 
 def test_on_tool_error_unknown_run_id_does_not_raise(monkeypatch):
-    monkeypatch.setenv(
-        "OTEL_SEMCONV_STABILITY_OPT_IN", "gen_ai_latest_experimental"
-    )
-    _enable_experimental_mode()
     tracer_provider, span_exporter, logger_provider, meter_provider = (
         _make_providers()
     )
@@ -970,12 +891,8 @@ def test_on_tool_error_unknown_run_id_does_not_raise(monkeypatch):
 def test_on_tool_start_uses_input_str_when_inputs_is_none(monkeypatch):
     """When inputs kwarg is absent (None), input_str is used for arguments."""
     monkeypatch.setenv(
-        "OTEL_SEMCONV_STABILITY_OPT_IN", "gen_ai_latest_experimental"
-    )
-    monkeypatch.setenv(
         "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT", "SPAN_ONLY"
     )
-    _enable_experimental_mode()
     tracer_provider, span_exporter, logger_provider, meter_provider = (
         _make_providers()
     )
@@ -1004,12 +921,8 @@ def test_on_tool_start_uses_input_str_when_inputs_is_none(monkeypatch):
 def test_on_tool_start_inputs_takes_priority_over_input_str(monkeypatch):
     """When both inputs dict and input_str are provided, inputs dict wins."""
     monkeypatch.setenv(
-        "OTEL_SEMCONV_STABILITY_OPT_IN", "gen_ai_latest_experimental"
-    )
-    monkeypatch.setenv(
         "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT", "SPAN_ONLY"
     )
-    _enable_experimental_mode()
     tracer_provider, span_exporter, logger_provider, meter_provider = (
         _make_providers()
     )
@@ -1040,12 +953,8 @@ def test_on_tool_start_inputs_takes_priority_over_input_str(monkeypatch):
 def test_on_tool_start_json_input_str_is_deserialized(monkeypatch):
     """When inputs is None but input_str is valid JSON, it is deserialized to an object."""
     monkeypatch.setenv(
-        "OTEL_SEMCONV_STABILITY_OPT_IN", "gen_ai_latest_experimental"
-    )
-    monkeypatch.setenv(
         "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT", "SPAN_ONLY"
     )
-    _enable_experimental_mode()
     tracer_provider, span_exporter, logger_provider, meter_provider = (
         _make_providers()
     )
@@ -1082,12 +991,8 @@ def test_on_tool_start_json_input_str_is_deserialized(monkeypatch):
 def test_on_chat_model_start_with_functions_key_sets_definitions(monkeypatch):
     """Tool definitions are also picked up from the 'functions' invocation param."""
     monkeypatch.setenv(
-        "OTEL_SEMCONV_STABILITY_OPT_IN", "gen_ai_latest_experimental"
-    )
-    monkeypatch.setenv(
         "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT", "SPAN_ONLY"
     )
-    _enable_experimental_mode()
     tracer_provider, span_exporter, logger_provider, meter_provider = (
         _make_providers()
     )
@@ -1134,12 +1039,8 @@ def test_on_chat_model_start_with_functions_key_sets_definitions(monkeypatch):
 def test_on_chat_model_start_without_tools_omits_definitions(monkeypatch):
     """No tool_definitions attribute when invocation_params has no tools."""
     monkeypatch.setenv(
-        "OTEL_SEMCONV_STABILITY_OPT_IN", "gen_ai_latest_experimental"
-    )
-    monkeypatch.setenv(
         "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT", "SPAN_ONLY"
     )
-    _enable_experimental_mode()
     tracer_provider, span_exporter, logger_provider, meter_provider = (
         _make_providers()
     )

--- a/instrumentation/opentelemetry-instrumentation-genai-openai-agents/examples/manual/.env.example
+++ b/instrumentation/opentelemetry-instrumentation-genai-openai-agents/examples/manual/.env.example
@@ -17,9 +17,6 @@ OTEL_SERVICE_NAME=openai-agents-manual-demo
 # - `span_only` - record content on span attributes
 # - `event_only` - record content on event attributes
 # - `span_and_event` - record content on both span and event attributes
-# - `true` - only used for backward compatibility when
-#            `gen_ai_latest_experimental` is not set in the
-#            `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable.
 # - everything else - don't record content on any signal
 OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=span_only
 

--- a/instrumentation/opentelemetry-instrumentation-genai-openai-agents/examples/manual/.env.example
+++ b/instrumentation/opentelemetry-instrumentation-genai-openai-agents/examples/manual/.env.example
@@ -23,13 +23,6 @@ OTEL_SERVICE_NAME=openai-agents-manual-demo
 # - everything else - don't record content on any signal
 OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=span_only
 
-# Enables latest and greatest features available in GenAI semantic conventions.
-# Note: since conventions are still in development, using this flag would
-# likely result in having breaking changes.
-#
-# Comment out if you want to use semantic conventions of version 1.30.0.
-OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental
-
 # Uncomment to upload prompts and responses to an fsspec-compatible
 # destination instead of or in addition to recording them inline on spans/events.
 # OTEL_INSTRUMENTATION_GENAI_COMPLETION_HOOK=upload

--- a/instrumentation/opentelemetry-instrumentation-genai-openai-agents/examples/zero-code/.env.example
+++ b/instrumentation/opentelemetry-instrumentation-genai-openai-agents/examples/zero-code/.env.example
@@ -20,9 +20,6 @@ OTEL_SERVICE_NAME=openai-agents-zero-code-demo
 # - `span_only` - record content on span attributes
 # - `event_only` - record content on event attributes
 # - `span_and_event` - record content on both span and event attributes
-# - `true` - only used for backward compatibility when
-#            `gen_ai_latest_experimental` is not set in the
-#            `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable.
 # - everything else - don't record content on any signal
 OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=span_only
 

--- a/instrumentation/opentelemetry-instrumentation-genai-openai-agents/examples/zero-code/.env.example
+++ b/instrumentation/opentelemetry-instrumentation-genai-openai-agents/examples/zero-code/.env.example
@@ -26,13 +26,6 @@ OTEL_SERVICE_NAME=openai-agents-zero-code-demo
 # - everything else - don't record content on any signal
 OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=span_only
 
-# Enables latest and greatest features available in GenAI semantic conventions.
-# Note: since conventions are still in development, using this flag would
-# likely result in having breaking changes.
-#
-# Comment out if you want to use semantic conventions of version 1.30.0.
-OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental
-
 # Uncomment to upload prompts and responses to an fsspec-compatible
 # destination instead of or in addition to recording them inline on spans/events.
 # OTEL_INSTRUMENTATION_GENAI_COMPLETION_HOOK=upload

--- a/instrumentation/opentelemetry-instrumentation-genai-openai/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-genai-openai/README.rst
@@ -122,14 +122,10 @@ for additional options.
 Enabling the latest experimental features
 ***********************************************
 
-To enable the latest experimental features, set the environment variable
-``OTEL_SEMCONV_STABILITY_OPT_IN`` to ``gen_ai_latest_experimental``. Or, if you use
-``OTEL_SEMCONV_STABILITY_OPT_IN`` to enable other features, append ``,gen_ai_latest_experimental`` to its value.
+The latest experimental GenAI semantic conventions are used unconditionally; there is
+no environment variable to opt in or out.
 
-Without this setting, OpenAI instrumentation aligns with `Semantic Conventions v1.30.0 <https://github.com/open-telemetry/semantic-conventions/tree/v1.30.0/docs/gen-ai>`_
-and would not capture additional details introduced in later versions.
-
-.. note:: Generative AI semantic conventions are still evolving. The latest experimental features will introduce breaking changes in future releases.
+.. note:: Generative AI semantic conventions are still evolving. The latest experimental features may introduce breaking changes in future releases.
 
 Uninstrument
 ************

--- a/instrumentation/opentelemetry-instrumentation-genai-openai/examples/manual/.env
+++ b/instrumentation/opentelemetry-instrumentation-genai-openai/examples/manual/.env
@@ -23,13 +23,6 @@ OTEL_SERVICE_NAME=opentelemetry-python-openai
 # - everything else - don't record content on any signal
 OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=span_only
 
-# Enables latest and greatest features available in GenAI semantic conventions.
-# Note: since conventions are still in development, using this flag would
-# likely result in having breaking changes.
-#
-# Comment out if you want to use semantic conventions of version 1.30.0.
-OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental
-
 # Uncomment to upload prompts and responses to an fsspec-compatible
 # destination instead of or in addition to recording them inline on spans/events.
 # OTEL_INSTRUMENTATION_GENAI_COMPLETION_HOOK=upload

--- a/instrumentation/opentelemetry-instrumentation-genai-openai/examples/manual/.env
+++ b/instrumentation/opentelemetry-instrumentation-genai-openai/examples/manual/.env
@@ -17,9 +17,6 @@ OTEL_SERVICE_NAME=opentelemetry-python-openai
 # - `span_only` - record content on span attibutes
 # - `event_only` - record content on event attributes
 # - `span_and_event` - record content on both span and event attributes
-# - `true` - only used for backward compatibility when
-#            `gen_ai_latest_experimental` is not set in the
-#            `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable.
 # - everything else - don't record content on any signal
 OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=span_only
 

--- a/instrumentation/opentelemetry-instrumentation-genai-openai/examples/manual/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-genai-openai/examples/manual/README.rst
@@ -12,7 +12,6 @@ your OpenAI requests.
 Note: `.env <.env>`_ file configures additional environment variables:
 
 - ``OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=span_only`` configures OpenAI instrumentation to capture prompt and completion contents on *span* attributes.
-- ``OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental`` enables latest experimental features.
 - ``OTEL_INSTRUMENTATION_GENAI_COMPLETION_HOOK`` (commented out) - uncomment along with ``OTEL_INSTRUMENTATION_GENAI_UPLOAD_BASE_PATH`` to upload prompts and completions to an ``fsspec``-compatible destination instead of recording them inline. Also uncomment the ``opentelemetry-util-genai[upload]`` line in `requirements.txt <requirements.txt>`_ and reinstall.
 
 Setup

--- a/instrumentation/opentelemetry-instrumentation-genai-openai/examples/zero-code/.env
+++ b/instrumentation/opentelemetry-instrumentation-genai-openai/examples/zero-code/.env
@@ -20,9 +20,6 @@ OTEL_SERVICE_NAME=opentelemetry-python-openai
 # - `span_only` - record content on span attibutes
 # - `event_only` - record content on event attributes
 # - `span_and_event` - record content on both span and event attributes
-# - `true` - only used for backward compatibility when
-#            `gen_ai_latest_experimental` is not set in the
-#            `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable.
 # - everything else - don't record content on any signal
 OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=span_only
 

--- a/instrumentation/opentelemetry-instrumentation-genai-openai/examples/zero-code/.env
+++ b/instrumentation/opentelemetry-instrumentation-genai-openai/examples/zero-code/.env
@@ -26,13 +26,6 @@ OTEL_SERVICE_NAME=opentelemetry-python-openai
 # - everything else - don't record content on any signal
 OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=span_only
 
-# Enables latest and greatest features available in GenAI semantic conventions.
-# Note: since conventions are still in development, using this flag would
-# likely result in having breaking changes.
-#
-# Comment out if you want to use semantic conventions of version 1.30.0.
-OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental
-
 # Uncomment to upload prompts and responses to an fsspec-compatible
 # destination instead of or in addition to recording them inline on spans/events.
 # OTEL_INSTRUMENTATION_GENAI_COMPLETION_HOOK=upload

--- a/instrumentation/opentelemetry-instrumentation-genai-openai/examples/zero-code/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-genai-openai/examples/zero-code/README.rst
@@ -14,7 +14,6 @@ Note: `.env <.env>`_ file configures additional environment variables:
 
 - ``OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=span_only`` configures OpenAI instrumentation to capture prompt and completion contents on *span* attributes.
 - ``OTEL_LOGS_EXPORTER=otlp`` to specify exporter type.
-- ``OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental`` enables latest experimental features.
 - ``OTEL_INSTRUMENTATION_GENAI_COMPLETION_HOOK`` (commented out) - uncomment along with ``OTEL_INSTRUMENTATION_GENAI_UPLOAD_BASE_PATH`` to upload prompts and completions to an ``fsspec``-compatible destination instead of recording them inline. Also uncomment the ``opentelemetry-util-genai[upload]`` line in `requirements.txt <requirements.txt>`_ and reinstall.
 
 Setup

--- a/instrumentation/opentelemetry-instrumentation-genai-openai/src/opentelemetry/instrumentation/genai/openai/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-openai/src/opentelemetry/instrumentation/genai/openai/__init__.py
@@ -34,8 +34,7 @@ Behavior is controlled via environment variables:
 
 - ``OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT`` - enable capture of
     prompts, completions, tool arguments, and return values. Supported values
-    are ``span_only``, ``event_only``, and ``span_and_event``. This requires
-    ``OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental``.
+    are ``span_only``, ``event_only``, and ``span_and_event``.
 - ``OTEL_INSTRUMENTATION_GENAI_COMPLETION_HOOK=upload`` together with
   ``OTEL_INSTRUMENTATION_GENAI_UPLOAD_BASE_PATH=<fsspec-uri>`` - upload
   prompts and completions to an ``fsspec``-compatible destination

--- a/instrumentation/opentelemetry-instrumentation-genai-openai/tests/test_completion_hook.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-openai/tests/test_completion_hook.py
@@ -5,7 +5,6 @@ import os
 from unittest.mock import MagicMock, patch
 
 from opentelemetry.instrumentation._semconv import (
-    OTEL_SEMCONV_STABILITY_OPT_IN,
     _OpenTelemetrySemanticConventionStability,
 )
 from opentelemetry.instrumentation.genai.openai import OpenAIInstrumentor
@@ -16,10 +15,6 @@ from opentelemetry.util.genai.environment_variables import (
 from .test_utils import DEFAULT_MODEL, USER_ONLY_PROMPT
 
 
-@patch.dict(
-    os.environ,
-    {OTEL_SEMCONV_STABILITY_OPT_IN: "gen_ai_latest_experimental"},
-)
 def test_custom_hook_is_called(
     span_exporter,
     log_exporter,
@@ -68,10 +63,7 @@ def test_custom_hook_is_called(
 
 @patch.dict(
     os.environ,
-    {
-        OTEL_SEMCONV_STABILITY_OPT_IN: "gen_ai_latest_experimental",
-        OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT: "span_only",
-    },
+    {OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT: "span_only"},
 )
 def test_default_hook_loaded_from_env(
     span_exporter,

--- a/util/opentelemetry-test-util-genai/src/opentelemetry/test_util_genai/instrumentor.py
+++ b/util/opentelemetry-test-util-genai/src/opentelemetry/test_util_genai/instrumentor.py
@@ -7,8 +7,7 @@ Every instrumentation's ``tests/conftest.py`` carries a handful of fixtures
 shaped like:
 
 - reset ``_OpenTelemetrySemanticConventionStability._initialized``
-- set ``OTEL_SEMCONV_STABILITY_OPT_IN`` and/or
-  ``OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT`` (and sometimes
+- set ``OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT`` (and sometimes
   ``OTEL_INSTRUMENTATION_GENAI_EMIT_EVENT``)
 - ``instrumentor.instrument(tracer_provider=..., logger_provider=..., meter_provider=...)``
 - ``yield instrumentor``
@@ -18,11 +17,10 @@ The body is identical across packages — only the instrumentor class and the
 env values differ. This module hosts that body once so per-package
 conftests collapse to a thin wrapper.
 
-The stability-class reset is required because
-``_OpenTelemetrySemanticConventionStability`` caches the first read of
-``OTEL_SEMCONV_STABILITY_OPT_IN`` — without resetting ``_initialized``
-mid-test, a later env change would not take effect on the next
-``.instrument()`` call.
+The stability-class reset is kept as test-isolation hygiene:
+``_OpenTelemetrySemanticConventionStability`` caches state across
+``.instrument()`` calls, so resetting ``_initialized`` between tests avoids
+that cache leaking from one test into the next.
 """
 
 from __future__ import annotations

--- a/util/opentelemetry-test-util-genai/src/opentelemetry/test_util_genai/instrumentor.py
+++ b/util/opentelemetry-test-util-genai/src/opentelemetry/test_util_genai/instrumentor.py
@@ -6,21 +6,15 @@
 Every instrumentation's ``tests/conftest.py`` carries a handful of fixtures
 shaped like:
 
-- reset ``_OpenTelemetrySemanticConventionStability._initialized``
 - set ``OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT`` (and sometimes
   ``OTEL_INSTRUMENTATION_GENAI_EMIT_EVENT``)
 - ``instrumentor.instrument(tracer_provider=..., logger_provider=..., meter_provider=...)``
 - ``yield instrumentor``
-- restore env vars; ``instrumentor.uninstrument()``; reset the stability flag
+- restore env vars; ``instrumentor.uninstrument()``
 
 The body is identical across packages — only the instrumentor class and the
 env values differ. This module hosts that body once so per-package
 conftests collapse to a thin wrapper.
-
-The stability-class reset is kept as test-isolation hygiene:
-``_OpenTelemetrySemanticConventionStability`` caches state across
-``.instrument()`` calls, so resetting ``_initialized`` between tests avoids
-that cache leaking from one test into the next.
 """
 
 from __future__ import annotations
@@ -30,9 +24,6 @@ from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
 from typing import Any
 
-from opentelemetry.instrumentation._semconv import (
-    _OpenTelemetrySemanticConventionStability,
-)
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 from opentelemetry.util.genai.environment_variables import (
     OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT,
@@ -87,7 +78,6 @@ def instrument(
         overrides.update(extra_env)
     previous = {k: os.environ.get(k) for k in overrides}
 
-    _OpenTelemetrySemanticConventionStability._initialized = False
     os.environ.update(overrides)
     try:
         instrumentor.instrument(
@@ -105,4 +95,3 @@ def instrument(
                 os.environ.pop(key, None)
             else:
                 os.environ[key] = prev
-        _OpenTelemetrySemanticConventionStability._initialized = False


### PR DESCRIPTION
Follow-up to #202; addresses part of #200.

`OTEL_SEMCONV_STABILITY_OPT_IN` is no longer read anywhere — the experimental
GenAI semantic conventions are the default and only behavior — so the remaining
references to it are dead. This removes them.

**Docs**
- openai `README.rst`, `examples/`, and the package `__init__` docstring: drop the
  "set `OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental`" instructions.
- openai-agents `.env` examples: drop the opt-in line.
- shared test-helper docstring: drop the stale opt-in reference.

**Tests**
- Remove the now-dead `OTEL_SEMCONV_STABILITY_OPT_IN` `setenv` calls and the
  langchain `_enable_experimental_mode()` helper.
- Drop the flag from the openai completion-hook test's patched env.
- `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` is left untouched.

**Kept on purpose**
- The stability-singleton reset in the shared test helper stays as test-isolation
  hygiene (docstring updated to say so).

**Out of scope (see #200)**
- The larger `is_experimental_mode()` / `latest_experimental_enabled` dead-branch
  cleanup in the openai tests (~29 sites) isn't surfaced by the
  `gen_ai_latest_experimental` search and is openai-only. Flagged on #200; happy to
  do it as a follow-up — so this `Refs #200` rather than closing it.

Ran the touched packages' test and lint envs locally (langchain, openai,
openai-agents, anthropic, util-genai) — all green.
