### PR TITLE
add missing permissions for release workflows

### DIFF
--- a/.github/workflows/_prepare-release-package.yml
+++ b/.github/workflows/_prepare-release-package.yml
@@ -21,7 +21,6 @@ jobs:
   prepare:
     permissions:
       contents: write
-      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/_release-package.yml
+++ b/.github/workflows/_release-package.yml
@@ -26,7 +26,6 @@ jobs:
     environment: pypi
     permissions:
       contents: write
-      pull-requests: write
       id-token: write
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/package-prepare-patch-release.yml
+++ b/.github/workflows/package-prepare-patch-release.yml
@@ -21,7 +21,6 @@ jobs:
   prepare-patch-release:
     permissions:
       contents: write
-      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/package-prepare-release.yml
+++ b/.github/workflows/package-prepare-release.yml
@@ -21,6 +21,9 @@ run-name: "[Package][${{ inputs.package }}] Prepare release"
 
 jobs:
   prepare:
+    permissions:
+      contents: write
+      pull-requests: write
     uses: ./.github/workflows/_prepare-release-package.yml
     with:
       package: ${{ inputs.package }}

--- a/.github/workflows/package-prepare-release.yml
+++ b/.github/workflows/package-prepare-release.yml
@@ -23,7 +23,6 @@ jobs:
   prepare:
     permissions:
       contents: write
-      pull-requests: write
     uses: ./.github/workflows/_prepare-release-package.yml
     with:
       package: ${{ inputs.package }}

--- a/.github/workflows/package-release.yml
+++ b/.github/workflows/package-release.yml
@@ -23,7 +23,6 @@ jobs:
   release:
     permissions:
       contents: write
-      pull-requests: write
       id-token: write
     uses: ./.github/workflows/_release-package.yml
     with:

--- a/.github/workflows/package-release.yml
+++ b/.github/workflows/package-release.yml
@@ -21,6 +21,10 @@ run-name: "[Package][${{ inputs.package }}] Release"
 
 jobs:
   release:
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
     uses: ./.github/workflows/_release-package.yml
     with:
       package: ${{ inputs.package }}

--- a/.github/workflows/release-all-prepare.yml
+++ b/.github/workflows/release-all-prepare.yml
@@ -21,7 +21,6 @@ jobs:
   prepare:
     permissions:
       contents: write
-      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/release-all.yml
+++ b/.github/workflows/release-all.yml
@@ -71,7 +71,6 @@ jobs:
     needs: enumerate
     permissions:
       contents: write
-      pull-requests: write
       id-token: write
     strategy:
       fail-fast: false

--- a/.github/workflows/release-all.yml
+++ b/.github/workflows/release-all.yml
@@ -69,6 +69,10 @@ jobs:
 
   publish:
     needs: enumerate
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Currently all  merged PR trigger [[All] Release](https://github.com/open-telemetry/opentelemetry-python-genai/actions/runs/28980900818) that fails before it filters out non-release PRs.

It fails on the validation with 

> The nested job 'release' is requesting 'contents: write, pull-requests: write, id-token: write', but is only allowed 'contents: read, pull-requests: none, id-token: none'.

Adding missing permissions and removing redundant pr: write since PR is created with otel bot creds.