### PR TITLE
Populate gen_ai.response.model from responses API when the response body includes the served model header

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/.changelog/305.added
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/.changelog/305.added
@@ -1,0 +1,1 @@
+Populate gen_ai.response.model from responses API when the response body includes the served model header

--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/src/opentelemetry/instrumentation/genai/langchain/callback_handler.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/src/opentelemetry/instrumentation/genai/langchain/callback_handler.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import json
 from collections.abc import Sequence
-from typing import Any, Optional, cast
+from typing import Any, Mapping, Optional, cast
 from uuid import UUID
 
 from langchain_core.callbacks import BaseCallbackHandler
@@ -45,6 +45,8 @@ from opentelemetry.util.genai.types import (
     Text,
     ToolCallRequest,
 )
+
+SUPPORTED_RAPI_RESPONSE_HEADERS = ("x-ms-served-model",)
 
 
 class OpenTelemetryLangChainCallbackHandler(BaseCallbackHandler):
@@ -443,6 +445,35 @@ class OpenTelemetryLangChainCallbackHandler(BaseCallbackHandler):
             response_id = llm_output.get("id")
             if response_id is not None:
                 llm_invocation.response_id = str(response_id)
+
+        # Responses API (RAPI) may include the served model in the response headers, which accurately returns the served model name for the request.
+        for generation in getattr(response, "generations", []):
+            for chat_generation in generation:
+                if chat_generation.message is not None:
+                    if chat_generation.message.response_metadata is not None:
+                        meta = chat_generation.message.response_metadata
+                        headers = (
+                            meta.get("headers")
+                            if isinstance(meta, Mapping)
+                            else None
+                        )
+                        if isinstance(headers, Mapping):
+                            for name, value in headers.items():
+                                if (
+                                    isinstance(name, str)
+                                    and name.lower()
+                                    in SUPPORTED_RAPI_RESPONSE_HEADERS
+                                    and value
+                                ):
+                                    served_model = str(value)
+                                    break
+                        if served_model:
+                            break
+            if served_model:
+                break
+
+        if served_model:
+            llm_invocation.response_model_name = served_model
 
         llm_invocation.stop()
         if not llm_invocation.span.is_recording():

--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/src/opentelemetry/instrumentation/genai/langchain/callback_handler.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/src/opentelemetry/instrumentation/genai/langchain/callback_handler.py
@@ -447,6 +447,7 @@ class OpenTelemetryLangChainCallbackHandler(BaseCallbackHandler):
                 llm_invocation.response_id = str(response_id)
 
         # Responses API (RAPI) may include the served model in the response headers, which accurately returns the served model name for the request.
+        served_model: str | None = None
         for generation in getattr(response, "generations", []):
             for chat_generation in generation:
                 if chat_generation.message is not None:
@@ -458,7 +459,8 @@ class OpenTelemetryLangChainCallbackHandler(BaseCallbackHandler):
                             else None
                         )
                         if isinstance(headers, Mapping):
-                            for name, value in headers.items():
+                            headers_map = cast(Mapping[Any, Any], headers)
+                            for name, value in headers_map.items():
                                 if (
                                     isinstance(name, str)
                                     and name.lower()

--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/src/opentelemetry/instrumentation/genai/langchain/callback_handler.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/src/opentelemetry/instrumentation/genai/langchain/callback_handler.py
@@ -313,6 +313,7 @@ class OpenTelemetryLangChainCallbackHandler(BaseCallbackHandler):
             return
 
         output_messages: list[OutputMessage] = []
+        served_model: str | None = None
         for generation in getattr(response, "generations", []):
             for chat_generation in generation:
                 message = chat_generation.message
@@ -334,6 +335,30 @@ class OpenTelemetryLangChainCallbackHandler(BaseCallbackHandler):
                     )
 
                 if chat_generation.message:
