### PR TITLE
feat(google-genai): support event-only extra attributes

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-google-genai/.changelog/22.added
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/.changelog/22.added
@@ -1,0 +1,1 @@
+Add a context key for attaching attributes to `gen_ai.client.inference.operation.details` events without adding them to spans.

--- a/instrumentation/opentelemetry-instrumentation-google-genai/src/opentelemetry/instrumentation/google_genai/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/src/opentelemetry/instrumentation/google_genai/__init__.py
@@ -30,12 +30,16 @@ API
 ---
 """
 
-from .generate_content import GENERATE_CONTENT_EXTRA_ATTRIBUTES_CONTEXT_KEY
+from .generate_content import (
+    GENERATE_CONTENT_EVENT_ONLY_EXTRA_ATTRIBUTES_CONTEXT_KEY,
+    GENERATE_CONTENT_EXTRA_ATTRIBUTES_CONTEXT_KEY,
+)
 from .instrumentor import GoogleGenAiSdkInstrumentor
 from .version import __version__
 
 __all__ = [
     "GoogleGenAiSdkInstrumentor",
     "GENERATE_CONTENT_EXTRA_ATTRIBUTES_CONTEXT_KEY",
+    "GENERATE_CONTENT_EVENT_ONLY_EXTRA_ATTRIBUTES_CONTEXT_KEY",
     "__version__",
 ]

--- a/instrumentation/opentelemetry-instrumentation-google-genai/src/opentelemetry/instrumentation/google_genai/generate_content.py
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/src/opentelemetry/instrumentation/google_genai/generate_content.py
@@ -63,6 +63,11 @@ except ImportError:
 GENERATE_CONTENT_EXTRA_ATTRIBUTES_CONTEXT_KEY = context_api.create_key(
     "generate_content_extra_attributes_context_key"
 )
+GENERATE_CONTENT_EVENT_ONLY_EXTRA_ATTRIBUTES_CONTEXT_KEY = (
+    context_api.create_key(
+        "generate_content_event_only_extra_attributes_context_key"
+    )
+)
 
 
 class _MethodsSnapshot:
@@ -385,6 +390,13 @@ def _get_extra_generate_content_attributes() -> dict[str, AttributeValue]:
     return dict(attrs or {})
 
 
+def _get_event_only_generate_content_attributes() -> dict[str, AttributeValue]:
+    attrs = context_api.get_value(
+        GENERATE_CONTENT_EVENT_ONLY_EXTRA_ATTRIBUTES_CONTEXT_KEY
+    )
+    return dict(attrs or {})
+
+
 def _apply_response_attributes(
     response: GenerateContentResponse,
     finish_reasons: list[str],
@@ -487,6 +499,9 @@ def _create_instrumented_generate_content(
                 )
                 invocation.attributes.update(
                     _get_extra_generate_content_attributes()
+                )
+                invocation.event_attributes.update(
+                    _get_event_only_generate_content_attributes()
                 )
                 invocation.tool_definitions = _maybe_get_tool_definitions(
                     wrapped_config
@@ -647,6 +662,9 @@ def _create_instrumented_generate_content_stream(
             invocation.attributes.update(
                 _get_extra_generate_content_attributes()
             )
+            invocation.event_attributes.update(
+                _get_event_only_generate_content_attributes()
+            )
             invocation.tool_definitions = _maybe_get_tool_definitions(
                 wrapped_config
             )
@@ -713,6 +731,9 @@ def _create_instrumented_async_generate_content(
             ) as invocation:
                 invocation.attributes.update(
                     _get_extra_generate_content_attributes()
+                )
+                invocation.event_attributes.update(
+                    _get_event_only_generate_content_attributes()
                 )
                 _apply_request_attributes(
                     wrapped_config,
@@ -796,6 +817,9 @@ def _create_instrumented_async_generate_content_stream(  # type: ignore
             )
             invocation.attributes.update(
                 _get_extra_generate_content_attributes()
+            )
+            invocation.event_attributes.update(
+                _get_event_only_generate_content_attributes()
             )
             _apply_request_attributes(
                 wrapped_config,

--- a/instrumentation/opentelemetry-instrumentation-google-genai/tests/generate_content/nonstreaming_base.py
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/tests/generate_content/nonstreaming_base.py
@@ -16,6 +16,7 @@ from pydantic import BaseModel, Field
 
 from opentelemetry import context as context_api
 from opentelemetry.instrumentation.google_genai import (
+    GENERATE_CONTENT_EVENT_ONLY_EXTRA_ATTRIBUTES_CONTEXT_KEY,
     GENERATE_CONTENT_EXTRA_ATTRIBUTES_CONTEXT_KEY,
 )
 from opentelemetry.semconv._incubating.attributes import gen_ai_attributes
@@ -650,6 +651,46 @@ class NonStreamingTestCase(TestCase):
                 == "extra_attribute_value"
             )
         finally:
+            context_api.detach(tok)
+
+    def test_event_only_extra_attributes_are_not_added_to_span(self):
+        self.configure_valid_response(text="Yep, it works!")
+        tok = context_api.attach(
+            context_api.set_value(
+                GENERATE_CONTENT_EVENT_ONLY_EXTRA_ATTRIBUTES_CONTEXT_KEY,
+                {
+                    "event_only_attribute": "event-value",
+                    "shared_attribute": "event-value",
+                },
+            )
+        )
+        extra_tok = context_api.attach(
+            context_api.set_value(
+                GENERATE_CONTENT_EXTRA_ATTRIBUTES_CONTEXT_KEY,
+                {"shared_attribute": "span-value"},
+            )
+        )
+        try:
+            self.generate_content(
+                model="gemini-2.0-flash",
+                contents="Does this work?",
+            )
+            span = self.otel.get_span_named(
+                "generate_content gemini-2.0-flash"
+            )
+            event = self.otel.get_event_named(
+                "gen_ai.client.inference.operation.details"
+            )
+            self.assertNotIn("event_only_attribute", span.attributes)
+            self.assertEqual(span.attributes["shared_attribute"], "span-value")
+            self.assertEqual(
+                event.attributes["event_only_attribute"], "event-value"
+            )
+            self.assertEqual(
+                event.attributes["shared_attribute"], "event-value"
+            )
+        finally:
+            context_api.detach(extra_tok)
             context_api.detach(tok)
 
     def test_records_metrics_data(self):

--- a/instrumentation/opentelemetry-instrumentation-google-genai/tests/generate_content/streaming_base.py
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/tests/generate_content/streaming_base.py
@@ -5,6 +5,7 @@ import unittest
 
 from opentelemetry import context as context_api
 from opentelemetry.instrumentation.google_genai import (
+    GENERATE_CONTENT_EVENT_ONLY_EXTRA_ATTRIBUTES_CONTEXT_KEY,
     GENERATE_CONTENT_EXTRA_ATTRIBUTES_CONTEXT_KEY,
 )
 
@@ -117,4 +118,44 @@ class StreamingTestCase(TestCase):
                 == "extra_attribute_value"
             )
         finally:
+            context_api.detach(tok)
+
+    def test_event_only_extra_attributes_are_not_added_to_span(self):
+        self.configure_valid_response(text="Yep, it works!")
+        tok = context_api.attach(
+            context_api.set_value(
+                GENERATE_CONTENT_EVENT_ONLY_EXTRA_ATTRIBUTES_CONTEXT_KEY,
+                {
+                    "event_only_attribute": "event-value",
+                    "shared_attribute": "event-value",
+                },
+            )
+        )
+        extra_tok = context_api.attach(
+            context_api.set_value(
+                GENERATE_CONTENT_EXTRA_ATTRIBUTES_CONTEXT_KEY,
+                {"shared_attribute": "span-value"},
+            )
+        )
+        try:
+            self.generate_content(
+                model="gemini-2.0-flash",
+                contents="Does this work?",
+            )
+            span = self.otel.get_span_named(
+                "generate_content gemini-2.0-flash"
+            )
+            event = self.otel.get_event_named(
+                "gen_ai.client.inference.operation.details"
+            )
+            self.assertNotIn("event_only_attribute", span.attributes)
+            self.assertEqual(span.attributes["shared_attribute"], "span-value")
+            self.assertEqual(
+                event.attributes["event_only_attribute"], "event-value"
+            )
+            self.assertEqual(
+                event.attributes["shared_attribute"], "event-value"
+            )
+        finally:
+            context_api.detach(extra_tok)
             context_api.detach(tok)

--- a/util/opentelemetry-util-genai/.changelog/22.added
+++ b/util/opentelemetry-util-genai/.changelog/22.added
@@ -1,0 +1,1 @@
+Support event-only attributes on GenAI inference invocation events.

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_inference_invocation.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_inference_invocation.py
@@ -214,6 +214,7 @@ class InferenceInvocation(GenAIInvocation):
         attributes.update(self._get_attributes())
         attributes.update(self._get_message_attributes(for_span=False))
         attributes.update(self.attributes)
+        attributes.update(self.event_attributes)
         return LogRecord(
             event_name="gen_ai.client.inference.operation.details",
             attributes=attributes,

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_invocation.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_invocation.py
@@ -77,6 +77,8 @@ class GenAIInvocation(AbstractContextManager["GenAIInvocation"]):
             {} if attributes is None else attributes
         )
         """Additional attributes to set on spans and/or events. Not set on metrics."""
+        self.event_attributes: dict[str, AttributeValue] = {}
+        """Additional attributes to set on events, but not spans or metrics."""
         self.metric_attributes: dict[str, AttributeValue] = (
             {} if metric_attributes is None else metric_attributes
         )


### PR DESCRIPTION
## Summary

- add a public context key for event-only `generate_content` attributes
- preserve event-only attributes on `gen_ai.client.inference.operation.details` while keeping them off spans
- cover sync/async streaming and non-streaming paths, including collision precedence

Fixes #22

## Validation

- `python -m pytest instrumentation/opentelemetry-instrumentation-google-genai/tests/generate_content/test_sync_nonstreaming.py instrumentation/opentelemetry-instrumentation-google-genai/tests/generate_content/test_sync_streaming.py instrumentation/opentelemetry-instrumentation-google-genai/tests/generate_content/test_async_nonstreaming.py instrumentation/opentelemetry-instrumentation-google-genai/tests/generate_content/test_async_streaming.py -q` � 84 passed, 84 base skips
- `python -m pytest util/opentelemetry-util-genai/tests -q` � 239 passed
- Ruff checks and `git diff --check` pass