### PR TITLE
[`opentelemetry-instrumentation-google-genai`] Require the latest version of `opentelemetry-util-genai`

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-google-genai/.changelog/248.fixed
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/.changelog/248.fixed
@@ -1,0 +1,1 @@
+Fix minimum version of `opentelemetry-util-genai` dependency.

--- a/instrumentation/opentelemetry-instrumentation-google-genai/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
   "opentelemetry-api ~=1.40",
   "opentelemetry-instrumentation >=0.61b0, <2",
   "opentelemetry-semantic-conventions >=0.61b0, <2",
-  "opentelemetry-util-genai >= 1.0b0.dev",
+  "opentelemetry-util-genai >= 1.0b0, <2",
   "wrapt >= 1.0.0, < 3.0.0",
 ]
 

--- a/instrumentation/opentelemetry-instrumentation-google-genai/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
   "opentelemetry-api ~=1.40",
   "opentelemetry-instrumentation >=0.61b0, <2",
   "opentelemetry-semantic-conventions >=0.61b0, <2",
-  "opentelemetry-util-genai >= 0.4b0, <2",
+  "opentelemetry-util-genai >= 1.0b0.dev",
   "wrapt >= 1.0.0, < 3.0.0",
 ]
 


### PR DESCRIPTION
# Description

The library only works with the latest version of `opentelemetry-util-genai`. This should be patched into the release, is that possible to do ?

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
# Checklist

See [CONTRIBUTING.md](https://github.com/open-telemetry/opentelemetry-python-genai/blob/main/CONTRIBUTING.md)
for the style guide, changelog guidance, and more.

- [x] Followed the style guidelines of this project
- [x] Changelog updated if the change requires an entry
- [x] Unit tests added
- [x] Documentation updated
