### PR TITLE
feat(google-genai): derive error.type from google.genai API error codes

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-google-genai/.changelog/304.added
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/.changelog/304.added
@@ -1,0 +1,1 @@
+Surface the HTTP status code (e.g. ``429``) as ``error.type`` on failed ``generate_content`` and ``interactions.create`` inference spans and metrics, instead of collapsing every ``google.genai`` error into ``ClientError`` / ``ServerError``.

--- a/instrumentation/opentelemetry-instrumentation-google-genai/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
   "opentelemetry-api ~= 1.43",
   "opentelemetry-instrumentation >= 0.64b0, <1",
   "opentelemetry-semantic-conventions >= 0.64b0, <1",
-  "opentelemetry-util-genai >= 1.0b0, <2",
+  "opentelemetry-util-genai >= 1.1b0, <2",
   "wrapt >= 1.17.0, < 3.0.0",
 ]
 

--- a/instrumentation/opentelemetry-instrumentation-google-genai/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
   "opentelemetry-api ~= 1.43",
   "opentelemetry-instrumentation >= 0.64b0, <1",
   "opentelemetry-semantic-conventions >= 0.64b0, <1",
-  "opentelemetry-util-genai >= 1.1b0, <2",
+  "opentelemetry-util-genai >= 1.0b0, <2",
   "wrapt >= 1.17.0, < 3.0.0",
 ]
 

--- a/instrumentation/opentelemetry-instrumentation-google-genai/src/opentelemetry/instrumentation/google_genai/_error_type.py
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/src/opentelemetry/instrumentation/google_genai/_error_type.py
@@ -1,0 +1,19 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from google.genai import errors as genai_errors
+
+
+def resolve_error_type(exc: BaseException) -> str | None:
+    """Derive error.type from a google.genai exception.
+
+    google.genai collapses all 4xx into ClientError and 5xx into ServerError,
+    so surface the HTTP status code (e.g. ``429``), which distinguishes them.
+    Returns None for other exceptions so the util layer falls back to the
+    exception class name.
+    """
+    if isinstance(exc, genai_errors.APIError):
+        return str(exc.code)
+    return None

--- a/instrumentation/opentelemetry-instrumentation-google-genai/src/opentelemetry/instrumentation/google_genai/generate_content.py
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/src/opentelemetry/instrumentation/google_genai/generate_content.py
@@ -38,6 +38,7 @@ from opentelemetry.util.genai.types import (
 )
 from opentelemetry.util.types import AttributeValue
 
+from ._error_type import resolve_error_type
 from .allowlist_util import AllowList
 from .client_info import get_client_info as _get_client_info
 from .custom_semconv import GCP_GENAI_OPERATION_CONFIG
