### PR TITLE
feat(google-genai): support event-only extra attributes

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-google-genai/.changelog/22.changed
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/.changelog/22.changed
@@ -1,0 +1,3 @@
+Add ``GENERATE_CONTENT_EVENT_ONLY_EXTRA_ATTRIBUTES_CONTEXT_KEY`` for attaching
+caller-supplied attributes to ``gen_ai.client.inference.operation.details``
+events without adding them to the corresponding span.

--- a/instrumentation/opentelemetry-instrumentation-google-genai/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/README.rst
@@ -65,6 +65,41 @@ Make sure to configure OpenTelemetry tracing, logging, and metrics to capture al
     )
 
 
+Adding extra attributes
+***********************
+
+The instrumentation exposes two Context API keys for adding caller-supplied
+attributes to ``generate_content`` telemetry. Import the keys from
+``opentelemetry.instrumentation.google_genai`` and attach a context value for
+the duration of the call:
+
+.. code-block:: python
+
+    from opentelemetry import context
+    from opentelemetry.instrumentation.google_genai import (
+        GENERATE_CONTENT_EVENT_ONLY_EXTRA_ATTRIBUTES_CONTEXT_KEY,
+        GENERATE_CONTENT_EXTRA_ATTRIBUTES_CONTEXT_KEY,
+    )
+
+    token = context.attach(
+        context.set_value(
+            GENERATE_CONTENT_EXTRA_ATTRIBUTES_CONTEXT_KEY,
+            {"tenant.id": "acme"},
+        )
+    )
+    try:
+        client.models.generate_content(model="gemini-1.5-flash-002", contents="Hi")
+    finally:
+        context.detach(token)
+
+``GENERATE_CONTENT_EXTRA_ATTRIBUTES_CONTEXT_KEY`` adds attributes to both the
+span and the operation-details event. Use
+``GENERATE_CONTENT_EVENT_ONLY_EXTRA_ATTRIBUTES_CONTEXT_KEY`` when an attribute
+should appear only on the operation-details event and not on the span. If both
+keys contain the same attribute name, the event-only value takes precedence on
+the event while the regular value remains on the span.
+
+
 Limitations
 ***********
 

