### PR TITLE
feat(google-genai): capture embedding config attributes

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-google-genai/.changelog/170.added
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/.changelog/170.added
@@ -1,1 +1,1 @@
-Capture non-sensitive `EmbedContentConfig` fields on Google GenAI embedding spans.
+Capture non-sensitive ``EmbedContentConfig`` fields on Google GenAI embedding spans.

--- a/instrumentation/opentelemetry-instrumentation-google-genai/.changelog/170.added
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/.changelog/170.added
@@ -1,0 +1,1 @@
+Capture non-sensitive `EmbedContentConfig` fields on Google GenAI embedding spans.

--- a/instrumentation/opentelemetry-instrumentation-google-genai/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/README.rst
@@ -92,8 +92,9 @@ This controls whether the following content is captured on spans and/or events:
 Configuration recording
 ***********************
 
-The instrumentation can optionally record ``GenerateContentConfig`` parameters
-as span and event attributes under the ``gcp.gen_ai.operation.config.*`` namespace.
+The instrumentation can optionally record ``GenerateContentConfig`` and
+``EmbedContentConfig`` parameters as span and event attributes under the
+``gcp.gen_ai.operation.config.*`` namespace.
 
 By default, no config fields are recorded. You can control which fields are
 captured using the following environment variables:
@@ -114,6 +115,17 @@ captured using the following environment variables:
 
 If both variables are set, the includes list is applied first, then the
 excludes list filters the result further.
+
+Embedding configuration uses the same opt-in behavior, with its own variables:
+
+* ``OTEL_GOOGLE_GENAI_EMBED_CONTENT_CONFIG_INCLUDES``
+* ``OTEL_GOOGLE_GENAI_EMBED_CONTENT_CONFIG_EXCLUDES``
+
+For example, to capture all embedding configuration fields:
+
+.. code-block:: bash
+
+    export OTEL_GOOGLE_GENAI_EMBED_CONTENT_CONFIG_INCLUDES=*
 
 Uninstrument
 ************

--- a/instrumentation/opentelemetry-instrumentation-google-genai/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/README.rst
@@ -93,25 +93,29 @@ Configuration recording
 ***********************
 
 The instrumentation can optionally record ``GenerateContentConfig`` and
-``EmbedContentConfig`` parameters as span and event attributes under the
-``gcp.gen_ai.operation.config.*`` namespace.
+``EmbedContentConfig`` parameters under the
+``gcp.gen_ai.operation.config.*`` namespace. Generate-content configuration
+is recorded on both spans and events, while embedding configuration is
+recorded on spans only.
 
 By default, no config fields are recorded. You can control which fields are
 captured using the following environment variables:
 
-* ``OTEL_GOOGLE_GENAI_GENERATE_CONTENT_CONFIG_INCLUDES`` — A comma-separated
-  list of config field names to include in the span attributes. For example:
+* ``OTEL_GOOGLE_GENAI_GENERATE_CONTENT_CONFIG_INCLUDES`` - A comma-separated
+  list of fully-qualified attribute keys to include. The keys are produced by
+  flattening the configuration, so use the complete key rather than only the
+  config field name. For example:
 
   .. code-block:: bash
 
-      export OTEL_GOOGLE_GENAI_GENERATE_CONTENT_CONFIG_INCLUDES=temperature,max_output_tokens
+      export OTEL_GOOGLE_GENAI_GENERATE_CONTENT_CONFIG_INCLUDES=gcp.gen_ai.operation.config.temperature,gcp.gen_ai.operation.config.max_output_tokens
 
-* ``OTEL_GOOGLE_GENAI_GENERATE_CONTENT_CONFIG_EXCLUDES`` — A comma-separated
-  list of config field names to exclude from the span attributes:
+* ``OTEL_GOOGLE_GENAI_GENERATE_CONTENT_CONFIG_EXCLUDES`` - A comma-separated
+  list of fully-qualified attribute keys to exclude:
 
   .. code-block:: bash
 
-      export OTEL_GOOGLE_GENAI_GENERATE_CONTENT_CONFIG_EXCLUDES=stop_sequences
+      export OTEL_GOOGLE_GENAI_GENERATE_CONTENT_CONFIG_EXCLUDES=gcp.gen_ai.operation.config.stop_sequences
 
 If both variables are set, the includes list is applied first, then the
 excludes list filters the result further.

--- a/instrumentation/opentelemetry-instrumentation-google-genai/src/opentelemetry/instrumentation/google_genai/embeddings.py
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/src/opentelemetry/instrumentation/google_genai/embeddings.py
@@ -24,6 +24,7 @@ from opentelemetry.util.genai.invocation import (
     EmbeddingInvocation,
 )
 