@@ -477,6 +478,7 @@ def _create_instrumented_generate_content(
                 request_model=model,
                 operation_name="generate_content",
                 server_address=server_address,
+                error_type_resolver=resolve_error_type,
             ) as invocation:
                 _apply_request_attributes(
                     wrapped_config,
@@ -635,6 +637,7 @@ def _create_instrumented_generate_content_stream(
                 request_model=model,
                 operation_name="generate_content",
                 server_address=server_address,
+                error_type_resolver=resolve_error_type,
             )
             _apply_request_attributes(
                 wrapped_config,
@@ -706,6 +709,7 @@ def _create_instrumented_async_generate_content(
                 request_model=model,
                 operation_name="generate_content",
                 server_address=server_address,
+                error_type_resolver=resolve_error_type,
             ) as invocation:
                 invocation.attributes.update(
                     _get_extra_generate_content_attributes()
@@ -788,6 +792,7 @@ def _create_instrumented_async_generate_content_stream(  # type: ignore
                 request_model=model,
                 operation_name="generate_content",
                 server_address=server_address,
+                error_type_resolver=resolve_error_type,
             )
             invocation.attributes.update(
                 _get_extra_generate_content_attributes()

--- a/instrumentation/opentelemetry-instrumentation-google-genai/src/opentelemetry/instrumentation/google_genai/interactions.py
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/src/opentelemetry/instrumentation/google_genai/interactions.py
@@ -75,6 +75,9 @@ except ImportError:
 
 from wrapt import wrap_function_wrapper
 
+from opentelemetry.instrumentation.google_genai._error_type import (
+    resolve_error_type,
+)
 from opentelemetry.instrumentation.google_genai.client_info import (
     get_client_info as _get_client_info,
 )
@@ -392,6 +395,7 @@ def _start_interactions_invocation(
             request_model=kwargs.get("model"),
             operation_name="interactions.create",
             server_address=server_address,
+            error_type_resolver=resolve_error_type,
         )
     invocation.tool_definitions = _maybe_get_tool_definitions(
         kwargs.get("tools")

--- a/instrumentation/opentelemetry-instrumentation-google-genai/tests/generate_content/nonstreaming_base.py
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/tests/generate_content/nonstreaming_base.py
@@ -5,6 +5,7 @@ import unittest
 from unittest.mock import AsyncMock, create_autospec, patch
 
 import pytest
+from google.genai import errors as genai_errors
 from google.genai.types import (
     FunctionDeclarationDict,
     GenerateContentConfig,
@@ -278,6 +279,28 @@ class NonStreamingTestCase(TestCase):
             span.attributes["error.type"]
             == event.attributes["error.type"]
             == "ValueError"
+        )
+
+    def test_error_type_uses_google_genai_code_not_class_name(self):
+        # google.genai collapses all 4xx into ClientError; the HTTP status code
+        # (e.g. 429) must surface as error.type instead of the class name.
+        self.configure_exception(
+            genai_errors.ClientError(
+                429, {"error": {"code": 429, "status": "RESOURCE_EXHAUSTED"}}
+            )
+        )
+        with pytest.raises(genai_errors.ClientError):
+            self.generate_content(
+                model="gemini-2.0-flash", contents="Does this work?"
+            )
+        span = self.otel.get_span_named("generate_content gemini-2.0-flash")
+        event = self.otel.get_event_named(
+            "gen_ai.client.inference.operation.details"
+        )
+        assert (
+            span.attributes["error.type"]
+            == event.attributes["error.type"]
+            == "429"
         )
 
     def test_generated_span_has_vertex_ai_system_when_configured(self):

--- a/util/opentelemetry-util-genai/.changelog/304.added
+++ b/util/opentelemetry-util-genai/.changelog/304.added
@@ -1,0 +1,1 @@
+Add an optional ``error_type_resolver`` callback to ``TelemetryHandler.inference()`` and ``InferenceInvocation`` so instrumentors can derive the ``error.type`` attribute from the raw exception, plus a ``type_str`` field on ``Error`` to carry the pre-resolved value.

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_inference_invocation.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_inference_invocation.py
@@ -19,6 +19,7 @@ from opentelemetry.util.genai._invocation import (
 from opentelemetry.util.genai.completion_hook import CompletionHook
 from opentelemetry.util.genai.metrics import InvocationMetricsRecorder
 from opentelemetry.util.genai.types import (
+    ErrorTypeResolver,
     InputMessage,
     MessagePart,
     OutputMessage,
@@ -48,6 +49,7 @@ class InferenceInvocation(GenAIInvocation):
         server_address: str | None = None,
         server_port: int | None = None,
         operation_name: str | None = None,
+        error_type_resolver: ErrorTypeResolver | None = None,
     ) -> None:
         operation_name = (
             operation_name or GenAI.GenAiOperationNameValues.CHAT.value
@@ -63,6 +65,7 @@ class InferenceInvocation(GenAIInvocation):
             if request_model
             else operation_name,
             span_kind=SpanKind.CLIENT,
+            error_type_resolver=error_type_resolver,
         )
         self._provider: str = provider
         self._request_model: str | None = request_model

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_invocation.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_invocation.py
@@ -23,6 +23,7 @@ from opentelemetry.trace.status import Status, StatusCode
 from opentelemetry.util.genai.completion_hook import CompletionHook
 from opentelemetry.util.genai.types import (
     Error,
+    ErrorTypeResolver,
     InputMessage,
     MessagePart,
     OutputMessage,
@@ -64,11 +65,13 @@ class GenAIInvocation(AbstractContextManager["GenAIInvocation"]):
         span_kind: SpanKind = SpanKind.CLIENT,
         attributes: dict[str, AttributeValue] | None = None,
         metric_attributes: dict[str, AttributeValue] | None = None,
+        error_type_resolver: ErrorTypeResolver | None = None,
     ) -> None:
         self._tracer = tracer
         self._metrics_recorder = metrics_recorder
         self._logger = logger
         self._completion_hook = completion_hook
+        self._error_type_resolver = error_type_resolver
         self._operation_name: str = operation_name
         self.attributes: dict[str, AttributeValue] = (
             {} if attributes is None else attributes
@@ -112,7 +115,7 @@ class GenAIInvocation(AbstractContextManager["GenAIInvocation"]):
 
     def _apply_error_attributes(self, error: Error) -> None:
         """Apply error status and error.type attribute to the span, events, and metrics."""
-        error_type = error.type.__qualname__
+        error_type = error.type_str or error.type.__qualname__
         self.span.set_status(Status(StatusCode.ERROR, error.message))
         self.attributes[error_attributes.ERROR_TYPE] = error_type
         self.metric_attributes[error_attributes.ERROR_TYPE] = error_type
@@ -164,7 +167,14 @@ class GenAIInvocation(AbstractContextManager["GenAIInvocation"]):
     def fail(self, error: Error | BaseException) -> None:
         """Fail the invocation and end its span with error status."""
         if isinstance(error, BaseException):
-            error = Error(type=type(error), message=str(error))
+            type_str = (
+                self._error_type_resolver(error)
+                if self._error_type_resolver is not None
+                else None
+            )
+            error = Error(
+                message=str(error), type=type(error), type_str=type_str
+            )
         self._finish(error)
 
     def __enter__(self) -> GenAIInvocation:

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/handler.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/handler.py
@@ -63,7 +63,10 @@ from opentelemetry.util.genai.invocation import (
     WorkflowInvocation,
 )
 from opentelemetry.util.genai.metrics import InvocationMetricsRecorder
-from opentelemetry.util.genai.types import ContentCapturingMode
+from opentelemetry.util.genai.types import (
+    ContentCapturingMode,
+    ErrorTypeResolver,
+)
 from opentelemetry.util.genai.utils import get_content_capturing_mode
 from opentelemetry.util.genai.version import __version__
 
@@ -310,6 +313,7 @@ class TelemetryHandler:
         server_address: str | None = None,
         server_port: int | None = None,
         operation_name: str | None = None,
+        error_type_resolver: ErrorTypeResolver | None = None,
     ) -> InferenceInvocation:
         """Returns an Inference invocation. Starts span when called.
 
@@ -329,6 +333,7 @@ class TelemetryHandler:
             server_address=server_address,
             server_port=server_port,
             operation_name=operation_name,
+            error_type_resolver=error_type_resolver,
         )
 
     def embedding(

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/types.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/types.py
@@ -5,7 +5,15 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Literal, Type, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Literal,
+    Type,
+    TypeAlias,
+    Union,
+)
 
 if TYPE_CHECKING:
     from opentelemetry.util.genai._inference_invocation import (  # pylint: disable=useless-import-alias
@@ -248,6 +256,16 @@ class OutputMessage:
 class Error:
     message: str
     type: Type[BaseException]
+    # Pre-resolved error.type value
+    # When set it takes precedence over error.type value derived from ``type``.
+    # Kept separate from ``type`` to stay backwards compatible.
+    type_str: str | None = None
+
+
+# Callback an instrumentor may supply to derive the error.type attribute from a
+# provider exception.
+# Returns None to fall back to the default derived from ``Error.type``.
+ErrorTypeResolver: TypeAlias = Callable[[BaseException], "str | None"]
 
 
 def __getattr__(name: str) -> object:

--- a/util/opentelemetry-util-genai/tests/test_handler_metrics.py
+++ b/util/opentelemetry-util-genai/tests/test_handler_metrics.py
@@ -156,6 +156,50 @@ class TelemetryHandlerMetricsTest(TestBase):
         )
         self.assertAlmostEqual(token_point.sum, 11.0, places=3)
 
+    def test_fail_llm_error_type_uses_supplied_resolver(self) -> None:
+        # An instrumentor-supplied error_type_resolver derives error.type from
+        # the raw exception (e.g. surfacing a provider's canonical status).
+        handler = TelemetryHandler(
+            tracer_provider=self.tracer_provider,
+            meter_provider=self.meter_provider,
+        )
+        invocation = handler.inference(
+            "",
+            request_model="err-model",
+            error_type_resolver=lambda exc: "429",
+        )
+        invocation.fail(ValueError("boom"))
+
+        metrics = self._harvest_metrics()
+        duration_points = metrics["gen_ai.client.operation.duration"]
+        self.assertEqual(len(duration_points), 1)
+        self.assertEqual(
+            duration_points[0].attributes.get("error.type"),
+            "429",
+        )
+
+    def test_fail_llm_error_type_falls_back_when_resolver_returns_none(
+        self,
+    ) -> None:
+        # Resolver returning None falls back to the exception class name.
+        handler = TelemetryHandler(
+            tracer_provider=self.tracer_provider,
+            meter_provider=self.meter_provider,
+        )
+        invocation = handler.inference(
+            "",
+            request_model="err-model",
+            error_type_resolver=lambda exc: None,
+        )
+        invocation.fail(ValueError("boom"))
+
+        metrics = self._harvest_metrics()
+        duration_points = metrics["gen_ai.client.operation.duration"]
+        self.assertEqual(
+            duration_points[0].attributes.get("error.type"),
+            "ValueError",
+        )
+
     def _harvest_metrics(
         self,
     ) -> Dict[str, List[Any]]:


### PR DESCRIPTION
# Description

`google.genai` raises `ClientError` for every 4xx and `ServerError` for every 5xx, so failed-inference telemetry collapsed all distinct failures (403, 404, 429, ...) into just two `error.type` values, making them indistinguishable on the `gen_ai.client.operation.duration` metric and on inference spans.

This adds a way for an instrumentor to derive `error.type` from the raw exception, and uses it in the google-genai instrumentation to surface the HTTP status code.

**util-genai (additive, backwards compatible):**
- `TelemetryHandler.inference()` and `InferenceInvocation` accept an optional `error_type_resolver: Callable[[BaseException], str | None]`. On failure the callback is invoked with the exception; returning `None` falls back to the exception class name (previous behavior).
- `Error` gains an optional `type_str: str | None` field carrying the pre-resolved value. The existing `type: Type[BaseException]` field and all existing `Error(...)` call sites are unchanged, so this is not a breaking change.

**google-genai instrumentation:**
- New `_error_type.resolve_error_type` returns `str(exc.code)` for `google.genai.errors.APIError` (e.g. `"429"`), otherwise `None`.
- Wired into all `generate_content` and `interactions.create` inference call sites.

Fixes # (issue)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How has this been tested?

Unit tests:

- [x] util-genai: the supplied resolver value is applied to span + metric `error.type`; a resolver returning `None` falls back to the exception class name.
- [x] google-genai: a `ClientError(429, ...)` yields `error.type == "429"` on both the span and the inference event; the existing plain-exception path (`ValueError` -> `"ValueError"`) is preserved.

# Checklist

See [CONTRIBUTING.md](https://github.com/open-telemetry/opentelemetry-python-genai/blob/main/CONTRIBUTING.md)
for the style guide, changelog guidance, and more.

- [x] Followed the style guidelines of this project
- [x] Changelog updated if the change requires an entry
- [x] Unit tests added
- [ ] Documentation updated