### PR TITLE
Fix the prepare patch workflow so it executes the right bash script

### DIFF
--- a/.github/actions/prepare-package/action.yml
+++ b/.github/actions/prepare-package/action.yml
@@ -62,13 +62,13 @@ runs:
     - name: Install uv
       uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
 
-    - name: Prepare package on main
-      if: steps.verify.outputs.on_main == 'true'
+    - name: Prepare minor release on main
+      if: steps.verify.outputs.on_main == 'true' && inputs.release_type == 'minor'
       shell: bash
       run: ./scripts/prepare_package_for_release.sh "${{ inputs.package }}"
 
-    - name: Prepare patch on backport branch
-      if: steps.verify.outputs.on_backport == 'true'
+    - name: Prepare patch release
+      if: inputs.release_type == 'patch'
       shell: bash
       run: ./scripts/prepare_package_for_patch_release.sh "${{ inputs.package }}"
 


### PR DESCRIPTION
# Description

Fix the prepare patch workflow so it executes the right bash script

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist

See [CONTRIBUTING.md](https://github.com/open-telemetry/opentelemetry-python-genai/blob/main/CONTRIBUTING.md)
for the style guide, changelog guidance, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelog updated if the change requires an entry
- [ ] Unit tests added
- [x] Documentation updated