+                    # Responses API (RAPI) may include the served model in the
+                    # response headers, which accurately returns the served
+                    # model name for the request.
+                    if (
+                        served_model is None
+                        and chat_generation.message.response_metadata
+                    ):
+                        headers = (
+                            chat_generation.message.response_metadata.get(
+                                "headers"
+                            )
+                        )
+                        if isinstance(headers, Mapping):
+                            headers_map = cast(Mapping[Any, Any], headers)
+                            for name, value in headers_map.items():
+                                if (
+                                    isinstance(name, str)
+                                    and name.lower()
+                                    in SUPPORTED_RAPI_RESPONSE_HEADERS
+                                    and value
+                                ):
+                                    served_model = str(value)
+                                    break
+
                     # Get finish reason if generation_info is None above
                     if (
                         generation_info is None
@@ -445,33 +470,6 @@ class OpenTelemetryLangChainCallbackHandler(BaseCallbackHandler):
             response_id = llm_output.get("id")
             if response_id is not None:
                 llm_invocation.response_id = str(response_id)
-
-        # Responses API (RAPI) may include the served model in the response headers, which accurately returns the served model name for the request.
-        served_model: str | None = None
-        for generation in getattr(response, "generations", []):
-            for chat_generation in generation:
-                if chat_generation.message is not None:
-                    if chat_generation.message.response_metadata is not None:
-                        meta = cast(
-                            Mapping[Any, Any],
-                            chat_generation.message.response_metadata,
-                        )
-                        headers = meta.get("headers")
-                        if isinstance(headers, Mapping):
-                            headers_map = cast(Mapping[Any, Any], headers)
-                            for name, value in headers_map.items():
-                                if (
-                                    isinstance(name, str)
-                                    and name.lower()
-                                    in SUPPORTED_RAPI_RESPONSE_HEADERS
-                                    and value
-                                ):
-                                    served_model = str(value)
-                                    break
-                        if served_model:
-                            break
-            if served_model:
-                break
 
         if served_model:
             llm_invocation.response_model_name = served_model

--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/src/opentelemetry/instrumentation/genai/langchain/callback_handler.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/src/opentelemetry/instrumentation/genai/langchain/callback_handler.py
@@ -4,8 +4,8 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Sequence
-from typing import Any, Mapping, Optional, cast
+from collections.abc import Mapping, Sequence
+from typing import Any, Optional, cast
 from uuid import UUID
 
 from langchain_core.callbacks import BaseCallbackHandler

--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/src/opentelemetry/instrumentation/genai/langchain/callback_handler.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/src/opentelemetry/instrumentation/genai/langchain/callback_handler.py
@@ -452,12 +452,11 @@ class OpenTelemetryLangChainCallbackHandler(BaseCallbackHandler):
             for chat_generation in generation:
                 if chat_generation.message is not None:
                     if chat_generation.message.response_metadata is not None:
-                        meta = chat_generation.message.response_metadata
-                        headers = (
-                            meta.get("headers")
-                            if isinstance(meta, Mapping)
-                            else None
+                        meta = cast(
+                            Mapping[Any, Any],
+                            chat_generation.message.response_metadata,
                         )
+                        headers = meta.get("headers")
                         if isinstance(headers, Mapping):
                             headers_map = cast(Mapping[Any, Any], headers)
                             for name, value in headers_map.items():

--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/tests/test_callback_handler.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/tests/test_callback_handler.py
@@ -1644,3 +1644,123 @@ def test_to_input_messages_includes_legacy_function_call():
         isinstance(p, ToolCallRequest) and p.name == "f"
         for p in messages[0].parts
     )
+
+
+# ---------------------------------------------------------------------------
+# on_llm_end – response model resolution (RAPI header + llm_output)
+# ---------------------------------------------------------------------------
+
+
+class TestOnLlmEndResponseModel:
+    def test_served_model_from_rapi_header(self):
+        run_id = _run_id()
+        handler, _, llm_inv = _make_handler_with_llm_invocation(run_id)
+
+        ai_msg = AIMessage(
+            content="hello",
+            response_metadata={
+                "headers": {"x-ms-served-model": "gpt-4.1-2025-04-14"}
+            },
+        )
+        gen = ChatGeneration(
+            message=ai_msg, generation_info={"finish_reason": "stop"}
+        )
+        response = LLMResult(generations=[[gen]])
+
+        handler.on_llm_end(response=response, run_id=run_id)
+
+        assert llm_inv.response_model_name == "gpt-4.1-2025-04-14"
+
+    def test_served_model_header_case_insensitive(self):
+        run_id = _run_id()
+        handler, _, llm_inv = _make_handler_with_llm_invocation(run_id)
+
+        ai_msg = AIMessage(
+            content="hello",
+            response_metadata={
+                "headers": {"X-MS-Served-Model": "gpt-4.1-2025-04-14"}
+            },
+        )
+        gen = ChatGeneration(
+            message=ai_msg, generation_info={"finish_reason": "stop"}
+        )
+        response = LLMResult(generations=[[gen]])
+
+        handler.on_llm_end(response=response, run_id=run_id)
+
+        assert llm_inv.response_model_name == "gpt-4.1-2025-04-14"
+
+    def test_served_model_overrides_llm_output_model_name(self):
+        run_id = _run_id()
+        handler, _, llm_inv = _make_handler_with_llm_invocation(run_id)
+
+        ai_msg = AIMessage(
+            content="hello",
+            response_metadata={
+                "headers": {"x-ms-served-model": "served-from-header"}
+            },
+        )
+        gen = ChatGeneration(
+            message=ai_msg, generation_info={"finish_reason": "stop"}
+        )
+        response = LLMResult(
+            generations=[[gen]],
+            llm_output={"model_name": "gpt-4.1-body", "id": "resp_123"},
+        )
+
+        handler.on_llm_end(response=response, run_id=run_id)
+
+        assert llm_inv.response_model_name == "served-from-header"
+        assert llm_inv.response_id == "resp_123"
+
+    def test_llm_output_model_fallback(self):
+        run_id = _run_id()
+        handler, _, llm_inv = _make_handler_with_llm_invocation(run_id)
+
+        ai_msg = AIMessage(content="hello", response_metadata={})
+        gen = ChatGeneration(
+            message=ai_msg, generation_info={"finish_reason": "stop"}
+        )
+        response = LLMResult(
+            generations=[[gen]], llm_output={"model": "gpt-4.1-fallback"}
+        )
+
+        handler.on_llm_end(response=response, run_id=run_id)
+
+        assert llm_inv.response_model_name == "gpt-4.1-fallback"
+
+    def test_unsupported_header_ignored(self):
+        run_id = _run_id()
+        handler, _, llm_inv = _make_handler_with_llm_invocation(run_id)
+        llm_inv.response_model_name = None
+
+        ai_msg = AIMessage(
+            content="hello",
+            response_metadata={"headers": {"x-request-id": "abc-123"}},
+        )
+        gen = ChatGeneration(
+            message=ai_msg, generation_info={"finish_reason": "stop"}
+        )
+        response = LLMResult(generations=[[gen]])
+
+        handler.on_llm_end(response=response, run_id=run_id)
+
+        assert llm_inv.response_model_name is None
+
+    def test_empty_header_value_ignored(self):
+        run_id = _run_id()
+        handler, _, llm_inv = _make_handler_with_llm_invocation(run_id)
+        llm_inv.response_model_name = None
+
+        ai_msg = AIMessage(
+            content="hello",
+            response_metadata={"headers": {"x-ms-served-model": ""}},
+        )
+        gen = ChatGeneration(
+            message=ai_msg, generation_info={"finish_reason": "stop"}
+        )
+        response = LLMResult(generations=[[gen]])
+
+        handler.on_llm_end(response=response, run_id=run_id)
+
+        assert llm_inv.response_model_name is None


### PR DESCRIPTION
# Description

Fixes # ([267](https://github.com/open-telemetry/opentelemetry-python-genai/issues/267))

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. List any relevant details for your test
configuration.

- [x] uv run tox -e py312-test-instrumentation-genai-langchain -- -q
- [x] uv run tox -e py312-test-instrumentation-genai-langchain-conformance -- -q
- [x] uv run --python 3.12 tox -e lint-instrumentation-genai-langchain

# Checklist

See [CONTRIBUTING.md](https://github.com/open-telemetry/opentelemetry-python-genai/blob/main/CONTRIBUTING.md)
for the style guide, changelog guidance, and more.

- [x] Followed the style guidelines of this project
- [x] Changelog updated if the change requires an entry
- [x] Unit tests added
- [ ] Documentation updated