+from .allowlist_util import AllowList
 from .custom_semconv import GCP_GENAI_OPERATION_CONFIG
 from .dict_util import flatten_dict
 
@@ -94,6 +95,7 @@ def _apply_embedding_response_attributes(
 
 def _apply_embedding_request_attributes(
     config: EmbedContentConfig | dict[str, Any] | None,
+    allow_list: AllowList,
     invocation: EmbeddingInvocation,
 ) -> None:
     if config is None:
@@ -111,11 +113,18 @@ def _apply_embedding_request_attributes(
         # telemetry attributes.
         exclude_keys={f"{GCP_GENAI_OPERATION_CONFIG}.http_options"},
     )
-    invocation.attributes.update(attributes)
+    invocation.attributes.update(
+        {
+            key: value
+            for key, value in attributes.items()
+            if allow_list.allowed(key)
+        }
+    )
 
 
 def _create_instrumented_embed_content(
     telemetry_handler: TelemetryHandler,
+    embed_content_config_key_allowlist: AllowList,
 ) -> Callable[
     [
         Callable[..., EmbedContentResponse],
@@ -142,7 +151,9 @@ def _create_instrumented_embed_content(
             server_address=server_address,
         ) as invocation:
             _apply_embedding_request_attributes(
-                kwargs.get("config"), invocation
+                kwargs.get("config"),
+                embed_content_config_key_allowlist,
+                invocation,
             )
             response = wrapped(*args, **kwargs)
             _apply_embedding_response_attributes(response, invocation)
@@ -154,6 +165,7 @@ def _create_instrumented_embed_content(
 
 def _create_instrumented_async_embed_content(
     telemetry_handler: TelemetryHandler,
+    embed_content_config_key_allowlist: AllowList,
 ) -> Callable[
     [
         Callable[..., Any],
@@ -180,7 +192,9 @@ def _create_instrumented_async_embed_content(
             server_address=server_address,
         ) as invocation:
             _apply_embedding_request_attributes(
-                kwargs.get("config"), invocation
+                kwargs.get("config"),
+                embed_content_config_key_allowlist,
+                invocation,
             )
             response = await wrapped(*args, **kwargs)
             _apply_embedding_response_attributes(response, invocation)
@@ -197,18 +211,23 @@ def uninstrument_embeddings(snapshot: object) -> None:
 
 def instrument_embeddings(
     telemetry_handler: TelemetryHandler,
+    embed_content_config_key_allowlist: AllowList,
 ) -> object:
     snapshot = _EmbeddingMethodsSnapshot()
 
     wrapped = wrap_function_wrapper(
         "google.genai.models",
         "Models.embed_content",
-        _create_instrumented_embed_content(telemetry_handler),
+        _create_instrumented_embed_content(
+            telemetry_handler, embed_content_config_key_allowlist
+        ),
     )
     wrapped2 = wrap_function_wrapper(
         "google.genai.models",
         "AsyncModels.embed_content",
-        _create_instrumented_async_embed_content(telemetry_handler),
+        _create_instrumented_async_embed_content(
+            telemetry_handler, embed_content_config_key_allowlist
+        ),
     )
     _set_co_filename(wrapped)
     _set_co_filename(wrapped2)

--- a/instrumentation/opentelemetry-instrumentation-google-genai/src/opentelemetry/instrumentation/google_genai/embeddings.py
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/src/opentelemetry/instrumentation/google_genai/embeddings.py
@@ -10,7 +10,7 @@ from typing import Any
 
 from google.genai._api_client import BaseApiClient
 from google.genai.models import AsyncModels, Models
-from google.genai.types import EmbedContentResponse
+from google.genai.types import EmbedContentConfig, EmbedContentResponse
 from wrapt import wrap_function_wrapper
 
 from opentelemetry.instrumentation.google_genai.client_info import (
@@ -23,6 +23,9 @@ from opentelemetry.util.genai.handler import TelemetryHandler
 from opentelemetry.util.genai.invocation import (
     EmbeddingInvocation,
 )
+
+from .custom_semconv import GCP_GENAI_OPERATION_CONFIG
+from .dict_util import flatten_dict
 
 _RAW_RESPONSE_BODY: ContextVar[str | None] = ContextVar(
     "raw_response_body", default=None
@@ -89,6 +92,28 @@ def _apply_embedding_response_attributes(
             pass
 
 
+def _apply_embedding_request_attributes(
+    config: EmbedContentConfig | dict[str, Any] | None,
+    invocation: EmbeddingInvocation,
+) -> None:
+    if config is None:
+        return
+    if isinstance(config, dict):
+        try:
+            config = EmbedContentConfig.model_validate(config)
+        except Exception:
+            return
+
+    attributes = flatten_dict(
+        config.model_dump(exclude_none=True),
+        key_prefix=GCP_GENAI_OPERATION_CONFIG,
+        # HTTP options can contain request headers and must not be copied into
+        # telemetry attributes.
+        exclude_keys={f"{GCP_GENAI_OPERATION_CONFIG}.http_options"},
+    )
+    invocation.attributes.update(attributes)
+
+
 def _create_instrumented_embed_content(
     telemetry_handler: TelemetryHandler,
 ) -> Callable[
@@ -116,6 +141,9 @@ def _create_instrumented_embed_content(
             request_model=kwargs.get("model"),
             server_address=server_address,
         ) as invocation:
+            _apply_embedding_request_attributes(
+                kwargs.get("config"), invocation
+            )
             response = wrapped(*args, **kwargs)
             _apply_embedding_response_attributes(response, invocation)
             _RAW_RESPONSE_BODY.set(None)
@@ -151,6 +179,9 @@ def _create_instrumented_async_embed_content(
             request_model=kwargs.get("model"),
             server_address=server_address,
         ) as invocation:
+            _apply_embedding_request_attributes(
+                kwargs.get("config"), invocation
+            )
             response = await wrapped(*args, **kwargs)
             _apply_embedding_response_attributes(response, invocation)
             _RAW_RESPONSE_BODY.set(None)

--- a/instrumentation/opentelemetry-instrumentation-google-genai/src/opentelemetry/instrumentation/google_genai/instrumentor.py
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/src/opentelemetry/instrumentation/google_genai/instrumentor.py
@@ -28,7 +28,9 @@ from .interactions import (
 
 class GoogleGenAiSdkInstrumentor(BaseInstrumentor):
     def __init__(
-        self, generate_content_config_key_allowlist: AllowList | None = None
+        self,
+        generate_content_config_key_allowlist: AllowList | None = None,
+        embed_content_config_key_allowlist: AllowList | None = None,
     ):
         self._generate_content_snapshot = None
         self._interactions_snapshot = None
@@ -38,6 +40,13 @@ class GoogleGenAiSdkInstrumentor(BaseInstrumentor):
             or AllowList.from_env(
                 "OTEL_GOOGLE_GENAI_GENERATE_CONTENT_CONFIG_INCLUDES",
                 excludes_env_var="OTEL_GOOGLE_GENAI_GENERATE_CONTENT_CONFIG_EXCLUDES",
+            )
+        )
+        self._embed_content_config_key_allowlist = (
+            embed_content_config_key_allowlist
+            or AllowList.from_env(
+                "OTEL_GOOGLE_GENAI_EMBED_CONTENT_CONFIG_INCLUDES",
+                excludes_env_var="OTEL_GOOGLE_GENAI_EMBED_CONTENT_CONFIG_EXCLUDES",
             )
         )
 
@@ -70,7 +79,10 @@ class GoogleGenAiSdkInstrumentor(BaseInstrumentor):
         self._interactions_snapshot = instrument_interactions(
             telemetry_handler,
         )
-        self._embedding_snapshot = instrument_embeddings(telemetry_handler)
+        self._embedding_snapshot = instrument_embeddings(
+            telemetry_handler,
+            embed_content_config_key_allowlist=self._embed_content_config_key_allowlist,
+        )
 
     def _uninstrument(self, **kwargs: Any):
         uninstrument_generate_content(self._generate_content_snapshot)

--- a/instrumentation/opentelemetry-instrumentation-google-genai/tests/embeddings/test_embeddings.py
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/tests/embeddings/test_embeddings.py
@@ -8,6 +8,7 @@ from google.genai.models import AsyncModels, Models
 from google.genai.types import (
     ContentEmbedding,
     ContentEmbeddingStatistics,
+    EmbedContentConfig,
     EmbedContentResponse,
 )
 
@@ -126,6 +127,51 @@ class TestEmbeddings(TestCase):
         self.assertEqual(
             attrs["server.address"],
             "generativelanguage.googleapis.com",
+        )
+
+    def test_embed_content_captures_config_attributes(self):
+        self.client.models.embed_content(
+            model="text-embedding-004",
+            contents="hello world",
+            config=EmbedContentConfig(
+                task_type="RETRIEVAL_QUERY",
+                output_dimensionality=256,
+                auto_truncate=True,
+            ),
+        )
+
+        span = self.otel.get_finished_spans()[0]
+        attrs = span.attributes
+        self.assertEqual(
+            attrs["gcp.gen_ai.operation.config.task_type"],
+            "RETRIEVAL_QUERY",
+        )
+        self.assertEqual(
+            attrs["gcp.gen_ai.operation.config.output_dimensionality"], 256
+        )
+        self.assertTrue(attrs["gcp.gen_ai.operation.config.auto_truncate"])
+
+    def test_async_embed_content_captures_config_attributes(self):
+        async def run_test():
+            await self.client.aio.models.embed_content(
+                model="text-embedding-004",
+                contents="hello world",
+                config={
+                    "taskType": "RETRIEVAL_DOCUMENT",
+                    "outputDimensionality": 128,
+                },
+            )
+
+        asyncio.run(run_test())
+
+        span = self.otel.get_finished_spans()[0]
+        attrs = span.attributes
+        self.assertEqual(
+            attrs["gcp.gen_ai.operation.config.task_type"],
+            "RETRIEVAL_DOCUMENT",
+        )
+        self.assertEqual(
+            attrs["gcp.gen_ai.operation.config.output_dimensionality"], 128
         )
 
     def test_embed_content_multiple_inputs(self):

--- a/instrumentation/opentelemetry-instrumentation-google-genai/tests/embeddings/test_embeddings.py
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/tests/embeddings/test_embeddings.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from google.genai.models import AsyncModels, Models
 from google.genai.types import (
@@ -129,7 +129,7 @@ class TestEmbeddings(TestCase):
             "generativelanguage.googleapis.com",
         )
 
-    def test_embed_content_captures_config_attributes(self):
+    def test_embed_content_does_not_capture_config_attributes_by_default(self):
         self.client.models.embed_content(
             model="text-embedding-004",
             contents="hello world",
@@ -142,15 +142,16 @@ class TestEmbeddings(TestCase):
 
         span = self.otel.get_finished_spans()[0]
         attrs = span.attributes
-        self.assertEqual(
-            attrs["gcp.gen_ai.operation.config.task_type"],
-            "RETRIEVAL_QUERY",
+        self.assertNotIn("gcp.gen_ai.operation.config.task_type", attrs)
+        self.assertNotIn(
+            "gcp.gen_ai.operation.config.output_dimensionality", attrs
         )
-        self.assertEqual(
-            attrs["gcp.gen_ai.operation.config.output_dimensionality"], 256
-        )
-        self.assertTrue(attrs["gcp.gen_ai.operation.config.auto_truncate"])
+        self.assertNotIn("gcp.gen_ai.operation.config.auto_truncate", attrs)
 
+    @patch.dict(
+        "os.environ",
+        {"OTEL_GOOGLE_GENAI_EMBED_CONTENT_CONFIG_INCLUDES": "*"},
+    )
     def test_async_embed_content_captures_config_attributes(self):
         async def run_test():
             await self.client.aio.models.embed_content(

--- a/instrumentation/opentelemetry-instrumentation-google-genai/tests/embeddings/test_embeddings.py
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/tests/embeddings/test_embeddings.py
@@ -10,6 +10,7 @@ from google.genai.types import (
     ContentEmbeddingStatistics,
     EmbedContentConfig,
     EmbedContentResponse,
+    HttpOptions,
 )
 
 from opentelemetry.semconv._incubating.attributes import (
@@ -173,6 +174,35 @@ class TestEmbeddings(TestCase):
         )
         self.assertEqual(
             attrs["gcp.gen_ai.operation.config.output_dimensionality"], 128
+        )
+
+    @patch.dict(
+        "os.environ",
+        {"OTEL_GOOGLE_GENAI_EMBED_CONTENT_CONFIG_INCLUDES": "*"},
+    )
+    def test_sync_embed_content_captures_config_without_http_options(self):
+        self.client.models.embed_content(
+            model="text-embedding-004",
+            contents="hello world",
+            config=EmbedContentConfig(
+                task_type="RETRIEVAL_QUERY",
+                output_dimensionality=256,
+                http_options=HttpOptions(headers={"authorization": "secret"}),
+            ),
+        )
+
+        attrs = self.otel.get_finished_spans()[0].attributes
+        self.assertEqual(
+            attrs["gcp.gen_ai.operation.config.task_type"], "RETRIEVAL_QUERY"
+        )
+        self.assertEqual(
+            attrs["gcp.gen_ai.operation.config.output_dimensionality"], 256
+        )
+        self.assertFalse(
+            any(
+                key.startswith("gcp.gen_ai.operation.config.http_options")
+                for key in attrs
+            )
         )
 
     def test_embed_content_multiple_inputs(self):


### PR DESCRIPTION
## Summary

- capture non-sensitive `EmbedContentConfig` fields on Google GenAI embedding spans
- support both `EmbedContentConfig` objects and dict configurations for sync and async calls
- omit `http_options` so headers and request settings are not copied into telemetry

Fixes #170

## Validation

- `python -m pytest instrumentation/opentelemetry-instrumentation-google-genai/tests/embeddings/test_embeddings.py -q` � 6 passed
- Full package run: 193 passed, 116 skipped; 8 credential-dependent setup errors and 1 async-plugin failure are pre-existing environment limitations
- Ruff and `git diff --check` pass