### PR TITLE
Simplify validation in conformance tests

### DIFF
--- a/.github/skills/write-conformance-tests/SKILL.md
+++ b/.github/skills/write-conformance-tests/SKILL.md
@@ -103,6 +103,12 @@ Each scenario module defines a subclass of `Scenario` from
 `opentelemetry.test_util_genai.conformance`. It sets the `expected_spans` /
 `expected_metrics` ClassVars and implements
 `run(self, *, tracer_provider, meter_provider, logger_provider, vcr)`.
+
+`expected_spans` is a `dict[str, int]` of exact per-operation span counts
+(e.g. `{"chat": 2}` for a tool-calling turn's two LLM calls); the base
+`validate` fails on any mismatch. Pin real counts here — don't re-assert them
+in a `validate` override. `expected_metrics` is a tuple of metric names that
+must each appear at least once.
 Drive instrumentation through the shared `instrument` context manager (not
 `instr.instrument()` / `trace.set_tracer_provider`). The runner injects an
 already-configured `vcr`, so a cassette-based scenario just calls
@@ -121,7 +127,7 @@ from opentelemetry.test_util_genai.instrumentor import instrument
 
 
 class InferenceScenario(Scenario):
-    expected_spans = ("chat",)
+    expected_spans = {"chat": 1}
     expected_metrics = (
         "gen_ai.client.operation.duration",
         "gen_ai.client.token.usage",
@@ -219,7 +225,7 @@ from opentelemetry.test_util_genai.conformance import Scenario
 
 
 class ToolCallingScenario(Scenario):
-    expected_spans = ("chat",)
+    expected_spans = {"chat": 2}  # initial turn + follow-up with tool results
     expected_metrics = ("gen_ai.client.operation.duration",)
 
     def run(self, *, tracer_provider, meter_provider, logger_provider, vcr) -> None:

--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/conformance/inference.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/conformance/inference.py
@@ -20,7 +20,7 @@ from opentelemetry.test_util_genai.instrumentor import instrument
 
 
 class InferenceScenario(Scenario):
-    expected_spans = ("chat",)
+    expected_spans = {"chat": 1}
     expected_metrics = (
         "gen_ai.client.operation.duration",
         "gen_ai.client.token.usage",

--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/conformance/tool_calling.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/conformance/tool_calling.py
@@ -20,7 +20,7 @@ from opentelemetry.test_util_genai.instrumentor import instrument
 
 
 class ToolCallingScenario(Scenario):
-    expected_spans = ("chat",)
+    expected_spans = {"chat": 1}
     expected_metrics = (
         "gen_ai.client.operation.duration",
         "gen_ai.client.token.usage",

--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/tests/conformance/agent.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/tests/conformance/agent.py
@@ -18,7 +18,6 @@ from opentelemetry.instrumentation.genai.langchain import LangChainInstrumentor
 from opentelemetry.sdk._logs import LoggerProvider
 from opentelemetry.sdk.metrics import MeterProvider
 from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.test.weaver_live_check import LiveCheckReport
 from opentelemetry.test_util_genai.conformance import (
     ExpectedViolation,
     Scenario,
@@ -39,7 +38,7 @@ def add(a: float, b: float) -> float:
 
 
 class AgentScenario(Scenario):
-    expected_spans = ("invoke_agent", "chat", "chat")
+    expected_spans = {"invoke_agent": 1, "chat": 3, "execute_tool": 2}
     expected_metrics = (
         "gen_ai.client.operation.duration",
         "gen_ai.client.token.usage",
@@ -100,20 +99,3 @@ class AgentScenario(Scenario):
                             ]
                         }
                     )
-
-    def validate(self, report: LiveCheckReport) -> None:
-        super().validate(report)
-        operations = [
-            attr["value"]
-            for entry in report["samples"]
-            if "span" in entry
-            for attr in entry["span"]["attributes"]
-            if attr["name"] == "gen_ai.operation.name"
-        ]
-        assert "invoke_agent" in operations, (
-            f"Expected an invoke_agent span; saw operations {operations}"
-        )
-        assert operations.count("chat") >= 2, (
-            "ReAct agent exercises at least two chat completions "
-            f"(initial tool-call request and follow-up); saw {operations}"
-        )

--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/tests/conformance/inference.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/tests/conformance/inference.py
@@ -24,7 +24,7 @@ from opentelemetry.test_util_genai.instrumentor import instrument
 
 
 class InferenceScenario(Scenario):
-    expected_spans = ("chat",)
+    expected_spans = {"chat": 1}
     expected_metrics = (
         "gen_ai.client.operation.duration",
         "gen_ai.client.token.usage",

--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/tests/conformance/tool_calling.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/tests/conformance/tool_calling.py
@@ -22,7 +22,6 @@ from opentelemetry.instrumentation.genai.langchain import LangChainInstrumentor
 from opentelemetry.sdk._logs import LoggerProvider
 from opentelemetry.sdk.metrics import MeterProvider
 from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.test.weaver_live_check import LiveCheckReport
 from opentelemetry.test_util_genai.conformance import (
     ExpectedViolation,
     Scenario,
@@ -71,7 +70,7 @@ def _execute_weather_tool(arguments: str) -> str:
 
 
 class ToolCallingScenario(Scenario):
-    expected_spans = ("chat", "execute_tool")
+    expected_spans = {"chat": 2, "execute_tool": 2}
     expected_metrics = (
         "gen_ai.client.operation.duration",
         "gen_ai.client.token.usage",
@@ -142,22 +141,3 @@ class ToolCallingScenario(Scenario):
                         )
 
                     llm_with_tools.invoke(messages)
-
-    def validate(self, report: LiveCheckReport) -> None:
-        super().validate(report)
-        operations = [
-            attr["value"]
-            for entry in report["samples"]
-            if "span" in entry
-            for attr in entry["span"]["attributes"]
-            if attr["name"] == "gen_ai.operation.name"
-        ]
-        assert operations == [
-            "chat",
-            "execute_tool",
-            "execute_tool",
-            "chat",
-        ], (
-            "Tool calling exercises two chat completions with two execute_tool "
-            "spans in between (one per tool call); saw spans {operations}"
-        )

--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/tests/conformance/workflow.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/tests/conformance/workflow.py
@@ -18,7 +18,6 @@ from opentelemetry.instrumentation.genai.langchain import LangChainInstrumentor
 from opentelemetry.sdk._logs import LoggerProvider
 from opentelemetry.sdk.metrics import MeterProvider
 from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.test.weaver_live_check import LiveCheckReport
 from opentelemetry.test_util_genai.conformance import (
     ExpectedViolation,
     Scenario,
@@ -32,7 +31,7 @@ class GraphState(TypedDict):
 
 
 class WorkflowScenario(Scenario):
-    expected_spans = ("invoke_workflow", "chat", "chat")
+    expected_spans = {"invoke_workflow": 1, "chat": 2}
     expected_metrics = (
         "gen_ai.client.operation.duration",
         "gen_ai.client.token.usage",
@@ -119,20 +118,3 @@ class WorkflowScenario(Scenario):
                             "research": "",
                         }
                     )
-
-    def validate(self, report: LiveCheckReport) -> None:
-        super().validate(report)
-        operations = [
-            attr["value"]
-            for entry in report["samples"]
-            if "span" in entry
-            for attr in entry["span"]["attributes"]
-            if attr["name"] == "gen_ai.operation.name"
-        ]
-        assert "invoke_workflow" in operations, (
-            f"Expected an invoke_workflow span; saw operations {operations}"
-        )
-        assert operations.count("chat") >= 2, (
-            "Two-node workflow exercises two chat completions "
-            f"(researcher and summariser); saw {operations}"
-        )

--- a/instrumentation/opentelemetry-instrumentation-genai-openai-agents/tests/conformance/orchestration.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-openai-agents/tests/conformance/orchestration.py
@@ -70,11 +70,11 @@ def _build_triage_agent() -> Agent:
 
 
 class OrchestrationScenario(Scenario):
-    expected_spans = (
-        "invoke_workflow",
-        "invoke_agent",
-        "execute_tool",
-    )
+    expected_spans = {
+        "invoke_workflow": 1,
+        "invoke_agent": 2,
+        "execute_tool": 1,
+    }
     expected_metrics = ("gen_ai.client.operation.duration",)
     expected_violations = (
         # `FunctionSpanData` in the openai-agents library doesn't expose
@@ -120,13 +120,6 @@ class OrchestrationScenario(Scenario):
 
     def validate(self, report: LiveCheckReport) -> None:
         super().validate(report)
-        operations = [
-            attr["value"]
-            for entry in report["samples"]
-            if "span" in entry
-            for attr in entry["span"]["attributes"]
-            if attr["name"] == "gen_ai.operation.name"
-        ]
         agent_names = {
             attr["value"]
             for entry in report["samples"]
@@ -134,14 +127,6 @@ class OrchestrationScenario(Scenario):
             for attr in entry["span"]["attributes"]
             if attr["name"] == "gen_ai.agent.name"
         }
-        assert operations.count("invoke_agent") >= 2, (
-            "Orchestration involves a triage agent handing off to a specialist; "
-            f"expected at least two invoke_agent spans, saw {operations}"
-        )
-        assert operations.count("execute_tool") >= 1, (
-            "Specialist agent calls the get_weather function tool; "
-            f"expected at least one execute_tool span, saw {operations}"
-        )
         assert len(agent_names) >= 2, (
             "Triage and specialist must each surface their own gen_ai.agent.name; "
             f"saw {sorted(agent_names)}"

--- a/instrumentation/opentelemetry-instrumentation-genai-openai/tests/conformance/embedding.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-openai/tests/conformance/embedding.py
@@ -18,7 +18,7 @@ from opentelemetry.test_util_genai.instrumentor import instrument
 
 
 class EmbeddingScenario(Scenario):
-    expected_spans = ("embeddings",)
+    expected_spans = {"embeddings": 1}
     expected_metrics = (
         "gen_ai.client.operation.duration",
         "gen_ai.client.token.usage",

--- a/instrumentation/opentelemetry-instrumentation-genai-openai/tests/conformance/inference.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-openai/tests/conformance/inference.py
@@ -18,7 +18,7 @@ from opentelemetry.test_util_genai.instrumentor import instrument
 
 
 class InferenceScenario(Scenario):
-    expected_spans = ("chat",)
+    expected_spans = {"chat": 1}
     expected_metrics = (
         "gen_ai.client.operation.duration",
         "gen_ai.client.token.usage",

--- a/instrumentation/opentelemetry-instrumentation-genai-openai/tests/conformance/responses_conversation.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-openai/tests/conformance/responses_conversation.py
@@ -13,7 +13,6 @@ from opentelemetry.instrumentation.genai.openai import OpenAIInstrumentor
 from opentelemetry.sdk._logs import LoggerProvider
 from opentelemetry.sdk.metrics import MeterProvider
 from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.test.weaver_live_check import LiveCheckReport
 from opentelemetry.test_util_genai.conformance import Scenario
 from opentelemetry.test_util_genai.instrumentor import instrument
 
@@ -21,7 +20,7 @@ DEFAULT_MODEL = "gpt-4o-mini"
 
 
 class ResponsesConversationScenario(Scenario):
-    expected_spans = ("chat",)
+    expected_spans = {"chat": 2}
     expected_metrics = (
         "gen_ai.client.operation.duration",
         "gen_ai.client.token.usage",
@@ -54,17 +53,3 @@ class ResponsesConversationScenario(Scenario):
                     input="What is my favorite color?",
                     previous_response_id=first.id,
                 )
-
-    def validate(self, report: LiveCheckReport) -> None:
-        super().validate(report)
-        operations = [
-            attr["value"]
-            for entry in report["samples"]
-            if "span" in entry
-            for attr in entry["span"]["attributes"]
-            if attr["name"] == "gen_ai.operation.name"
-        ]
-        assert operations == ["chat", "chat"], (
-            "Responses conversation exercises two Responses API calls "
-            f"(initial request and follow-up); saw spans {operations}"
-        )

--- a/instrumentation/opentelemetry-instrumentation-genai-openai/tests/conformance/responses_stream.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-openai/tests/conformance/responses_stream.py
@@ -22,7 +22,7 @@ USER_PROMPT = "Say this is a test"
 
 
 class ResponsesStreamScenario(Scenario):
-    expected_spans = ("chat",)
+    expected_spans = {"chat": 1}
     expected_metrics = (
         "gen_ai.client.operation.duration",
         "gen_ai.client.token.usage",

--- a/instrumentation/opentelemetry-instrumentation-genai-openai/tests/conformance/tool_calling.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-openai/tests/conformance/tool_calling.py
@@ -14,7 +14,6 @@ from opentelemetry.instrumentation.genai.openai import OpenAIInstrumentor
 from opentelemetry.sdk._logs import LoggerProvider
 from opentelemetry.sdk.metrics import MeterProvider
 from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.test.weaver_live_check import LiveCheckReport
 from opentelemetry.test_util_genai.conformance import Scenario
 from opentelemetry.test_util_genai.instrumentor import instrument
 
@@ -60,7 +59,7 @@ def _execute_weather_tool(arguments: str) -> str:
 
 
 class ToolCallingScenario(Scenario):
-    expected_spans = ("chat",)
+    expected_spans = {"chat": 2}
     expected_metrics = (
         "gen_ai.client.operation.duration",
         "gen_ai.client.token.usage",
@@ -111,17 +110,3 @@ class ToolCallingScenario(Scenario):
                     messages=messages,
                     model=DEFAULT_MODEL,
                 )
-
-    def validate(self, report: LiveCheckReport) -> None:
-        super().validate(report)
-        operations = [
-            attr["value"]
-            for entry in report["samples"]
-            if "span" in entry
-            for attr in entry["span"]["attributes"]
-            if attr["name"] == "gen_ai.operation.name"
-        ]
-        assert operations == ["chat", "chat"], (
-            "Tool calling exercises two chat completions (initial request and "
-            f"follow-up with tool results); saw spans {operations}"
-        )

--- a/instrumentation/opentelemetry-instrumentation-google-genai/tests/conformance/embedding.py
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/tests/conformance/embedding.py
@@ -23,7 +23,7 @@ from opentelemetry.test_util_genai.instrumentor import instrument
 
 
 class EmbeddingScenario(Scenario):
-    expected_spans = ("embeddings",)
+    expected_spans = {"embeddings": 1}
     expected_metrics = (
         "gen_ai.client.operation.duration",
         "gen_ai.client.token.usage",

--- a/instrumentation/opentelemetry-instrumentation-google-genai/tests/conformance/generate_content.py
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/tests/conformance/generate_content.py
@@ -21,7 +21,7 @@ from opentelemetry.test_util_genai.instrumentor import instrument
 
 
 class GenerateContentScenario(Scenario):
-    expected_spans = ("generate_content",)
+    expected_spans = {"generate_content": 1}
     expected_metrics = (
         "gen_ai.client.operation.duration",
         "gen_ai.client.token.usage",

--- a/instrumentation/opentelemetry-instrumentation-google-genai/tests/conformance/inference.py
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/tests/conformance/inference.py
@@ -24,7 +24,7 @@ from opentelemetry.test_util_genai.instrumentor import instrument
 
 
 class InferenceScenario(Scenario):
-    expected_spans = ("interactions.create",)
+    expected_spans = {"interactions.create": 1}
     expected_metrics = (
         "gen_ai.client.operation.duration",
         "gen_ai.client.token.usage",

--- a/instrumentation/opentelemetry-instrumentation-google-genai/tests/conformance/tool_calling.py
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/tests/conformance/tool_calling.py
@@ -23,7 +23,7 @@ from opentelemetry.test_util_genai.instrumentor import instrument
 
 
 class ToolCallingScenario(Scenario):
-    expected_spans = ("generate_content",)
+    expected_spans = {"generate_content": 1}
     expected_metrics = (
         "gen_ai.client.operation.duration",
         "gen_ai.client.token.usage",

--- a/util/opentelemetry-test-util-genai/src/opentelemetry/test_util_genai/conformance.py
+++ b/util/opentelemetry-test-util-genai/src/opentelemetry/test_util_genai/conformance.py
@@ -174,6 +174,7 @@ def _seen_span_operations(report: LiveCheckReport) -> dict[str, int]:
         for attr in entry["span"]["attributes"]:
             if attr["name"] == "gen_ai.operation.name":
                 counts[attr["value"]] = counts.get(attr["value"], 0) + 1
+                break
     return counts
 
 

--- a/util/opentelemetry-test-util-genai/src/opentelemetry/test_util_genai/conformance.py
+++ b/util/opentelemetry-test-util-genai/src/opentelemetry/test_util_genai/conformance.py
@@ -19,8 +19,8 @@ to be installed in the conformance envs.
 
 Each ``tests/conformance/<op>.py`` defines a :class:`Scenario` subclass with:
 
-- ``expected_spans`` — ``gen_ai.operation.name`` values that must appear in
-  the report's span samples.
+- ``expected_spans`` — maps each ``gen_ai.operation.name`` to the exact number
+  of spans the report must carry it on, with no undeclared operations present.
 - ``expected_metrics`` — metric names that must appear in
   ``statistics.seen_registry_metrics``.
 - ``expected_violations`` — :class:`ExpectedViolation` entries for known
@@ -30,9 +30,10 @@ Each ``tests/conformance/<op>.py`` defines a :class:`Scenario` subclass with:
   the instrumentor against the providers and exercises one semconv operation
   type's happy path inside ``vcr.use_cassette(...)``.
 - ``validate(report)`` — asserts the emitted telemetry matches the scenario.
-  The base implementation enforces ``expected_spans`` / ``expected_metrics``
-  presence; per-scenario overrides call ``super().validate(report)`` and
-  layer on additional checks against the weaver report.
+  The base implementation enforces the exact ``expected_spans`` operation
+  counts and ``expected_metrics`` presence; per-scenario overrides call
+  ``super().validate(report)`` and layer on additional checks against the
+  weaver report.
 """
 
 from __future__ import annotations
@@ -79,7 +80,7 @@ class ExpectedViolation:
 class Scenario(ABC):
     """Base class every ``tests/conformance/<op>.py`` scenario must subclass."""
 
-    expected_spans: ClassVar[tuple[str, ...]] = ()
+    expected_spans: ClassVar[dict[str, int]] = {}
     expected_metrics: ClassVar[tuple[str, ...]] = ()
     expected_violations: ClassVar[tuple[ExpectedViolation, ...]] = ()
 
@@ -96,17 +97,18 @@ class Scenario(ABC):
     def validate(self, report: LiveCheckReport) -> None:
         """Assert the weaver live-check report matches the scenario.
 
-        The base implementation enforces that every ``expected_spans`` and
-        ``expected_metrics`` entry appears at least once. Subclasses should
-        override and call ``super().validate(report)`` to layer on extra
-        scenario-specific checks against the report.
+        ``expected_spans`` maps each ``gen_ai.operation.name`` to the exact
+        number of spans that must carry it: the report's spans must match these
+        operation counts exactly — no missing, no extra. ``expected_metrics``
+        entries must each appear at least once. Subclasses should override and
+        call ``super().validate(report)`` to layer on extra scenario-specific
+        checks against the report.
         """
-        expected_spans = set(self.expected_spans)
+        expected_spans = dict(self.expected_spans)
         seen_spans = _seen_span_operations(report)
-        missing_spans = expected_spans - seen_spans
-        assert not missing_spans, (
-            f"Expected span operations {sorted(expected_spans)} but weaver "
-            f"only saw {sorted(seen_spans)} — missing {sorted(missing_spans)}"
+        assert seen_spans == expected_spans, (
+            f"Expected span operation counts {dict(sorted(expected_spans.items()))} "
+            f"but weaver saw {dict(sorted(seen_spans.items()))}"
         )
 
         expected_metrics = set(self.expected_metrics)
@@ -163,15 +165,16 @@ def _seen_metric_names(report: LiveCheckReport) -> set[str]:
     return {name for name, count in seen.items() if count}
 
 
-def _seen_span_operations(report: LiveCheckReport) -> set[str]:
-    """`gen_ai.operation.name` values observed across the report's span samples."""
-    return {
-        attr["value"]
-        for entry in report["samples"]
-        if "span" in entry
-        for attr in entry["span"]["attributes"]
-        if attr["name"] == "gen_ai.operation.name"
-    }
+def _seen_span_operations(report: LiveCheckReport) -> dict[str, int]:
+    """`gen_ai.operation.name` counts across the report's span samples."""
+    counts: dict[str, int] = {}
+    for entry in report["samples"]:
+        if "span" not in entry:
+            continue
+        for attr in entry["span"]["attributes"]:
+            if attr["name"] == "gen_ai.operation.name":
+                counts[attr["value"]] = counts.get(attr["value"], 0) + 1
+    return counts
 
 
 def _dump_report(scenario: Scenario, report: LiveCheckReport) -> None:


### PR DESCRIPTION
expected_spans becomes a dict[str, int] of exact per-operation span counts, and the base Scenario.validate fails on any mismatch (conformance replays recorded cassettes, so counts are deterministic). Scenarios pin real counts here instead of re-asserting them in redundant validate overrides.
