### PR TITLE
generate conformance reports as in semconv-genai

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -25,6 +25,21 @@
       ]
     },
     {
+      // The generated conformance reports link to the semconv docs at the
+      // pinned revision. Same datasource/depName as the SEMCONV_GENAI_REF
+      // entry above, so both move in one PR and the generated pages don't
+      // lag versions.env.
+      "customType": "regex",
+      "managerFilePatterns": ["/^docs/conformance/reports/.*\\.md$/"],
+      "matchStrings": [
+        "https://github\\.com/open-telemetry/semantic-conventions-genai/blob/(?<currentValue>[0-9a-f]{40})/"
+      ],
+      "datasourceTemplate": "git-refs",
+      "depNameTemplate": "open-telemetry/semantic-conventions-genai",
+      "packageNameTemplate": "https://github.com/open-telemetry/semantic-conventions-genai.git",
+      "versioningTemplate": "git"
+    },
+    {
       // Keep .weaver.toml schema URL pinned to the latest Weaver tag.
       "customType": "regex",
       "managerFilePatterns": ["/^\\.weaver\\.toml$/"],

--- a/.github/skills/write-conformance-tests/SKILL.md
+++ b/.github/skills/write-conformance-tests/SKILL.md
@@ -366,3 +366,13 @@ The `*-conformance` tox envs target `tests/test_conformance.py` directly; the
 regular `*-{oldest,latest}` envs `--ignore` it so they don't need the
 OTLP/gRPC exporter or `weaver_live_check`.
 
+The run also writes `tests/conformance/data.json` — which semconv attributes
+the package emits. **Commit it**, and re-run without `-k` first: a filtered run
+writes a partial file. It feeds the tables in
+[`docs/conformance/`](../../../docs/conformance/), rebuilt with
+`uv run python scripts/update_conformance_reports.py`.
+
+Those tables show what the scenarios *exercise*, not what the package can emit.
+So set the request parameters the library maps (temperature, max_tokens, …)
+instead of sending a bare request.
+

--- a/.github/workflows/misc.yml
+++ b/.github/workflows/misc.yml
@@ -178,3 +178,29 @@ jobs:
       - name: Run oldest dependency check
         run: uv run --with packaging scripts/check_oldest_deps.py
 
+  conformance-report:
+    name: conformance-report
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repo @ SHA - ${{ github.sha }}
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Python 3.14
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.14"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+
+      - name: Regenerate semconv coverage reports
+        run: uv run python scripts/update_conformance_reports.py
+
+      - name: Check conformance reports are up to date
+        run: |
+          # -N so a newly added report page also shows up.
+          git add -N -- docs/conformance
+          git diff --exit-code -- docs/conformance \
+            || (echo 'Conformance reports are out of date, run "uv run python scripts/update_conformance_reports.py" and commit the changes in this PR.' && exit 1)
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,3 +69,11 @@ jobs:
 
       - name: Run tests
         run: uvx --with tox-uv tox -e ${{ matrix.tox_env }} -- -ra
+
+      - name: Check conformance reports are up to date
+        if: ${{ matrix.needs_weaver }}
+        run: |
+          # -N so a package's first, still-untracked data.json also shows up.
+          git add -N -- 'instrumentation/*/tests/conformance/data.json'
+          git diff --exit-code -- 'instrumentation/*/tests/conformance/data.json' \
+            || (echo 'Semconv coverage changed. Re-run this conformance env locally and commit the updated data.json.' && exit 1)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -287,6 +287,13 @@ Run via `uv run tox -e py314-test-instrumentation-genai-<lib>-conformance`. The
 regular `*-{oldest,latest}` envs `--ignore` it so they don't need the
 OTLP/gRPC exporter or `weaver_live_check`.
 
+Each run also records the package's semconv attribute coverage to
+`tests/conformance/data.json` (committed — CI fails if a conformance run
+changes it and the file wasn't updated). Because it is rewritten from a full
+env run, a `-k`-filtered run yields a partial file; check the diff. Those files
+feed the coverage reports under [`docs/conformance/`](docs/conformance/),
+regenerated with `uv run python scripts/update_conformance_reports.py`.
+
 The parallel PR-review rules live in
 [`.github/instructions/instrumentation.instructions.md`](.github/instructions/instrumentation.instructions.md)
 and should be kept in sync with this section.

--- a/docs/conformance/README.md
+++ b/docs/conformance/README.md
@@ -1,0 +1,57 @@
+# GenAI Semantic Convention Coverage
+
+Which semantic convention attributes each instrumentation package in this repo
+emits, per GenAI signal type. The pages under [reports/](reports/) mirror the
+layout of the reference reports published by
+[semantic-conventions-genai](https://github.com/open-telemetry/semantic-conventions-genai/tree/main/reference/reports),
+so the two can be compared side by side.
+
+## How this is generated
+
+The conformance tests (`uv run tox -e py3XX-test-instrumentation-genai-<lib>-conformance`)
+validate emitted telemetry against the pinned GenAI semconv registry using Weaver
+live-check. Each run records the package's attribute coverage to
+`instrumentation/<pkg>/tests/conformance/data.json`. Regenerate the pages below
+from those files with:
+
+```sh
+uv run python scripts/update_conformance_reports.py
+```
+
+Requirement levels and span classification come from the registry revision
+pinned as `SEMCONV_GENAI_REF` in [versions.env](../../versions.env), so bumping
+that pin can change these pages.
+
+## Reading the tables
+
+- Coverage reflects **what the conformance scenarios exercise**, not everything
+  an instrumentation is capable of emitting. Most scenarios issue a single
+  minimal request, so attributes like `gen_ai.request.temperature` read as
+  unsupported for packages that would emit them given a richer request.
+  Broadening the scenarios is the way to close those gaps.
+- `data.json` is rewritten from a full conformance env run. A run filtered with
+  `-k` produces a partial file — check the diff before committing.
+
+<!-- status:begin -->
+### Spans
+
+| Span | Libraries |
+| --- | --- |
+| [Create Agent](reports/create-agent-span.md) | (none) |
+| [Invoke Agent Client](reports/invoke-agent-client-span.md) | (none) |
+| [Invoke Agent Internal](reports/invoke-agent-internal-span.md) | langchain, openai-agents |
+| [Invoke Workflow](reports/invoke-workflow-span.md) | langchain, openai-agents |
+| [Plan](reports/plan-span.md) | (none) |
+| [Inference](reports/inference-span.md) | anthropic, crewai, google-genai, langchain, openai |
+| [Embeddings](reports/embeddings-span.md) | google-genai, openai |
+| [Retrieval](reports/retrieval-span.md) | (none) |
+| [Memory](reports/memory-span.md) | (none) |
+| [Execute Tool](reports/execute-tool-span.md) | langchain, openai-agents |
+
+### Events
+
+| Event | Libraries |
+| --- | --- |
+| [Inference Operation Details](reports/gen-ai-client-inference-operation-details-event.md) | google-genai |
+| [Evaluation Result](reports/gen-ai-evaluation-result-event.md) | (none) |
+<!-- status:end -->

--- a/docs/conformance/README.md
+++ b/docs/conformance/README.md
@@ -42,7 +42,7 @@ that pin can change these pages.
 | [Invoke Agent Internal](reports/invoke-agent-internal-span.md) | langchain, openai-agents |
 | [Invoke Workflow](reports/invoke-workflow-span.md) | langchain, openai-agents |
 | [Plan](reports/plan-span.md) | (none) |
-| [Inference](reports/inference-span.md) | anthropic, crewai, google-genai, langchain, openai |
+| [Inference](reports/inference-span.md) | anthropic, google-genai, langchain, openai |
 | [Embeddings](reports/embeddings-span.md) | google-genai, openai |
 | [Retrieval](reports/retrieval-span.md) | (none) |
 | [Memory](reports/memory-span.md) | (none) |

--- a/docs/conformance/reports/create-agent-span.md
+++ b/docs/conformance/reports/create-agent-span.md
@@ -1,0 +1,33 @@
+# Create Agent Span
+
+> **[Semantic Convention](https://github.com/open-telemetry/semantic-conventions-genai/blob/528c45308c35c4d0cc31d386238908b4a1e7fd8f/docs/gen-ai/gen-ai-agent-spans.md#create-agent-span)**
+
+## Required
+
+| Attribute | Supporting Libraries |
+| --- | --- |
+| gen_ai.operation.name | (none) |
+| gen_ai.provider.name | (none) |
+
+## Conditionally Required
+
+| Attribute | Supporting Libraries |
+| --- | --- |
+| gen_ai.agent.description | (none) |
+| gen_ai.agent.id | (none) |
+| gen_ai.agent.name | (none) |
+| gen_ai.agent.version | (none) |
+| gen_ai.request.model | (none) |
+| server.port | (none) |
+
+## Recommended
+
+| Attribute | Supporting Libraries |
+| --- | --- |
+| server.address | (none) |
+
+## Opt-In
+
+| Attribute | Supporting Libraries |
+| --- | --- |
+| gen_ai.system_instructions | (none) |

--- a/docs/conformance/reports/embeddings-span.md
+++ b/docs/conformance/reports/embeddings-span.md
@@ -1,0 +1,30 @@
+# Embeddings Span
+
+> **[Semantic Convention](https://github.com/open-telemetry/semantic-conventions-genai/blob/528c45308c35c4d0cc31d386238908b4a1e7fd8f/docs/gen-ai/gen-ai-spans.md#embeddings)**
+
+## Required
+
+| Attribute | Supporting Libraries |
+| --- | --- |
+| gen_ai.operation.name | [google-genai], [openai] |
+| gen_ai.provider.name | [google-genai], [openai] |
+
+## Conditionally Required
+
+| Attribute | Supporting Libraries |
+| --- | --- |
+| gen_ai.request.model | [google-genai], [openai] |
+| server.port | (none) |
+
+## Recommended
+
+| Attribute | Supporting Libraries |
+| --- | --- |
+| gen_ai.embeddings.dimension.count | [google-genai], [openai] |
+| gen_ai.request.encoding_formats | (none) |
+| gen_ai.response.model | [openai] |
+| gen_ai.usage.input_tokens | [google-genai], [openai] |
+| server.address | [google-genai], [openai] |
+
+[google-genai]: ../../../instrumentation/opentelemetry-instrumentation-google-genai/tests/conformance
+[openai]: ../../../instrumentation/opentelemetry-instrumentation-genai-openai/tests/conformance

--- a/docs/conformance/reports/execute-tool-span.md
+++ b/docs/conformance/reports/execute-tool-span.md
@@ -1,0 +1,28 @@
+# Execute Tool Span
+
+> **[Semantic Convention](https://github.com/open-telemetry/semantic-conventions-genai/blob/528c45308c35c4d0cc31d386238908b4a1e7fd8f/docs/gen-ai/gen-ai-spans.md#execute-tool-span)**
+
+## Required
+
+| Attribute | Supporting Libraries |
+| --- | --- |
+| gen_ai.operation.name | [langchain], [openai-agents] |
+| gen_ai.tool.name | [langchain], [openai-agents] |
+
+## Recommended
+
+| Attribute | Supporting Libraries |
+| --- | --- |
+| gen_ai.tool.call.id | [langchain] |
+| gen_ai.tool.description | [langchain] |
+| gen_ai.tool.type | [langchain], [openai-agents] |
+
+## Opt-In
+
+| Attribute | Supporting Libraries |
+| --- | --- |
+| gen_ai.tool.call.arguments | [langchain] |
+| gen_ai.tool.call.result | [langchain], [openai-agents] |
+
+[langchain]: ../../../instrumentation/opentelemetry-instrumentation-genai-langchain/tests/conformance
+[openai-agents]: ../../../instrumentation/opentelemetry-instrumentation-genai-openai-agents/tests/conformance

--- a/docs/conformance/reports/gen-ai-client-inference-operation-details-event.md
+++ b/docs/conformance/reports/gen-ai-client-inference-operation-details-event.md
@@ -1,0 +1,56 @@
+# Inference Operation Details Event
+
+> **[Semantic Convention](https://github.com/open-telemetry/semantic-conventions-genai/blob/528c45308c35c4d0cc31d386238908b4a1e7fd8f/docs/gen-ai/gen-ai-events.md#event-gen_aiclientinferenceoperationdetails)**
+
+## Required
+
+| Attribute | Supporting Libraries |
+| --- | --- |
+| gen_ai.operation.name | [google-genai] |
+| gen_ai.provider.name | [google-genai] |
+
+## Conditionally Required
+
+| Attribute | Supporting Libraries |
+| --- | --- |
+| gen_ai.conversation.id | (none) |
+| gen_ai.output.type | (none) |
+| gen_ai.request.choice.count | (none) |
+| gen_ai.request.model | [google-genai] |
+| gen_ai.request.seed | (none) |
+| gen_ai.request.stream | (none) |
+| gen_ai.request.top_k | (none) |
+| server.port | (none) |
+
+## Recommended
+
+| Attribute | Supporting Libraries |
+| --- | --- |
+| gen_ai.conversation.compacted | (none) |
+| gen_ai.request.frequency_penalty | (none) |
+| gen_ai.request.max_tokens | (none) |
+| gen_ai.request.presence_penalty | (none) |
+| gen_ai.request.stop_sequences | (none) |
+| gen_ai.request.temperature | (none) |
+| gen_ai.request.top_p | (none) |
+| gen_ai.response.finish_reasons | [google-genai] |
+| gen_ai.response.id | [google-genai] |
+| gen_ai.response.model | [google-genai] |
+| gen_ai.response.time_to_first_chunk | (none) |
+| gen_ai.usage.cache_creation.input_tokens | (none) |
+| gen_ai.usage.cache_read.input_tokens | [google-genai] |
+| gen_ai.usage.input_tokens | [google-genai] |
+| gen_ai.usage.output_tokens | [google-genai] |
+| gen_ai.usage.reasoning.output_tokens | [google-genai] |
+| server.address | [google-genai] |
+
+## Opt-In
+
+| Attribute | Supporting Libraries |
+| --- | --- |
+| gen_ai.input.messages | (none) |
+| gen_ai.output.messages | (none) |
+| gen_ai.system_instructions | (none) |
+| gen_ai.tool.definitions | [google-genai] |
+
+[google-genai]: ../../../instrumentation/opentelemetry-instrumentation-google-genai/tests/conformance

--- a/docs/conformance/reports/gen-ai-evaluation-result-event.md
+++ b/docs/conformance/reports/gen-ai-evaluation-result-event.md
@@ -1,0 +1,23 @@
+# Evaluation Result Event
+
+> **[Semantic Convention](https://github.com/open-telemetry/semantic-conventions-genai/blob/528c45308c35c4d0cc31d386238908b4a1e7fd8f/docs/gen-ai/gen-ai-events.md#event-gen_aievaluationresult)**
+
+## Required
+
+| Attribute | Supporting Libraries |
+| --- | --- |
+| gen_ai.evaluation.name | (none) |
+
+## Conditionally Required
+
+| Attribute | Supporting Libraries |
+| --- | --- |
+| gen_ai.evaluation.score.label | (none) |
+| gen_ai.evaluation.score.value | (none) |
+
+## Recommended
+
+| Attribute | Supporting Libraries |
+| --- | --- |
+| gen_ai.evaluation.explanation | (none) |
+| gen_ai.response.id | (none) |

--- a/docs/conformance/reports/inference-span.md
+++ b/docs/conformance/reports/inference-span.md
@@ -6,17 +6,17 @@
 
 | Attribute | Supporting Libraries |
 | --- | --- |
-| gen_ai.operation.name | [anthropic], [crewai], [google-genai], [langchain], [openai] |
-| gen_ai.provider.name | [anthropic], [crewai], [google-genai], [langchain], [openai] |
+| gen_ai.operation.name | [anthropic], [google-genai], [langchain], [openai] |
+| gen_ai.provider.name | [anthropic], [google-genai], [langchain], [openai] |
 
 ## Conditionally Required
 
 | Attribute | Supporting Libraries |
 | --- | --- |
 | gen_ai.conversation.id | (none) |
-| gen_ai.output.type | [crewai] |
+| gen_ai.output.type | (none) |
 | gen_ai.request.choice.count | (none) |
-| gen_ai.request.model | [anthropic], [crewai], [google-genai], [langchain], [openai] |
+| gen_ai.request.model | [anthropic], [google-genai], [langchain], [openai] |
 | gen_ai.request.seed | [langchain] |
 | gen_ai.request.stream | (none) |
 | gen_ai.request.top_k | (none) |
@@ -33,28 +33,27 @@
 | gen_ai.request.stop_sequences | [langchain] |
 | gen_ai.request.temperature | [langchain] |
 | gen_ai.request.top_p | [langchain] |
-| gen_ai.response.finish_reasons | [anthropic], [crewai], [google-genai], [langchain], [openai] |
-| gen_ai.response.id | [anthropic], [crewai], [google-genai], [langchain], [openai] |
-| gen_ai.response.model | [anthropic], [crewai], [google-genai], [langchain], [openai] |
+| gen_ai.response.finish_reasons | [anthropic], [google-genai], [langchain], [openai] |
+| gen_ai.response.id | [anthropic], [google-genai], [langchain], [openai] |
+| gen_ai.response.model | [anthropic], [google-genai], [langchain], [openai] |
 | gen_ai.response.time_to_first_chunk | (none) |
 | gen_ai.usage.cache_creation.input_tokens | [anthropic] |
 | gen_ai.usage.cache_read.input_tokens | [anthropic], [openai] |
-| gen_ai.usage.input_tokens | [anthropic], [crewai], [google-genai], [langchain], [openai] |
-| gen_ai.usage.output_tokens | [anthropic], [crewai], [google-genai], [langchain], [openai] |
+| gen_ai.usage.input_tokens | [anthropic], [google-genai], [langchain], [openai] |
+| gen_ai.usage.output_tokens | [anthropic], [google-genai], [langchain], [openai] |
 | gen_ai.usage.reasoning.output_tokens | [google-genai] |
-| server.address | [anthropic], [crewai], [google-genai], [openai] |
+| server.address | [anthropic], [google-genai], [openai] |
 
 ## Opt-In
 
 | Attribute | Supporting Libraries |
 | --- | --- |
-| gen_ai.input.messages | [anthropic], [crewai], [google-genai], [langchain], [openai] |
-| gen_ai.output.messages | [anthropic], [crewai], [google-genai], [langchain], [openai] |
+| gen_ai.input.messages | [anthropic], [google-genai], [langchain], [openai] |
+| gen_ai.output.messages | [anthropic], [google-genai], [langchain], [openai] |
 | gen_ai.system_instructions | [openai] |
-| gen_ai.tool.definitions | [crewai], [google-genai], [langchain], [openai] |
+| gen_ai.tool.definitions | [google-genai], [langchain], [openai] |
 
 [anthropic]: ../../../instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/conformance
-[crewai]: ../../../instrumentation/opentelemetry-instrumentation-genai-crewai/tests/conformance
 [google-genai]: ../../../instrumentation/opentelemetry-instrumentation-google-genai/tests/conformance
 [langchain]: ../../../instrumentation/opentelemetry-instrumentation-genai-langchain/tests/conformance
 [openai]: ../../../instrumentation/opentelemetry-instrumentation-genai-openai/tests/conformance

--- a/docs/conformance/reports/inference-span.md
+++ b/docs/conformance/reports/inference-span.md
@@ -1,0 +1,60 @@
+# Inference Span
+
+> **[Semantic Convention](https://github.com/open-telemetry/semantic-conventions-genai/blob/528c45308c35c4d0cc31d386238908b4a1e7fd8f/docs/gen-ai/gen-ai-spans.md#inference)**
+
+## Required
+
+| Attribute | Supporting Libraries |
+| --- | --- |
+| gen_ai.operation.name | [anthropic], [crewai], [google-genai], [langchain], [openai] |
+| gen_ai.provider.name | [anthropic], [crewai], [google-genai], [langchain], [openai] |
+
+## Conditionally Required
+
+| Attribute | Supporting Libraries |
+| --- | --- |
+| gen_ai.conversation.id | (none) |
+| gen_ai.output.type | [crewai] |
+| gen_ai.request.choice.count | (none) |
+| gen_ai.request.model | [anthropic], [crewai], [google-genai], [langchain], [openai] |
+| gen_ai.request.seed | [langchain] |
+| gen_ai.request.stream | (none) |
+| gen_ai.request.top_k | (none) |
+| server.port | (none) |
+
+## Recommended
+
+| Attribute | Supporting Libraries |
+| --- | --- |
+| gen_ai.conversation.compacted | (none) |
+| gen_ai.request.frequency_penalty | [langchain] |
+| gen_ai.request.max_tokens | [anthropic], [langchain] |
+| gen_ai.request.presence_penalty | [langchain] |
+| gen_ai.request.stop_sequences | [langchain] |
+| gen_ai.request.temperature | [langchain] |
+| gen_ai.request.top_p | [langchain] |
+| gen_ai.response.finish_reasons | [anthropic], [crewai], [google-genai], [langchain], [openai] |
+| gen_ai.response.id | [anthropic], [crewai], [google-genai], [langchain], [openai] |
+| gen_ai.response.model | [anthropic], [crewai], [google-genai], [langchain], [openai] |
+| gen_ai.response.time_to_first_chunk | (none) |
+| gen_ai.usage.cache_creation.input_tokens | [anthropic] |
+| gen_ai.usage.cache_read.input_tokens | [anthropic], [openai] |
+| gen_ai.usage.input_tokens | [anthropic], [crewai], [google-genai], [langchain], [openai] |
+| gen_ai.usage.output_tokens | [anthropic], [crewai], [google-genai], [langchain], [openai] |
+| gen_ai.usage.reasoning.output_tokens | [google-genai] |
+| server.address | [anthropic], [crewai], [google-genai], [openai] |
+
+## Opt-In
+
+| Attribute | Supporting Libraries |
+| --- | --- |
+| gen_ai.input.messages | [anthropic], [crewai], [google-genai], [langchain], [openai] |
+| gen_ai.output.messages | [anthropic], [crewai], [google-genai], [langchain], [openai] |
+| gen_ai.system_instructions | [openai] |
+| gen_ai.tool.definitions | [crewai], [google-genai], [langchain], [openai] |
+
+[anthropic]: ../../../instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/conformance
+[crewai]: ../../../instrumentation/opentelemetry-instrumentation-genai-crewai/tests/conformance
+[google-genai]: ../../../instrumentation/opentelemetry-instrumentation-google-genai/tests/conformance
+[langchain]: ../../../instrumentation/opentelemetry-instrumentation-genai-langchain/tests/conformance
+[openai]: ../../../instrumentation/opentelemetry-instrumentation-genai-openai/tests/conformance

--- a/docs/conformance/reports/invoke-agent-client-span.md
+++ b/docs/conformance/reports/invoke-agent-client-span.md
@@ -1,0 +1,52 @@
+# Invoke Agent Client Span
+
+> **[Semantic Convention](https://github.com/open-telemetry/semantic-conventions-genai/blob/528c45308c35c4d0cc31d386238908b4a1e7fd8f/docs/gen-ai/gen-ai-agent-spans.md#invoke-agent-client-span)**
+
+## Required
+
+| Attribute | Supporting Libraries |
+| --- | --- |
+| gen_ai.operation.name | (none) |
+| gen_ai.provider.name | (none) |
+
+## Conditionally Required
+
+| Attribute | Supporting Libraries |
+| --- | --- |
+| gen_ai.agent.description | (none) |
+| gen_ai.agent.id | (none) |
+| gen_ai.agent.name | (none) |
+| gen_ai.agent.version | (none) |
+| gen_ai.conversation.id | (none) |
+| gen_ai.data_source.id | (none) |
+| gen_ai.output.type | (none) |
+| gen_ai.request.choice.count | (none) |
+| gen_ai.request.model | (none) |
+| gen_ai.request.seed | (none) |
+| server.port | (none) |
+
+## Recommended
+
+| Attribute | Supporting Libraries |
+| --- | --- |
+| gen_ai.request.frequency_penalty | (none) |
+| gen_ai.request.max_tokens | (none) |
+| gen_ai.request.presence_penalty | (none) |
+| gen_ai.request.stop_sequences | (none) |
+| gen_ai.request.temperature | (none) |
+| gen_ai.request.top_p | (none) |
+| gen_ai.response.finish_reasons | (none) |
+| gen_ai.usage.cache_creation.input_tokens | (none) |
+| gen_ai.usage.cache_read.input_tokens | (none) |
+| gen_ai.usage.input_tokens | (none) |
+| gen_ai.usage.output_tokens | (none) |
+| server.address | (none) |
+
+## Opt-In
+
+| Attribute | Supporting Libraries |
+| --- | --- |
+| gen_ai.input.messages | (none) |
+| gen_ai.output.messages | (none) |
+| gen_ai.system_instructions | (none) |
+| gen_ai.tool.definitions | (none) |

--- a/docs/conformance/reports/invoke-agent-internal-span.md
+++ b/docs/conformance/reports/invoke-agent-internal-span.md
@@ -1,0 +1,51 @@
+# Invoke Agent Internal Span
+
+> **[Semantic Convention](https://github.com/open-telemetry/semantic-conventions-genai/blob/528c45308c35c4d0cc31d386238908b4a1e7fd8f/docs/gen-ai/gen-ai-agent-spans.md#invoke-agent-internal-span)**
+
+## Required
+
+| Attribute | Supporting Libraries |
+| --- | --- |
+| gen_ai.operation.name | [langchain], [openai-agents] |
+
+## Conditionally Required
+
+| Attribute | Supporting Libraries |
+| --- | --- |
+| gen_ai.agent.description | (none) |
+| gen_ai.agent.name | [langchain], [openai-agents] |
+| gen_ai.agent.version | (none) |
+| gen_ai.conversation.id | [langchain] |
+| gen_ai.data_source.id | (none) |
+| gen_ai.output.type | (none) |
+| gen_ai.request.choice.count | (none) |
+| gen_ai.request.model | (none) |
+| gen_ai.request.seed | (none) |
+
+## Recommended
+
+| Attribute | Supporting Libraries |
+| --- | --- |
+| gen_ai.request.frequency_penalty | (none) |
+| gen_ai.request.max_tokens | (none) |
+| gen_ai.request.presence_penalty | (none) |
+| gen_ai.request.stop_sequences | (none) |
+| gen_ai.request.temperature | (none) |
+| gen_ai.request.top_p | (none) |
+| gen_ai.response.finish_reasons | (none) |
+| gen_ai.usage.cache_creation.input_tokens | (none) |
+| gen_ai.usage.cache_read.input_tokens | (none) |
+| gen_ai.usage.input_tokens | (none) |
+| gen_ai.usage.output_tokens | (none) |
+
+## Opt-In
+
+| Attribute | Supporting Libraries |
+| --- | --- |
+| gen_ai.input.messages | [langchain] |
+| gen_ai.output.messages | [langchain] |
+| gen_ai.system_instructions | (none) |
+| gen_ai.tool.definitions | (none) |
+
+[langchain]: ../../../instrumentation/opentelemetry-instrumentation-genai-langchain/tests/conformance
+[openai-agents]: ../../../instrumentation/opentelemetry-instrumentation-genai-openai-agents/tests/conformance

--- a/docs/conformance/reports/invoke-workflow-span.md
+++ b/docs/conformance/reports/invoke-workflow-span.md
@@ -1,0 +1,25 @@
+# Invoke Workflow Span
+
+> **[Semantic Convention](https://github.com/open-telemetry/semantic-conventions-genai/blob/528c45308c35c4d0cc31d386238908b4a1e7fd8f/docs/gen-ai/gen-ai-agent-spans.md#invoke-workflow-span)**
+
+## Required
+
+| Attribute | Supporting Libraries |
+| --- | --- |
+| gen_ai.operation.name | [langchain], [openai-agents] |
+
+## Conditionally Required
+
+| Attribute | Supporting Libraries |
+| --- | --- |
+| gen_ai.workflow.name | [langchain], [openai-agents] |
+
+## Opt-In
+
+| Attribute | Supporting Libraries |
+| --- | --- |
+| gen_ai.input.messages | [langchain] |
+| gen_ai.output.messages | [langchain] |
+
+[langchain]: ../../../instrumentation/opentelemetry-instrumentation-genai-langchain/tests/conformance
+[openai-agents]: ../../../instrumentation/opentelemetry-instrumentation-genai-openai-agents/tests/conformance

--- a/docs/conformance/reports/memory-span.md
+++ b/docs/conformance/reports/memory-span.md
@@ -1,0 +1,32 @@
+# Memory Span
+
+> **[Semantic Convention](https://github.com/open-telemetry/semantic-conventions-genai/blob/528c45308c35c4d0cc31d386238908b4a1e7fd8f/docs/gen-ai/gen-ai-spans.md#memory)**
+
+## Required
+
+| Attribute | Supporting Libraries |
+| --- | --- |
+| gen_ai.operation.name | (none) |
+
+## Conditionally Required
+
+| Attribute | Supporting Libraries |
+| --- | --- |
+| gen_ai.memory.record.id | (none) |
+| gen_ai.memory.store.id | (none) |
+| gen_ai.provider.name | (none) |
+| server.port | (none) |
+
+## Recommended
+
+| Attribute | Supporting Libraries |
+| --- | --- |
+| gen_ai.memory.record.count | (none) |
+| server.address | (none) |
+
+## Opt-In
+
+| Attribute | Supporting Libraries |
+| --- | --- |
+| gen_ai.memory.query.text | (none) |
+| gen_ai.memory.records | (none) |

--- a/docs/conformance/reports/plan-span.md
+++ b/docs/conformance/reports/plan-span.md
@@ -1,0 +1,15 @@
+# Plan Span
+
+> **[Semantic Convention](https://github.com/open-telemetry/semantic-conventions-genai/blob/528c45308c35c4d0cc31d386238908b4a1e7fd8f/docs/gen-ai/gen-ai-agent-spans.md#plan-span)**
+
+## Required
+
+| Attribute | Supporting Libraries |
+| --- | --- |
+| gen_ai.operation.name | (none) |
+
+## Conditionally Required
+
+| Attribute | Supporting Libraries |
+| --- | --- |
+| gen_ai.agent.name | (none) |

--- a/docs/conformance/reports/retrieval-span.md
+++ b/docs/conformance/reports/retrieval-span.md
@@ -1,0 +1,32 @@
+# Retrieval Span
+
+> **[Semantic Convention](https://github.com/open-telemetry/semantic-conventions-genai/blob/528c45308c35c4d0cc31d386238908b4a1e7fd8f/docs/gen-ai/gen-ai-spans.md#retrievals)**
+
+## Required
+
+| Attribute | Supporting Libraries |
+| --- | --- |
+| gen_ai.operation.name | (none) |
+
+## Conditionally Required
+
+| Attribute | Supporting Libraries |
+| --- | --- |
+| gen_ai.data_source.id | (none) |
+| gen_ai.provider.name | (none) |
+| gen_ai.request.model | (none) |
+| server.port | (none) |
+
+## Recommended
+
+| Attribute | Supporting Libraries |
+| --- | --- |
+| gen_ai.retrieval.top_k | (none) |
+| server.address | (none) |
+
+## Opt-In
+
+| Attribute | Supporting Libraries |
+| --- | --- |
+| gen_ai.retrieval.documents | (none) |
+| gen_ai.retrieval.query.text | (none) |

--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/conformance/data.json
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/conformance/data.json
@@ -1,0 +1,20 @@
+{
+  "spans": {
+    "inference": [
+      "gen_ai.input.messages",
+      "gen_ai.operation.name",
+      "gen_ai.output.messages",
+      "gen_ai.provider.name",
+      "gen_ai.request.max_tokens",
+      "gen_ai.request.model",
+      "gen_ai.response.finish_reasons",
+      "gen_ai.response.id",
+      "gen_ai.response.model",
+      "gen_ai.usage.cache_creation.input_tokens",
+      "gen_ai.usage.cache_read.input_tokens",
+      "gen_ai.usage.input_tokens",
+      "gen_ai.usage.output_tokens",
+      "server.address"
+    ]
+  }
+}

--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/tests/conformance/data.json
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/tests/conformance/data.json
@@ -1,0 +1,46 @@
+{
+  "spans": {
+    "execute_tool": [
+      "gen_ai.operation.name",
+      "gen_ai.tool.call.arguments",
+      "gen_ai.tool.call.id",
+      "gen_ai.tool.call.result",
+      "gen_ai.tool.description",
+      "gen_ai.tool.name",
+      "gen_ai.tool.type"
+    ],
+    "inference": [
+      "gen_ai.input.messages",
+      "gen_ai.operation.name",
+      "gen_ai.output.messages",
+      "gen_ai.provider.name",
+      "gen_ai.request.frequency_penalty",
+      "gen_ai.request.max_tokens",
+      "gen_ai.request.model",
+      "gen_ai.request.presence_penalty",
+      "gen_ai.request.seed",
+      "gen_ai.request.stop_sequences",
+      "gen_ai.request.temperature",
+      "gen_ai.request.top_p",
+      "gen_ai.response.finish_reasons",
+      "gen_ai.response.id",
+      "gen_ai.response.model",
+      "gen_ai.tool.definitions",
+      "gen_ai.usage.input_tokens",
+      "gen_ai.usage.output_tokens"
+    ],
+    "invoke_agent_internal": [
+      "gen_ai.agent.name",
+      "gen_ai.conversation.id",
+      "gen_ai.input.messages",
+      "gen_ai.operation.name",
+      "gen_ai.output.messages"
+    ],
+    "invoke_workflow": [
+      "gen_ai.input.messages",
+      "gen_ai.operation.name",
+      "gen_ai.output.messages",
+      "gen_ai.workflow.name"
+    ]
+  }
+}

--- a/instrumentation/opentelemetry-instrumentation-genai-openai-agents/tests/conformance/data.json
+++ b/instrumentation/opentelemetry-instrumentation-genai-openai-agents/tests/conformance/data.json
@@ -1,0 +1,18 @@
+{
+  "spans": {
+    "execute_tool": [
+      "gen_ai.operation.name",
+      "gen_ai.tool.call.result",
+      "gen_ai.tool.name",
+      "gen_ai.tool.type"
+    ],
+    "invoke_agent_internal": [
+      "gen_ai.agent.name",
+      "gen_ai.operation.name"
+    ],
+    "invoke_workflow": [
+      "gen_ai.operation.name",
+      "gen_ai.workflow.name"
+    ]
+  }
+}

--- a/instrumentation/opentelemetry-instrumentation-genai-openai/tests/conformance/data.json
+++ b/instrumentation/opentelemetry-instrumentation-genai-openai/tests/conformance/data.json
@@ -1,0 +1,29 @@
+{
+  "spans": {
+    "embeddings": [
+      "gen_ai.embeddings.dimension.count",
+      "gen_ai.operation.name",
+      "gen_ai.provider.name",
+      "gen_ai.request.model",
+      "gen_ai.response.model",
+      "gen_ai.usage.input_tokens",
+      "server.address"
+    ],
+    "inference": [
+      "gen_ai.input.messages",
+      "gen_ai.operation.name",
+      "gen_ai.output.messages",
+      "gen_ai.provider.name",
+      "gen_ai.request.model",
+      "gen_ai.response.finish_reasons",
+      "gen_ai.response.id",
+      "gen_ai.response.model",
+      "gen_ai.system_instructions",
+      "gen_ai.tool.definitions",
+      "gen_ai.usage.cache_read.input_tokens",
+      "gen_ai.usage.input_tokens",
+      "gen_ai.usage.output_tokens",
+      "server.address"
+    ]
+  }
+}

--- a/instrumentation/opentelemetry-instrumentation-google-genai/tests/conformance/data.json
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/tests/conformance/data.json
@@ -1,0 +1,43 @@
+{
+  "events": {
+    "gen_ai.client.inference.operation.details": [
+      "gen_ai.operation.name",
+      "gen_ai.provider.name",
+      "gen_ai.request.model",
+      "gen_ai.response.finish_reasons",
+      "gen_ai.response.id",
+      "gen_ai.response.model",
+      "gen_ai.tool.definitions",
+      "gen_ai.usage.cache_read.input_tokens",
+      "gen_ai.usage.input_tokens",
+      "gen_ai.usage.output_tokens",
+      "gen_ai.usage.reasoning.output_tokens",
+      "server.address"
+    ]
+  },
+  "spans": {
+    "embeddings": [
+      "gen_ai.embeddings.dimension.count",
+      "gen_ai.operation.name",
+      "gen_ai.provider.name",
+      "gen_ai.request.model",
+      "gen_ai.usage.input_tokens",
+      "server.address"
+    ],
+    "inference": [
+      "gen_ai.input.messages",
+      "gen_ai.operation.name",
+      "gen_ai.output.messages",
+      "gen_ai.provider.name",
+      "gen_ai.request.model",
+      "gen_ai.response.finish_reasons",
+      "gen_ai.response.id",
+      "gen_ai.response.model",
+      "gen_ai.tool.definitions",
+      "gen_ai.usage.input_tokens",
+      "gen_ai.usage.output_tokens",
+      "gen_ai.usage.reasoning.output_tokens",
+      "server.address"
+    ]
+  }
+}

--- a/scripts/update_conformance_reports.py
+++ b/scripts/update_conformance_reports.py
@@ -3,17 +3,12 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Render semconv coverage reports from committed conformance data.
+"""Render semconv coverage reports from the committed conformance data.
 
-Reads every ``instrumentation/<pkg>/tests/conformance/data.json`` written by
-the conformance runs and renders the report pages under
-``docs/conformance/reports/`` plus an index in ``docs/conformance/README.md``.
-
-The rendering itself is ``semconv_genai.report`` from the pinned
-semantic-conventions-genai checkout, so the pages match the ones that repo
-publishes and follow its layout changes for free. Only two things there are
-bound to its own ``scenarios/<lib>/`` layout, and both are redirected below:
-where library data is loaded from, and what a library links to.
+Renders ``docs/conformance/`` from every
+``instrumentation/<pkg>/tests/conformance/data.json``, using
+``semconv_genai.report`` from the pinned semantic-conventions-genai checkout so
+the pages match the ones that repo publishes.
 
 Usage::
 
@@ -37,8 +32,8 @@ from opentelemetry.test_util_genai._setup_weaver import (
 
 DATA_FILES_GLOB = "instrumentation/*/tests/conformance/data.json"
 
-# Upstream links its report pages at the semconv docs sitting next to them in
-# its own tree; we have no local copy, so point at the pinned revision.
+# Upstream links the semconv docs sitting next to its reports; we have no local
+# copy, so these get rewritten to the pinned revision on GitHub.
 UPSTREAM_DOCS_PREFIX = "](../../docs/"
 
 
@@ -57,7 +52,6 @@ def _conformance_dirs() -> dict[str, Path]:
 
 
 def _load_entries() -> list[Any]:
-    """Load every package's conformance data as upstream ``ScenarioDataEntry``."""
     entries = []
     for data_file in sorted(_workspace_root().glob(DATA_FILES_GLOB)):
         library = _library_name(data_file.parents[2])
@@ -75,9 +69,9 @@ def _semconv_docs_url() -> str:
 
 
 def _report_module(conformance_dirs: dict[str, Path]) -> Any:
-    """Import upstream's renderer with our data sources bound into it.
+    """Import upstream's renderer, redirected at our layout.
 
-    Both patches must land before ``semconv_genai.report`` is imported: it
+    Both rebinds must land before ``semconv_genai.report`` is imported: it
     pulls the two names in by value, so patching afterwards has no effect.
     """
     tooling = reference_tooling()

--- a/scripts/update_conformance_reports.py
+++ b/scripts/update_conformance_reports.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Render semconv coverage reports from committed conformance data.
+
+Reads every ``instrumentation/<pkg>/tests/conformance/data.json`` written by
+the conformance runs and renders the report pages under
+``docs/conformance/reports/`` plus an index in ``docs/conformance/README.md``.
+
+The rendering itself is ``semconv_genai.report`` from the pinned
+semantic-conventions-genai checkout, so the pages match the ones that repo
+publishes and follow its layout changes for free. Only two things there are
+bound to its own ``scenarios/<lib>/`` layout, and both are redirected below:
+where library data is loaded from, and what a library links to.
+
+Usage::
+
+    uv run python scripts/update_conformance_reports.py
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from opentelemetry.test_util_genai._semconv_reference import (
+    load_scenario_data,
+    reference_tooling,
+)
+from opentelemetry.test_util_genai._setup_weaver import (
+    _load_version_pins,
+    _workspace_root,
+)
+
+DATA_FILES_GLOB = "instrumentation/*/tests/conformance/data.json"
+
+# Upstream links its report pages at the semconv docs sitting next to them in
+# its own tree; we have no local copy, so point at the pinned revision.
+UPSTREAM_DOCS_PREFIX = "](../../docs/"
+
+
+def _library_name(package_dir: Path) -> str:
+    name = package_dir.name
+    for prefix in ("opentelemetry-instrumentation-", "genai-"):
+        name = name.removeprefix(prefix)
+    return name
+
+
+def _conformance_dirs() -> dict[str, Path]:
+    return {
+        _library_name(p.parents[2]): p.parent
+        for p in _workspace_root().glob(DATA_FILES_GLOB)
+    }
+
+
+def _load_entries() -> list[Any]:
+    """Load every package's conformance data as upstream ``ScenarioDataEntry``."""
+    entries = []
+    for data_file in sorted(_workspace_root().glob(DATA_FILES_GLOB)):
+        library = _library_name(data_file.parents[2])
+        data = json.loads(data_file.read_text(encoding="utf-8"))
+        entries.append(load_scenario_data(data, library))
+    return entries
+
+
+def _semconv_docs_url() -> str:
+    pins = _load_version_pins(_workspace_root() / "versions.env")
+    return (
+        "](https://github.com/open-telemetry/semantic-conventions-genai/blob/"
+        f"{pins['SEMCONV_GENAI_REF']}/docs/"
+    )
+
+
+def _report_module(conformance_dirs: dict[str, Path]) -> Any:
+    """Import upstream's renderer with our data sources bound into it.
+
+    Both patches must land before ``semconv_genai.report`` is imported: it
+    pulls the two names in by value, so patching afterwards has no effect.
+    """
+    tooling = reference_tooling()
+    import semconv_genai  # noqa: PLC0415
+
+    semconv_genai.reference_scenario_file = conformance_dirs.__getitem__
+    tooling.data_files.load_scenario_data_files = _load_entries
+
+    from semconv_genai import report  # noqa: PLC0415
+
+    return report
+
+
+def main() -> None:
+    conformance_dirs = _conformance_dirs()
+    report = _report_module(conformance_dirs)
+
+    docs_dir = _workspace_root() / "docs" / "conformance"
+    report.write_status_report(docs_dir / "README.md")
+
+    rendered = {
+        report._report_filename(type_key, kind)  # noqa: SLF001
+        for kind, type_order in (
+            ("span", report.SPAN_TYPE_ORDER),
+            ("event", report.EVENT_TYPE_ORDER),
+            ("metric", getattr(report, "METRIC_TYPE_ORDER", ())),
+        )
+        for type_key in type_order
+    }
+
+    docs_url = _semconv_docs_url()
+    for page in sorted((docs_dir / "reports").glob("*.md")):
+        if page.name not in rendered:
+            page.unlink()
+            continue
+        page.write_text(
+            page.read_text(encoding="utf-8").replace(
+                UPSTREAM_DOCS_PREFIX, docs_url
+            ),
+            encoding="utf-8",
+        )
+
+    print(f"Wrote {len(rendered)} report pages under {docs_dir / 'reports'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/util/opentelemetry-test-util-genai/src/opentelemetry/test_util_genai/_semconv_reference.py
+++ b/util/opentelemetry-test-util-genai/src/opentelemetry/test_util_genai/_semconv_reference.py
@@ -9,11 +9,6 @@ generates the upstream coverage reports under ``reference/src/semconv_genai``.
 Importing it from there keeps span classification and semconv requirement
 levels in lockstep with the registry weaver validates against, instead of
 duplicating them here.
-
-Upstream's own entry points (``load_scenario_data_files``,
-``write_generated_scenario_data``, ``report``) are bound to its
-``scenarios/<lib>/`` layout, so we use the lower-level helpers and supply our
-own paths.
 """
 
 from __future__ import annotations
@@ -29,13 +24,9 @@ from opentelemetry.test_util_genai._setup_weaver import _provision_genai_root
 
 @dataclass(frozen=True)
 class ReferenceTooling:
-    """The upstream modules used to build and render coverage reports."""
-
-    attribute_spec: ModuleType
     classify: ModuleType
     data_files: ModuleType
     parse_results: ModuleType
-    semconv_model: ModuleType
 
 
 _tooling: ReferenceTooling | None = None
@@ -57,23 +48,21 @@ def reference_tooling() -> ReferenceTooling:
     if str(src) not in sys.path:
         sys.path.insert(0, str(src))
 
-    import semconv_genai.attribute_spec as attribute_spec  # noqa: PLC0415
     import semconv_genai.classify as classify  # noqa: PLC0415
     import semconv_genai.data_files as data_files  # noqa: PLC0415
     import semconv_genai.parse_results as parse_results  # noqa: PLC0415
-    import semconv_genai.semconv_model as semconv_model  # noqa: PLC0415
 
     _tooling = ReferenceTooling(
-        attribute_spec=attribute_spec,
         classify=classify,
         data_files=data_files,
         parse_results=parse_results,
-        semconv_model=semconv_model,
     )
     return _tooling
 
 
-def build_scenario_data(weaver_reports_dir: Path, library: str) -> dict[str, Any]:
+def build_scenario_data(
+    weaver_reports_dir: Path, library: str
+) -> dict[str, Any]:
     """Reduce a library's weaver live-check reports to a ``data.json`` payload."""
     tooling = reference_tooling()
     result = tooling.parse_results.parse_result_dir(

--- a/util/opentelemetry-test-util-genai/src/opentelemetry/test_util_genai/_semconv_reference.py
+++ b/util/opentelemetry-test-util-genai/src/opentelemetry/test_util_genai/_semconv_reference.py
@@ -1,0 +1,93 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Access the ``semconv_genai`` report tooling from the pinned genai registry.
+
+``_setup_weaver`` already downloads the whole ``semantic-conventions-genai``
+repo at the SHA pinned in ``versions.env``, which ships the tooling that
+generates the upstream coverage reports under ``reference/src/semconv_genai``.
+Importing it from there keeps span classification and semconv requirement
+levels in lockstep with the registry weaver validates against, instead of
+duplicating them here.
+
+Upstream's own entry points (``load_scenario_data_files``,
+``write_generated_scenario_data``, ``report``) are bound to its
+``scenarios/<lib>/`` layout, so we use the lower-level helpers and supply our
+own paths.
+"""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+from opentelemetry.test_util_genai._setup_weaver import _provision_genai_root
+
+
+@dataclass(frozen=True)
+class ReferenceTooling:
+    """The upstream modules used to build and render coverage reports."""
+
+    attribute_spec: ModuleType
+    classify: ModuleType
+    data_files: ModuleType
+    parse_results: ModuleType
+    semconv_model: ModuleType
+
+
+_tooling: ReferenceTooling | None = None
+
+
+def reference_tooling() -> ReferenceTooling:
+    """Import ``semconv_genai`` from the pinned genai registry checkout."""
+    global _tooling  # noqa: PLW0603
+    if _tooling is not None:
+        return _tooling
+
+    src = _provision_genai_root() / "reference" / "src"
+    if not (src / "semconv_genai").is_dir():
+        raise RuntimeError(
+            f"{src / 'semconv_genai'} not found. The report tooling ships with "
+            "semantic-conventions-genai; check the SEMCONV_GENAI_REF pin in "
+            "versions.env."
+        )
+    if str(src) not in sys.path:
+        sys.path.insert(0, str(src))
+
+    import semconv_genai.attribute_spec as attribute_spec  # noqa: PLC0415
+    import semconv_genai.classify as classify  # noqa: PLC0415
+    import semconv_genai.data_files as data_files  # noqa: PLC0415
+    import semconv_genai.parse_results as parse_results  # noqa: PLC0415
+    import semconv_genai.semconv_model as semconv_model  # noqa: PLC0415
+
+    _tooling = ReferenceTooling(
+        attribute_spec=attribute_spec,
+        classify=classify,
+        data_files=data_files,
+        parse_results=parse_results,
+        semconv_model=semconv_model,
+    )
+    return _tooling
+
+
+def build_scenario_data(weaver_reports_dir: Path, library: str) -> dict[str, Any]:
+    """Reduce a library's weaver live-check reports to a ``data.json`` payload."""
+    tooling = reference_tooling()
+    result = tooling.parse_results.parse_result_dir(
+        weaver_reports_dir, library, tooling.classify.classify_span
+    )
+    if result is None:
+        raise RuntimeError(
+            f"No weaver live-check reports found under {weaver_reports_dir}"
+        )
+    data, _ = tooling.data_files._build_single_scenario_data(result)  # noqa: SLF001
+    return data
+
+
+def load_scenario_data(data: dict[str, Any], library: str) -> Any:
+    """Normalize a ``data.json`` payload into a ``ScenarioDataEntry``."""
+    tooling = reference_tooling()
+    return tooling.data_files._normalize_scenario_data_entry(data, library)  # noqa: SLF001

--- a/util/opentelemetry-test-util-genai/src/opentelemetry/test_util_genai/conformance.py
+++ b/util/opentelemetry-test-util-genai/src/opentelemetry/test_util_genai/conformance.py
@@ -35,12 +35,10 @@ Each ``tests/conformance/<op>.py`` defines a :class:`Scenario` subclass with:
   ``super().validate(report)`` and layer on additional checks against the
   weaver report.
 
-Each run writes two artifacts: the raw weaver report to
-``weaver_reports/<library>/<Scenario>.json`` (gitignored, for debugging) and
-the package's semconv attribute coverage to
-``instrumentation/<pkg>/tests/conformance/data.json`` (committed). The latter
-feeds ``scripts/update_conformance_reports.py``, so it reflects a *full* env
-run — a filtered run produces a partial file.
+Each run writes the weaver report to ``weaver_reports/<library>/`` (gitignored)
+and the package's attribute coverage to ``tests/conformance/data.json``
+(committed, feeds ``scripts/update_conformance_reports.py``). Coverage is
+rewritten from the whole run, so a filtered run leaves a partial file.
 """
 
 from __future__ import annotations
@@ -192,7 +190,6 @@ def _seen_span_operations(report: LiveCheckReport) -> dict[str, int]:
 
 
 def _package_dir(scenario: Scenario) -> Path:
-    """The ``instrumentation/<pkg>`` directory the scenario is defined in."""
     path = Path(inspect.getfile(type(scenario))).resolve()
     for ancestor in path.parents:
         if ancestor.parent.name == "instrumentation":
@@ -211,8 +208,8 @@ def library_name(scenario: Scenario) -> str:
     return name
 
 
-# Library directories emptied so far in this process, so a renamed or deleted
-# scenario leaves no stale dump behind while repeated runs stay additive.
+# Emptied once per process, so a renamed or deleted scenario leaves no stale
+# dump behind while the run's own scenarios accumulate.
 _cleared_report_dirs: set[Path] = set()
 
 
@@ -228,7 +225,7 @@ def _report_dir(library: str) -> Path:
 def _dump_report(
     scenario: Scenario, report: LiveCheckReport, library: str
 ) -> None:
-    """Write the raw weaver report — the debugging artifact, kept verbatim."""
+    """Write the weaver report verbatim — it is the debugging artifact."""
     out = _report_dir(library) / f"{type(scenario).__name__}.json"
     out.write_text(json.dumps(report._report, indent=2, sort_keys=True))  # noqa: SLF001
 
@@ -236,9 +233,9 @@ def _dump_report(
 def _write_scenario_data(scenario: Scenario, library: str) -> None:
     """Refresh the package's committed semconv coverage data.
 
-    Derived from *every* report the package has dumped this run rather than
-    merged scenario by scenario: required-level attributes are the intersection
-    across all spans of a type, which only holds when they are reduced together.
+    Reduces *every* report dumped this run rather than merging scenario by
+    scenario: required-level attributes are the intersection across all spans
+    of a type, which only holds when they are reduced together.
     """
     data = build_scenario_data(_report_dir(library), library)
     out = _package_dir(scenario) / "tests" / "conformance" / "data.json"

--- a/util/opentelemetry-test-util-genai/src/opentelemetry/test_util_genai/conformance.py
+++ b/util/opentelemetry-test-util-genai/src/opentelemetry/test_util_genai/conformance.py
@@ -34,11 +34,20 @@ Each ``tests/conformance/<op>.py`` defines a :class:`Scenario` subclass with:
   counts and ``expected_metrics`` presence; per-scenario overrides call
   ``super().validate(report)`` and layer on additional checks against the
   weaver report.
+
+Each run writes two artifacts: the raw weaver report to
+``weaver_reports/<library>/<Scenario>.json`` (gitignored, for debugging) and
+the package's semconv attribute coverage to
+``instrumentation/<pkg>/tests/conformance/data.json`` (committed). The latter
+feeds ``scripts/update_conformance_reports.py``, so it reflects a *full* env
+run — a filtered run produces a partial file.
 """
 
 from __future__ import annotations
 
+import inspect
 import json
+import shutil
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from pathlib import Path
@@ -55,6 +64,10 @@ from opentelemetry.test.weaver_live_check import (
     LiveCheckReport,
     WeaverLiveCheck,
 )
+from opentelemetry.test_util_genai._semconv_reference import (
+    build_scenario_data,
+)
+from opentelemetry.test_util_genai._setup_weaver import _workspace_root
 
 
 @dataclass(frozen=True)
@@ -178,10 +191,58 @@ def _seen_span_operations(report: LiveCheckReport) -> dict[str, int]:
     return counts
 
 
-def _dump_report(scenario: Scenario, report: LiveCheckReport) -> None:
-    out = Path("weaver_reports") / f"{type(scenario).__name__}.json"
-    out.parent.mkdir(parents=True, exist_ok=True)
+def _package_dir(scenario: Scenario) -> Path:
+    """The ``instrumentation/<pkg>`` directory the scenario is defined in."""
+    path = Path(inspect.getfile(type(scenario))).resolve()
+    for ancestor in path.parents:
+        if ancestor.parent.name == "instrumentation":
+            return ancestor
+    raise RuntimeError(
+        f"{type(scenario).__name__} is defined at {path}, which is not inside "
+        "an instrumentation/<package> directory."
+    )
+
+
+def library_name(scenario: Scenario) -> str:
+    """The scenario's library slug, matching the semconv-genai naming."""
+    name = _package_dir(scenario).name
+    for prefix in ("opentelemetry-instrumentation-", "genai-"):
+        name = name.removeprefix(prefix)
+    return name
+
+
+# Library directories emptied so far in this process, so a renamed or deleted
+# scenario leaves no stale dump behind while repeated runs stay additive.
+_cleared_report_dirs: set[Path] = set()
+
+
+def _report_dir(library: str) -> Path:
+    out = _workspace_root() / "weaver_reports" / library
+    if out not in _cleared_report_dirs:
+        shutil.rmtree(out, ignore_errors=True)
+        _cleared_report_dirs.add(out)
+    out.mkdir(parents=True, exist_ok=True)
+    return out
+
+
+def _dump_report(
+    scenario: Scenario, report: LiveCheckReport, library: str
+) -> None:
+    """Write the raw weaver report — the debugging artifact, kept verbatim."""
+    out = _report_dir(library) / f"{type(scenario).__name__}.json"
     out.write_text(json.dumps(report._report, indent=2, sort_keys=True))  # noqa: SLF001
+
+
+def _write_scenario_data(scenario: Scenario, library: str) -> None:
+    """Refresh the package's committed semconv coverage data.
+
+    Derived from *every* report the package has dumped this run rather than
+    merged scenario by scenario: required-level attributes are the intersection
+    across all spans of a type, which only holds when they are reduced together.
+    """
+    data = build_scenario_data(_report_dir(library), library)
+    out = _package_dir(scenario) / "tests" / "conformance" / "data.json"
+    out.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n")
 
 
 def run_conformance(
@@ -212,7 +273,12 @@ def run_conformance(
         logger_provider.force_flush()
 
         report = weaver.end(timeout=120)
-        _dump_report(scenario, report)
+        library = library_name(scenario)
+        _dump_report(scenario, report, library)
+        # Coverage records what weaver observed, so it is written before the
+        # checks: a scenario that fails (or xfails, like the CrewAI baseline)
+        # still measured something worth reporting.
+        _write_scenario_data(scenario, library)
 
         _check_violations(scenario, report)
         scenario.validate(report)


### PR DESCRIPTION
Brings automation behind https://github.com/open-telemetry/semantic-conventions-genai/tree/main/reference/reports here - we can generate the same data in conformance tests