### PR TITLE
Prepare 1.0b1 patch for google-genai

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-google-genai/.changelog/232.added
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/.changelog/232.added
@@ -1,1 +1,0 @@
-Add Weaver conformance test scenarios for ``generate_content``, ``interactions.create``, and ``embed_content``.

--- a/instrumentation/opentelemetry-instrumentation-google-genai/.changelog/244.changed
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/.changelog/244.changed
@@ -1,1 +1,0 @@
-Bump dependencies: opentelemetry-api from ~= 1.40 to ~= 1.43, opentelemetry-instrumentation and opentelemetry-semantic-conventions from >= 0.61b0 to >= 0.64b0, and opentelemetry-util-genai from >= 0.4b0 to >= 1.0b0.

--- a/instrumentation/opentelemetry-instrumentation-google-genai/.changelog/248.fixed
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/.changelog/248.fixed
@@ -1,1 +1,0 @@
-Fix minimum version of `opentelemetry-util-genai` dependency.

--- a/instrumentation/opentelemetry-instrumentation-google-genai/.changelog/254.changed
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/.changelog/254.changed
@@ -1,1 +1,0 @@
-Bump minimum required version of ``opentelemetry-api`` to ``1.43.0``, ``opentelemetry-instrumentation``/``opentelemetry-semantic-conventions`` to ``0.64b0``, and ``wrapt`` to ``1.17.0``.

--- a/instrumentation/opentelemetry-instrumentation-google-genai/.changelog/260.fixed
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/.changelog/260.fixed
@@ -1,1 +1,0 @@
-Ensure ``__code__.co_filename`` on wrapped functions matches the instrumentation file path.

--- a/instrumentation/opentelemetry-instrumentation-google-genai/CHANGELOG.md
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/CHANGELOG.md
@@ -15,6 +15,33 @@ See https://github.com/open-telemetry/opentelemetry-python-genai/blob/main/CONTR
 
 <!-- changelog start -->
 
+## Version 1.0b1 (2026-07-13)
+
+### Added
+
+- Add Weaver conformance test scenarios for ``generate_content``,
+  ``interactions.create``, and ``embed_content``.
+  ([#232](https://github.com/open-telemetry/opentelemetry-python-genai/pull/232))
+
+### Changed
+
+- Bump dependencies: opentelemetry-api from ~= 1.40 to ~= 1.43,
+  opentelemetry-instrumentation and opentelemetry-semantic-conventions from >=
+  0.61b0 to >= 0.64b0, and opentelemetry-util-genai from >= 0.4b0 to >= 1.0b0.
+  ([#244](https://github.com/open-telemetry/opentelemetry-python-genai/pull/244))
+- Bump minimum required version of ``opentelemetry-api`` to ``1.43.0``,
+  ``opentelemetry-instrumentation``/``opentelemetry-semantic-conventions`` to
+  ``0.64b0``, and ``wrapt`` to ``1.17.0``.
+  ([#254](https://github.com/open-telemetry/opentelemetry-python-genai/pull/254))
+
+### Fixed
+
+- Fix minimum version of `opentelemetry-util-genai` dependency.
+  ([#248](https://github.com/open-telemetry/opentelemetry-python-genai/pull/248))
+- Ensure ``__code__.co_filename`` on wrapped functions matches the
+  instrumentation file path.
+  ([#260](https://github.com/open-telemetry/opentelemetry-python-genai/pull/260))
+
 ## Version 1.0b0 (2026-07-09)
 
 ### Added

--- a/instrumentation/opentelemetry-instrumentation-google-genai/src/opentelemetry/instrumentation/google_genai/version.py
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/src/opentelemetry/instrumentation/google_genai/version.py
@@ -1,4 +1,4 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-__version__ = "1.1b0.dev"
+__version__ = "1.0b1"


### PR DESCRIPTION
Prepare release is failing https://github.com/open-telemetry/opentelemetry-python-genai/actions/runs/29276045727

Manually preparing patch