### PR TITLE
Fix attribute error for raw tuples in langchain

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/.changelog/261.changed
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/.changelog/261.changed
@@ -1,0 +1,1 @@
+Support raw ("role", content) tuple messages in agent inputs, preventing duplicate `invoke_agent` spans.

--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/.changelog/261.changed
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/.changelog/261.changed
@@ -1,1 +1,1 @@
-Support raw ("role", content) tuple messages in agent inputs, preventing duplicate `invoke_agent` spans.
+Support raw LangChain message inputs (`("role", content)` tuples, dicts, and strings) in input messages, so the prompt is recorded and duplicate `invoke_agent` spans are avoided.

--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/src/opentelemetry/instrumentation/genai/langchain/utils.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/src/opentelemetry/instrumentation/genai/langchain/utils.py
@@ -157,6 +157,8 @@ def to_input_messages(
     """Convert LangChain messages into spec-conformant ``InputMessage`` s."""
     result: list[InputMessage] = []
     for message in messages:
+        if not isinstance(message, BaseMessage):
+            continue
         parts = _message_parts(message)
         if not parts:
             continue

--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/src/opentelemetry/instrumentation/genai/langchain/utils.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/src/opentelemetry/instrumentation/genai/langchain/utils.py
@@ -12,6 +12,7 @@ from langchain_core.messages import (
     AIMessage,
     BaseMessage,
     ToolMessage,
+    convert_to_messages,
 )
 
 from opentelemetry.semconv._incubating.attributes import (
@@ -152,13 +153,19 @@ def _message_parts(message: BaseMessage) -> list[MessagePart]:
 
 
 def to_input_messages(
-    messages: Iterable[BaseMessage],
+    messages: Iterable[Any],
 ) -> list[InputMessage]:
     """Convert LangChain messages into spec-conformant ``InputMessage`` s."""
+    try:
+        normalized_messages: Iterable[BaseMessage] = convert_to_messages(
+            list(messages)
+        )
+    except Exception:  # pylint: disable=broad-except
+        normalized_messages = [
+            m for m in messages if isinstance(m, BaseMessage)
+        ]
     result: list[InputMessage] = []
-    for message in messages:
-        if not isinstance(message, BaseMessage):
-            continue
+    for message in normalized_messages:
         parts = _message_parts(message)
         if not parts:
             continue

--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/tests/test_callback_handler.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/tests/test_callback_handler.py
@@ -649,6 +649,14 @@ class TestMakeInputMessage:
 
         assert len(result) == 1
         assert result[0].parts[0].content == "hello"
+    
+    def test_messages_key_skips_non_basemessage_entries(self):
+        result = make_input_message(
+            {"messages": [("human", "Hello"), HumanMessage(content="Hi")]}
+        )
+
+        assert len(result) == 1
+        assert result[0].parts[0].content == "Hi"
 
     def test_fallback_serializes_non_message_state_fields(self):
         result = make_input_message({"user_query": "what is 2+2?"})

--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/tests/test_callback_handler.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/tests/test_callback_handler.py
@@ -11,6 +11,7 @@ the callback-handler logic and the invocation-manager bookkeeping.
 import uuid
 from unittest import mock
 
+import pytest
 from langchain_core.messages import AIMessage, HumanMessage
 from langchain_core.outputs import ChatGeneration, LLMResult
 
@@ -22,6 +23,7 @@ from opentelemetry.instrumentation.genai.langchain.utils import (
     make_last_output_message,
     make_output_message,
     serialize,
+    to_input_messages,
     to_output_messages,
 )
 from opentelemetry.util.genai.invocation import (
@@ -649,14 +651,72 @@ class TestMakeInputMessage:
 
         assert len(result) == 1
         assert result[0].parts[0].content == "hello"
-    
-    def test_messages_key_skips_non_basemessage_entries(self):
+
+    def test_messages_key_converts_raw_role_content_tuples(self):
         result = make_input_message(
             {"messages": [("human", "Hello"), HumanMessage(content="Hi")]}
         )
 
+        assert len(result) == 2
+        assert result[0].role == "user"
+        assert result[0].parts[0].content == "Hello"
+        assert result[1].parts[0].content == "Hi"
+
+    def test_messages_key_converts_role_content_dicts(self):
+        result = make_input_message(
+            {"messages": [{"role": "user", "content": "Hello"}]}
+        )
+
+        assert len(result) == 1
+        assert result[0].role == "user"
+        assert result[0].parts[0].content == "Hello"
+
+    # Edge cases: a malformed message entry must never raise. An exception here
+    # aborts on_chain_start before the agent invocation is registered, which is
+    # what caused duplicate/deformed ``invoke_agent`` spans. These assert the
+    # callback stays intact (valid prompts preserved, bad entries dropped).
+    @pytest.mark.parametrize(
+        "bad_entry",
+        [
+            ("human",),  # too few items for (role, content)
+            ("human", "hi", "extra"),  # too many items
+            ("not_a_real_role", "hi"),  # unknown role string
+            {"content": "no role key"},  # dict missing role
+            {"role": "user"},  # dict missing content
+            None,  # not a message at all
+            42,  # not a message at all
+            object(),  # arbitrary object
+        ],
+    )
+    def test_messages_key_malformed_entry_does_not_raise(self, bad_entry):
+        # A valid message alongside the malformed one must still be recorded so
+        # the prompt is never silently lost.
+        result = make_input_message(
+            {"messages": [bad_entry, HumanMessage(content="Hi")]}
+        )
+
         assert len(result) == 1
         assert result[0].parts[0].content == "Hi"
+
+    def test_messages_key_all_malformed_returns_empty_without_raising(self):
+        result = make_input_message(
+            {"messages": [("human",), None, {"content": "x"}]}
+        )
+
+        assert result == []
+
+    def test_to_input_messages_never_raises_on_mixed_bad_input(self):
+        # Direct call: even with a completely unconvertible mix, no exception
+        # escapes and any BaseMessage content is preserved.
+        result = to_input_messages(
+            [object(), ("bad", "role", "shape"), HumanMessage(content="ok")]
+        )
+
+        assert len(result) == 1
+        assert result[0].parts[0].content == "ok"
+
+    def test_to_input_messages_empty_iterable_returns_empty(self):
+        assert to_input_messages([]) == []
 
     def test_fallback_serializes_non_message_state_fields(self):
         result = make_input_message({"user_query": "what is 2+2?"})

--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/tests/test_callback_handler.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/tests/test_callback_handler.py
@@ -671,10 +671,6 @@ class TestMakeInputMessage:
         assert result[0].role == "user"
         assert result[0].parts[0].content == "Hello"
 
-    # Edge cases: a malformed message entry must never raise. An exception here
-    # aborts on_chain_start before the agent invocation is registered, which is
-    # what caused duplicate/deformed ``invoke_agent`` spans. These assert the
-    # callback stays intact (valid prompts preserved, bad entries dropped).
     @pytest.mark.parametrize(
         "bad_entry",
         [
@@ -689,8 +685,6 @@ class TestMakeInputMessage:
         ],
     )
     def test_messages_key_malformed_entry_does_not_raise(self, bad_entry):
-        # A valid message alongside the malformed one must still be recorded so
-        # the prompt is never silently lost.
         result = make_input_message(
             {"messages": [bad_entry, HumanMessage(content="Hi")]}
         )
@@ -706,8 +700,6 @@ class TestMakeInputMessage:
         assert result == []
 
     def test_to_input_messages_never_raises_on_mixed_bad_input(self):
-        # Direct call: even with a completely unconvertible mix, no exception
-        # escapes and any BaseMessage content is preserved.
         result = to_input_messages(
             [object(), ("bad", "role", "shape"), HumanMessage(content="ok")]
         )


### PR DESCRIPTION
# Description

`to_input_messages` assumed every entry in an input messages list was a LangChain BaseMessage. LangGraph/create_agent inputs commonly use raw ("role", text) tuples (e.g. {"messages": [("human", user_input)]}). Accessing .content on such a tuple raised AttributeError("'tuple' object has no attribute 'content'"), which aborted the callback before the invocation could be registered.


<img width="1632" height="61" style="border:5px solid black" alt="image" src="https://github.com/user-attachments/assets/8655ab67-e74e-4d43-a1c1-c516b41ec087" />


This exception fired inside the root agent's on_chain_start, before the agent invocation was registered in the invocation manager. As a result, find_nearest_agent could never locate the root agent, so each LangGraph super-step node (model, tools, ...) created its own invoke_agent span, producing duplicate invoke_agent spans instead of one agent span with nested tool/LLM children.

<img width="400" height="200" alt="Screenshot 2026-07-13 094210" src="https://github.com/user-attachments/assets/cb76d14e-b3b2-4060-9621-1a9c1ab42fd3" />

**After Change -** 

<img width="500" height="200" alt="image" src="https://github.com/user-attachments/assets/dfe5a73e-8315-4c0a-af43-d2ebf3fd3958" />

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. List any relevant details for your test
configuration.

- [x]  uv run tox -e py312-test-instrumentation-genai-langchain -- -q
- [x]  uv run tox -e py312-test-instrumentation-genai-langchain-conformance -- -q
- [x]  uv run --python 3.12 tox -e lint-instrumentation-genai-langchain

# Checklist

See [CONTRIBUTING.md](https://github.com/open-telemetry/opentelemetry-python-genai/blob/main/CONTRIBUTING.md)
for the style guide, changelog guidance, and more.

- [x] Followed the style guidelines of this project
- [x] Changelog updated if the change requires an entry
- [x] Unit tests added
- [ ] Documentation updated
