### PR TITLE
Make opentelemetry-util-genai installation editable in tests to avoid stale env issues

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,6 +107,10 @@ Before opening a PR, run `uv run tox -e precommit`, `uv run tox -e typecheck`, a
 test envs (`-oldest` and `-latest`, plus `-conformance` if it ships scenarios) — these mirror
 the CI gates.
 
+tox reuses cached envs and won't re-resolve dependencies on its own, so pass `--recreate` (`-r`)
+after editing a `tests/requirements.*.txt` or a `pyproject.toml` dependency bound — otherwise the
+run silently uses the previously installed versions.
+
 ## Guidelines
 
 - Each package has its own `pyproject.toml` with version, dependencies, and entry points.

--- a/tox.ini
+++ b/tox.ini
@@ -143,8 +143,8 @@ deps =
 
   ; Langchain conformance tests
   langchain-conformance: {[testenv]pytest_deps}
-  langchain-conformance: {toxinidir}/util/opentelemetry-util-genai
-  langchain-conformance: {toxinidir}/instrumentation/opentelemetry-instrumentation-genai-langchain[instruments]
+  langchain-conformance: -e {toxinidir}/util/opentelemetry-util-genai
+  langchain-conformance: -e {toxinidir}/instrumentation/opentelemetry-instrumentation-genai-langchain[instruments]
   langchain-conformance: langchain-openai
   langchain-conformance: langchain-aws
   langchain-conformance: langchain-google-genai
@@ -153,7 +153,7 @@ deps =
   util-genai: {[testenv]test_deps}
   util-genai: {[testenv]pytest_deps}
   util-genai: -r {toxinidir}/util/opentelemetry-util-genai/test-requirements.txt
-  util-genai: {toxinidir}/util/opentelemetry-util-genai
+  util-genai: -e {toxinidir}/util/opentelemetry-util-genai
 
 allowlist_externals =
   sh
@@ -280,13 +280,14 @@ deps =
   -c {toxinidir}/dev-requirements.txt
   pyright
   {[testenv]test_deps}
-  {toxinidir}/util/opentelemetry-util-genai[upload]
-  {toxinidir}/instrumentation/opentelemetry-instrumentation-google-genai[instruments]
-  {toxinidir}/instrumentation/opentelemetry-instrumentation-genai-anthropic[instruments]
-  {toxinidir}/instrumentation/opentelemetry-instrumentation-genai-langchain[instruments]
-  {toxinidir}/instrumentation/opentelemetry-instrumentation-genai-claude-agent-sdk[instruments]
-  {toxinidir}/instrumentation/opentelemetry-instrumentation-genai-openai-agents[instruments]
-  {toxinidir}/instrumentation/opentelemetry-instrumentation-genai-weaviate-client[instruments]
+  ; editable so pyright reads the source tree, not a stale installed snapshot after src edits
+  -e {toxinidir}/util/opentelemetry-util-genai[upload]
+  -e {toxinidir}/instrumentation/opentelemetry-instrumentation-google-genai[instruments]
+  -e {toxinidir}/instrumentation/opentelemetry-instrumentation-genai-anthropic[instruments]
+  -e {toxinidir}/instrumentation/opentelemetry-instrumentation-genai-langchain[instruments]
+  -e {toxinidir}/instrumentation/opentelemetry-instrumentation-genai-claude-agent-sdk[instruments]
+  -e {toxinidir}/instrumentation/opentelemetry-instrumentation-genai-openai-agents[instruments]
+  -e {toxinidir}/instrumentation/opentelemetry-instrumentation-genai-weaviate-client[instruments]
 
 commands =
   pyright

--- a/tox.ini
+++ b/tox.ini
@@ -280,7 +280,6 @@ deps =
   -c {toxinidir}/dev-requirements.txt
   pyright
   {[testenv]test_deps}
-  ; editable so pyright reads the source tree, not a stale installed snapshot after src edits
   -e {toxinidir}/util/opentelemetry-util-genai[upload]
   -e {toxinidir}/instrumentation/opentelemetry-instrumentation-google-genai[instruments]
   -e {toxinidir}/instrumentation/opentelemetry-instrumentation-genai-anthropic[instruments]


### PR DESCRIPTION
Keep running into stale environment in tests, update missing tests to install with -e and add a sentence to agents.md to run with -r when updating dependencies.