--- a/instrumentation/opentelemetry-instrumentation-google-genai/src/opentelemetry/instrumentation/google_genai/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/src/opentelemetry/instrumentation/google_genai/__init__.py
@@ -30,12 +30,16 @@ API
 ---
 """
 
-from .generate_content import GENERATE_CONTENT_EXTRA_ATTRIBUTES_CONTEXT_KEY
+from .generate_content import (
+    GENERATE_CONTENT_EVENT_ONLY_EXTRA_ATTRIBUTES_CONTEXT_KEY,
+    GENERATE_CONTENT_EXTRA_ATTRIBUTES_CONTEXT_KEY,
+)
 from .instrumentor import GoogleGenAiSdkInstrumentor
 from .version import __version__
 
 __all__ = [
     "GoogleGenAiSdkInstrumentor",
+    "GENERATE_CONTENT_EVENT_ONLY_EXTRA_ATTRIBUTES_CONTEXT_KEY",
     "GENERATE_CONTENT_EXTRA_ATTRIBUTES_CONTEXT_KEY",
     "__version__",
 ]

--- a/instrumentation/opentelemetry-instrumentation-google-genai/src/opentelemetry/instrumentation/google_genai/generate_content.py
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/src/opentelemetry/instrumentation/google_genai/generate_content.py
@@ -63,6 +63,9 @@ except ImportError:
 GENERATE_CONTENT_EXTRA_ATTRIBUTES_CONTEXT_KEY = context_api.create_key(
     "generate_content_extra_attributes_context_key"
 )
+GENERATE_CONTENT_EVENT_ONLY_EXTRA_ATTRIBUTES_CONTEXT_KEY = context_api.create_key(
+    "generate_content_event_only_extra_attributes_context_key"
+)
 
 
 class _MethodsSnapshot:
@@ -385,6 +388,13 @@ def _get_extra_generate_content_attributes() -> dict[str, AttributeValue]:
     return dict(attrs or {})
 
 
+def _get_event_only_generate_content_attributes() -> dict[str, AttributeValue]:
+    attrs = context_api.get_value(
+        GENERATE_CONTENT_EVENT_ONLY_EXTRA_ATTRIBUTES_CONTEXT_KEY
+    )
+    return dict(attrs or {})
+
+
 def _apply_response_attributes(
     response: GenerateContentResponse,
     finish_reasons: list[str],
@@ -487,6 +497,9 @@ def _create_instrumented_generate_content(
                 )
                 invocation.attributes.update(
                     _get_extra_generate_content_attributes()
+                )
+                invocation.event_attributes.update(
+                    _get_event_only_generate_content_attributes()
                 )
                 invocation.tool_definitions = _maybe_get_tool_definitions(
                     wrapped_config
@@ -647,6 +660,9 @@ def _create_instrumented_generate_content_stream(
             invocation.attributes.update(
                 _get_extra_generate_content_attributes()
             )
+            invocation.event_attributes.update(
+                _get_event_only_generate_content_attributes()
+            )
             invocation.tool_definitions = _maybe_get_tool_definitions(
                 wrapped_config
             )
@@ -713,6 +729,9 @@ def _create_instrumented_async_generate_content(
             ) as invocation:
                 invocation.attributes.update(
                     _get_extra_generate_content_attributes()
+                )
+                invocation.event_attributes.update(
+                    _get_event_only_generate_content_attributes()
                 )
                 _apply_request_attributes(
                     wrapped_config,
@@ -796,6 +815,9 @@ def _create_instrumented_async_generate_content_stream(  # type: ignore
             )
             invocation.attributes.update(
                 _get_extra_generate_content_attributes()
+            )
+            invocation.event_attributes.update(
+                _get_event_only_generate_content_attributes()
             )
             _apply_request_attributes(
                 wrapped_config,

--- a/instrumentation/opentelemetry-instrumentation-google-genai/src/opentelemetry/instrumentation/google_genai/generate_content.py
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/src/opentelemetry/instrumentation/google_genai/generate_content.py
@@ -63,6 +63,8 @@ except ImportError:
 GENERATE_CONTENT_EXTRA_ATTRIBUTES_CONTEXT_KEY = context_api.create_key(
     "generate_content_extra_attributes_context_key"
 )
+# Unlike the regular extra-attributes key, these values are event-only. They
+# override regular extra attributes when the same key is present on the event.
 GENERATE_CONTENT_EVENT_ONLY_EXTRA_ATTRIBUTES_CONTEXT_KEY = context_api.create_key(
     "generate_content_event_only_extra_attributes_context_key"
 )

--- a/instrumentation/opentelemetry-instrumentation-google-genai/tests/generate_content/nonstreaming_base.py
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/tests/generate_content/nonstreaming_base.py
@@ -16,6 +16,7 @@ from pydantic import BaseModel, Field
 
 from opentelemetry import context as context_api
 from opentelemetry.instrumentation.google_genai import (
+    GENERATE_CONTENT_EVENT_ONLY_EXTRA_ATTRIBUTES_CONTEXT_KEY,
     GENERATE_CONTENT_EXTRA_ATTRIBUTES_CONTEXT_KEY,
 )
 from opentelemetry.semconv._incubating.attributes import gen_ai_attributes
@@ -259,6 +260,39 @@ class NonStreamingTestCase(TestCase):
                 span.attributes["extra_attribute_key"], "extra_attribute_value"
             )
         finally:
+            context_api.detach(tok)
+
+    def test_event_only_extra_attributes_are_not_added_to_span(self):
+        self.configure_valid_response(text="Yep, it works!")
+        tok = context_api.attach(
+            context_api.set_value(
+                GENERATE_CONTENT_EXTRA_ATTRIBUTES_CONTEXT_KEY,
+                {"shared_attribute": "span-value"},
+            )
+        )
+        event_tok = context_api.attach(
+            context_api.set_value(
+                GENERATE_CONTENT_EVENT_ONLY_EXTRA_ATTRIBUTES_CONTEXT_KEY,
+                {
+                    "event_only_attribute": "event-value",
+                    "shared_attribute": "event-value",
+                },
+            )
+        )
+        try:
+            self.generate_content(
+                model="gemini-2.0-flash", contents="Does this work?"
+            )
+            span = self.otel.get_span_named("generate_content gemini-2.0-flash")
+            event = self.otel.get_event_named(
+                "gen_ai.client.inference.operation.details"
+            )
+            self.assertNotIn("event_only_attribute", span.attributes)
+            self.assertEqual(span.attributes["shared_attribute"], "span-value")
+            self.assertEqual(event.attributes["event_only_attribute"], "event-value")
+            self.assertEqual(event.attributes["shared_attribute"], "event-value")
+        finally:
+            context_api.detach(event_tok)
             context_api.detach(tok)
 
     def test_span_and_event_still_written_when_response_is_exception(self):

--- a/instrumentation/opentelemetry-instrumentation-google-genai/tests/generate_content/streaming_base.py
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/tests/generate_content/streaming_base.py
@@ -5,6 +5,7 @@ import unittest
 
 from opentelemetry import context as context_api
 from opentelemetry.instrumentation.google_genai import (
+    GENERATE_CONTENT_EVENT_ONLY_EXTRA_ATTRIBUTES_CONTEXT_KEY,
     GENERATE_CONTENT_EXTRA_ATTRIBUTES_CONTEXT_KEY,
 )
 
@@ -116,5 +117,26 @@ class StreamingTestCase(TestCase):
                 event.attributes["extra_attribute_key"]
                 == "extra_attribute_value"
             )
+        finally:
+            context_api.detach(tok)
+
+    def test_event_only_extra_attributes_are_not_added_to_span(self):
+        self.configure_valid_response(text="Yep, it works!")
+        tok = context_api.attach(
+            context_api.set_value(
+                GENERATE_CONTENT_EVENT_ONLY_EXTRA_ATTRIBUTES_CONTEXT_KEY,
+                {"event_only_attribute": "event-value"},
+            )
+        )
+        try:
+            self.generate_content(
+                model="gemini-2.0-flash", contents="Does this work?"
+            )
+            span = self.otel.get_span_named("generate_content gemini-2.0-flash")
+            event = self.otel.get_event_named(
+                "gen_ai.client.inference.operation.details"
+            )
+            self.assertNotIn("event_only_attribute", span.attributes)
+            self.assertEqual(event.attributes["event_only_attribute"], "event-value")
         finally:
             context_api.detach(tok)

--- a/util/opentelemetry-util-genai/.changelog/22.changed
+++ b/util/opentelemetry-util-genai/.changelog/22.changed
@@ -1,0 +1,3 @@
+Support separate event-only attributes on ``InferenceInvocation`` so
+instrumentations can enrich GenAI operation-detail events without changing
+span attributes.

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_inference_invocation.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_inference_invocation.py
@@ -94,6 +94,7 @@ class InferenceInvocation(GenAIInvocation):
         self.top_k: float | None = None
         self.request_choice_count: int | None = None
         self.output_type: str | None = None
+        self.event_attributes: dict[str, AttributeValue] = {}
         self._start(self._get_start_attributes())
 
     def _get_message_attributes(
@@ -214,6 +215,7 @@ class InferenceInvocation(GenAIInvocation):
         attributes.update(self._get_attributes())
         attributes.update(self._get_message_attributes(for_span=False))
         attributes.update(self.attributes)
+        attributes.update(self.event_attributes)
         return LogRecord(
             event_name="gen_ai.client.inference.operation.details",
             attributes=attributes,

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_inference_invocation.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_inference_invocation.py
@@ -94,6 +94,8 @@ class InferenceInvocation(GenAIInvocation):
         self.top_k: float | None = None
         self.request_choice_count: int | None = None
         self.output_type: str | None = None
+        # These attributes are emitted only on the operation-details event,
+        # never on the corresponding span or metrics.
         self.event_attributes: dict[str, AttributeValue] = {}
         self._start(self._get_start_attributes())
 


### PR DESCRIPTION
## Summary

- add a context key for caller attributes that should appear only on operation-detail events
- preserve existing span attributes and let event-only values win on event collisions
- cover sync and async streaming and non-streaming wrappers

## Validation

- `python -m compileall -q` over the changed util, instrumentation, and test paths
- `git diff --check`
- Focused pytest selection was attempted; this Windows checkout has a shared fixture-scope mismatch (`fixture_vcr` is module-scoped while installed `pytest-recording` exposes function-scoped `vcr`), so test setup could not run

Closes #22