### PR TITLE
fix some versions not being bumped before release and issue behind it

### DIFF
--- a/.github/workflows/release-all.yml
+++ b/.github/workflows/release-all.yml
@@ -118,7 +118,7 @@ jobs:
     secrets: inherit
 
   bump-main:
-    needs: [enumerate, publish]
+    needs: [enumerate, publish, finalize]
     if: always() && needs.enumerate.result == 'success'
     permissions:
       contents: write

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -67,6 +67,9 @@ rest of the workspace is not ready for a bulk release.
 
 ## Patch release (current minor line)
 
+> [!NOTE]
+> This only works if the `major.minor` version on `main` is the same version you want to patch (i.e., before the post-release bump PR to the next minor version is merged). Once `main` is bumped to the next minor dev version, all patch releases for the older minor version must use the backport workflow instead.
+
 1. Land the fix on `main` as a normal PR (with a towncrier fragment).
 2. Run
    [`Prepare package patch release`](./.github/workflows/prepare-package-patch.yml)

--- a/instrumentation/opentelemetry-instrumentation-google-genai/src/opentelemetry/instrumentation/google_genai/version.py
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/src/opentelemetry/instrumentation/google_genai/version.py
@@ -1,9 +1,4 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-# **IMPORTANT**:
-#
-#   This version should stay below "1.0" until the fundamentals
-#   in "TODOS.md" have been addressed. Please revisit the TODOs
-#   listed there before bumping to a stable version.
 __version__ = "1.1b0.dev"

--- a/instrumentation/opentelemetry-instrumentation-google-genai/src/opentelemetry/instrumentation/google_genai/version.py
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/src/opentelemetry/instrumentation/google_genai/version.py
@@ -6,4 +6,4 @@
 #   This version should stay below "1.0" until the fundamentals
 #   in "TODOS.md" have been addressed. Please revisit the TODOs
 #   listed there before bumping to a stable version.
-__version__ = "1.0b0"
+__version__ = "1.1b0.dev"

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/version.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/version.py
@@ -1,4 +1,4 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-__version__ = "1.0b0"
+__version__ = "1.1b0.dev"


### PR DESCRIPTION
Smart AI figured it out.

bump-main job (which bumps versions to the next .dev version) ran in parallel with the finalize matrix jobs (which create the GitHub release tags).

Because bump-main only depended on [enumerate, publish], it checked for release tags via gh release view while the finalize jobs were still running. This race condition caused some package tags to not be found at the check time, skipping their version bump. Specifically, opentelemetry-instrumentation-google-genai and opentelemetry-util-genai were skipped, leaving them stuck at 1.0b0 instead of 1.1b0.dev.

Bump PR: https://github.com/open-telemetry/opentelemetry-python-genai/pull/240/