### PR TITLE
feat(util-genai): add per-signal context-scoped attributes

### DIFF
--- a/util/opentelemetry-util-genai/.changelog/337.added
+++ b/util/opentelemetry-util-genai/.changelog/337.added
@@ -1,0 +1,1 @@
+Add ``set_context_scoped_attributes`` for attaching attributes to an OpenTelemetry context so that GenAI telemetry emitted within it carries them, targeted per signal at spans or events.

--- a/util/opentelemetry-util-genai/README.rst
+++ b/util/opentelemetry-util-genai/README.rst
@@ -12,6 +12,7 @@ Key Components
 - ``TelemetryHandler`` -- manages LLM invocation lifecycles (spans, metrics, events)
 - ``InferenceInvocation`` and message types (``Text``, ``Reasoning``, ``Blob``, etc.) -- structured data model for GenAI interactions
 - ``CompletionHook`` -- protocol for uploading content to external storage (built-in ``fsspec`` support)
+- ``set_context_scoped_attributes`` -- attach attributes to a context so GenAI telemetry emitted within it carries them
 - Metrics -- ``gen_ai.client.operation.duration`` and ``gen_ai.client.token.usage`` histograms, plus
   the streaming timing histograms ``gen_ai.client.operation.time_to_first_chunk`` and
   ``gen_ai.client.operation.time_per_output_chunk``
@@ -22,6 +23,47 @@ Usage
 
 See the module docstring in ``opentelemetry.util.genai.handler`` for usage examples,
 including context manager and manual lifecycle patterns.
+
+
+Context-scoped Attributes
+-------------------------
+
+An agentic framework knows which agent, workflow, or conversation is running.
+The model-client instrumentation that emits the inference telemetry sits a layer
+below it and has no way to learn any of it -- there is no shared call path, and
+attributes cannot be read back off a parent span.
+``set_context_scoped_attributes`` bridges the two through the OpenTelemetry
+context.
+
+Each attribute declares which signal it applies to, so content that is unsafe on
+a sampled, widely-read span can still be recorded on the event::
+
+    from opentelemetry import context
+    from opentelemetry.util.genai.context_attributes import (
+        set_context_scoped_attributes,
+    )
+
+    token = context.attach(
+        set_context_scoped_attributes(
+            span_attributes={"gen_ai.agent.name": "trip-planner"},
+            log_attributes={"user.id": user_id},
+        )
+    )
+    try:
+        client.chat.completions.create(...)  # instrumented elsewhere
+    finally:
+        context.detach(token)
+
+- Attributes apply to GenAI telemetry emitted by this package only. Other
+  instrumentation, and telemetry the application emits directly, are unaffected.
+- Attributes are never propagated out of the process.
+- ``span_attributes`` are applied when the span starts, so they are visible to
+  samplers. Attributes an invocation sets itself take precedence.
+- ``log_attributes`` apply to the ``gen_ai.client.inference.operation.details``
+  event, which is the only event this package emits.
+- Nested calls merge, with the inner call taking precedence for keys it sets.
+- An invocation reads the context once, when it starts.
+- Metrics are deliberately not supported, to avoid unbounded cardinality.
 
 
 Environment Variables

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_inference_invocation.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_inference_invocation.py
@@ -246,6 +246,8 @@ class InferenceInvocation(GenAIInvocation):
             return None
 
         attributes = self._get_start_attributes()
+        if self._context_scoped_attributes.log:
+            attributes = {**self._context_scoped_attributes.log, **attributes}
         attributes.update(self._get_attributes())
         attributes.update(self._get_message_attributes(for_span=False))
         attributes.update(self.attributes)

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_invocation.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_invocation.py
@@ -21,6 +21,10 @@ from opentelemetry.trace import INVALID_SPAN as _INVALID_SPAN
 from opentelemetry.trace import Span, SpanKind, Tracer, set_span_in_context
 from opentelemetry.trace.status import Status, StatusCode
 from opentelemetry.util.genai.completion_hook import CompletionHook
+from opentelemetry.util.genai.context_attributes import (
+    _ContextScopedAttributes,
+    _get_context_scoped_attributes,
+)
 from opentelemetry.util.genai.types import (
     Error,
     ErrorTypeResolver,
@@ -94,6 +98,7 @@ class GenAIInvocation(AbstractContextManager["GenAIInvocation"]):
         self._request_stream: bool | None = None
         self._ttfc_seconds: float | None = None
         self._stream_last_chunk_at: float | None = None
+        self._context_scoped_attributes = _ContextScopedAttributes()
 
     def _start(
         self, attributes: dict[str, AttributeValue] | None = None
@@ -103,6 +108,12 @@ class GenAIInvocation(AbstractContextManager["GenAIInvocation"]):
         Args:
             attributes: Initial span attributes available for sampling decisions.
         """
+        self._context_scoped_attributes = _get_context_scoped_attributes()
+        if self._context_scoped_attributes.span:
+            attributes = {
+                **self._context_scoped_attributes.span,
+                **(attributes or {}),
+            }
         self.span = self._tracer.start_span(
             name=self._span_name,
             kind=self._span_kind,

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/context_attributes.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/context_attributes.py
@@ -1,0 +1,97 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Attach attributes to a context so GenAI telemetry emitted within it carries them.
+
+This lets a caller that knows something the instrumentation cannot -- which
+agent is running, which user made the request -- add it to telemetry emitted
+further down the stack. Each attribute targets a signal, so data that is unsafe
+on a span can still go on the event.
+
+.. code-block:: python
+
+    token = context.attach(
+        set_context_scoped_attributes(
+            span_attributes={"gen_ai.agent.name": "trip-planner"},
+            log_attributes={"user.id": user_id},
+        )
+    )
+    try:
+        client.chat.completions.create(...)  # instrumented elsewhere
+    finally:
+        context.detach(token)
+
+Only telemetry from this package is affected, and attributes never leave the
+process. Metrics are not supported, to avoid unbounded cardinality.
+
+The naming follows `OTEP 4931
+<https://github.com/open-telemetry/opentelemetry-specification/blob/main/oteps/4931-context-scoped-attributes.md>`_,
+but this is narrower: that OTEP has the SDK stamp all telemetry and gates it
+per signal on the provider.
+"""
+
+from __future__ import annotations
+
+from types import MappingProxyType
+from typing import Mapping, NamedTuple
+
+from opentelemetry.context import (
+    Context,
+    create_key,
+    get_current,
+    get_value,
+    set_value,
+)
+from opentelemetry.util.types import AttributeValue
+
+__all__ = ["set_context_scoped_attributes"]
+
+_CONTEXT_SCOPED_ATTRIBUTES_KEY = create_key(
+    "opentelemetry.util.genai.context_scoped_attributes"
+)
+
+_EMPTY: Mapping[str, AttributeValue] = MappingProxyType({})
+
+
+class _ContextScopedAttributes(NamedTuple):
+    """The per-signal attribute bags carried by a single context."""
+
+    span: Mapping[str, AttributeValue] = _EMPTY
+    log: Mapping[str, AttributeValue] = _EMPTY
+
+
+_NO_ATTRIBUTES = _ContextScopedAttributes()
+
+
+def set_context_scoped_attributes(
+    *,
+    span_attributes: Mapping[str, AttributeValue] | None = None,
+    log_attributes: Mapping[str, AttributeValue] | None = None,
+    context: Context | None = None,
+) -> Context:
+    """Return a new context carrying the given attributes. Does not attach it.
+
+    Args:
+        span_attributes: Added to GenAI spans on span start.
+        log_attributes: Added to the GenAI logs emitted.
+        context: Base context. Defaults to the current context.
+    """
+    if not span_attributes and not log_attributes:
+        return context if context is not None else get_current()
+
+    existing = _get_context_scoped_attributes(context)
+    merged = _ContextScopedAttributes(
+        span=MappingProxyType({**existing.span, **(span_attributes or {})}),
+        log=MappingProxyType({**existing.log, **(log_attributes or {})}),
+    )
+    return set_value(_CONTEXT_SCOPED_ATTRIBUTES_KEY, merged, context)
+
+
+def _get_context_scoped_attributes(
+    context: Context | None = None,
+) -> _ContextScopedAttributes:
+    """Return the attribute bags on the given context, or empty ones."""
+    value = get_value(_CONTEXT_SCOPED_ATTRIBUTES_KEY, context)
+    if isinstance(value, _ContextScopedAttributes):
+        return value
+    return _NO_ATTRIBUTES

--- a/util/opentelemetry-util-genai/tests/test_context_attributes.py
+++ b/util/opentelemetry-util-genai/tests/test_context_attributes.py
@@ -1,0 +1,182 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import unittest
+from contextlib import contextmanager
+from unittest.mock import patch
+
+from opentelemetry import context as otel_context
+from opentelemetry.sdk._logs import LoggerProvider
+from opentelemetry.sdk._logs.export import (
+    InMemoryLogRecordExporter,
+    SimpleLogRecordProcessor,
+)
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
+from opentelemetry.sdk.trace.sampling import Decision, Sampler, SamplingResult
+from opentelemetry.semconv._incubating.attributes import (
+    gen_ai_attributes as GenAI,
+)
+from opentelemetry.semconv._incubating.attributes import user_attributes
+from opentelemetry.util.genai.context_attributes import (
+    set_context_scoped_attributes,
+)
+from opentelemetry.util.genai.handler import get_telemetry_handler
+
+
+class _RecordingSampler(Sampler):
+    """Samples everything, remembering the attributes it was given."""
+
+    def __init__(self):
+        self.seen = []
+
+    def should_sample(
+        self,
+        parent_context,
+        trace_id,
+        name,
+        kind=None,
+        attributes=None,
+        *_,
+        **__,
+    ):
+        self.seen.append(attributes)
+        return SamplingResult(Decision.RECORD_AND_SAMPLE, attributes)
+
+    def get_description(self):
+        return "RecordingSampler"
+
+
+@patch.dict(
+    os.environ,
+    {
+        "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT": "EVENT_ONLY",
+        "OTEL_INSTRUMENTATION_GENAI_EMIT_EVENT": "true",
+    },
+)
+class TestContextScopedAttributes(unittest.TestCase):
+    def setUp(self):
+        self.sampler = _RecordingSampler()
+        self.span_exporter = InMemorySpanExporter()
+        tracer_provider = TracerProvider(sampler=self.sampler)
+        tracer_provider.add_span_processor(
+            SimpleSpanProcessor(self.span_exporter)
+        )
+        self.log_exporter = InMemoryLogRecordExporter()
+        logger_provider = LoggerProvider()
+        logger_provider.add_log_record_processor(
+            SimpleLogRecordProcessor(self.log_exporter)
+        )
+        self.handler = get_telemetry_handler(
+            tracer_provider=tracer_provider, logger_provider=logger_provider
+        )
+
+    def tearDown(self):
+        if hasattr(get_telemetry_handler, "_default_handler"):
+            delattr(get_telemetry_handler, "_default_handler")
+
+    @contextmanager
+    def _inference(self, context):
+        """Run one inference invocation with `context` attached."""
+        token = otel_context.attach(context)
+        try:
+            with self.handler.inference(
+                "test-provider", request_model="test-model"
+            ) as invocation:
+                yield invocation
+        finally:
+            otel_context.detach(token)
+
+    @property
+    def span_attributes(self):
+        (span,) = self.span_exporter.get_finished_spans()
+        return span.attributes
+
+    @property
+    def event_attributes(self):
+        (log,) = self.log_exporter.get_finished_logs()
+        return log.log_record.attributes
+
+    def test_attributes_go_only_to_the_signal_they_target(self):
+        with self._inference(
+            set_context_scoped_attributes(
+                span_attributes={GenAI.GEN_AI_AGENT_NAME: "trip-planner"},
+                log_attributes={user_attributes.USER_ID: "u-1"},
+            )
+        ):
+            pass
+
+        self.assertEqual(
+            self.span_attributes[GenAI.GEN_AI_AGENT_NAME], "trip-planner"
+        )
+        self.assertNotIn(user_attributes.USER_ID, self.span_attributes)
+        self.assertEqual(self.event_attributes[user_attributes.USER_ID], "u-1")
+        self.assertNotIn(GenAI.GEN_AI_AGENT_NAME, self.event_attributes)
+
+    def test_invocation_attributes_win(self):
+        context = set_context_scoped_attributes(
+            span_attributes={
+                GenAI.GEN_AI_PROVIDER_NAME: "from-context",
+                "custom": "from-context",
+            },
+            log_attributes={GenAI.GEN_AI_PROVIDER_NAME: "from-context"},
+        )
+        with self._inference(context) as invocation:
+            invocation.attributes["custom"] = "from-invocation"
+
+        self.assertEqual(
+            self.span_attributes[GenAI.GEN_AI_PROVIDER_NAME], "test-provider"
+        )
+        self.assertEqual(self.span_attributes["custom"], "from-invocation")
+        self.assertEqual(
+            self.event_attributes[GenAI.GEN_AI_PROVIDER_NAME], "test-provider"
+        )
+
+    def test_nested_contexts_merge_with_the_inner_one_winning(self):
+        outer = set_context_scoped_attributes(
+            span_attributes={"outer": "outer", "shared": "outer"}
+        )
+        with self._inference(
+            set_context_scoped_attributes(
+                span_attributes={"inner": "inner", "shared": "inner"},
+                context=outer,
+            )
+        ):
+            pass
+
+        self.assertEqual(self.span_attributes["outer"], "outer")
+        self.assertEqual(self.span_attributes["inner"], "inner")
+        self.assertEqual(self.span_attributes["shared"], "inner")
+
+    def test_span_attributes_are_visible_to_the_sampler(self):
+        with self._inference(
+            set_context_scoped_attributes(
+                span_attributes={GenAI.GEN_AI_AGENT_NAME: "trip-planner"}
+            )
+        ):
+            pass
+
+        (seen,) = self.sampler.seen
+        self.assertEqual(seen[GenAI.GEN_AI_AGENT_NAME], "trip-planner")
+
+    def test_attributes_do_not_apply_outside_the_attached_context(self):
+        with self._inference(
+            set_context_scoped_attributes(
+                span_attributes={GenAI.GEN_AI_AGENT_NAME: "trip-planner"}
+            )
+        ):
+            pass
+        self.span_exporter.clear()
+
+        with self.handler.inference("test-provider"):
+            pass
+
+        self.assertNotIn(GenAI.GEN_AI_AGENT_NAME, self.span_attributes)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Description

Adds `set_context_scoped_attributes` to `opentelemetry-util-genai`: a caller
attaches attributes to an OpenTelemetry context, and GenAI telemetry emitted
within that context carries them. Each attribute declares which signal it
applies to.

```python
token = context.attach(
    set_context_scoped_attributes(
        span_attributes={"gen_ai.agent.name": "trip-planner"},
        log_attributes={"user.id": user_id},
    )
)
try:
    client.chat.completions.create(...)  # instrumented elsewhere
finally:
    context.detach(token)
```

# Motivation

GenAI instrumentation is layered across packages that share no call path. An
agentic framework knows which agent, workflow, or conversation is running. The
model-client instrumentation that emits the inference telemetry
(`opentelemetry-instrumentation-genai-openai` and friends) sits a layer below
it and has no way to learn any of it:

- **Span parentage** is traces-only, the event carries no parent attributes, and
  OTel spans are write-only — an inference instrumentation cannot read
  `gen_ai.agent.name` off its parent span even when one exists.
- **Threading it through the call** is impossible; you cannot pass an agent name
  through `openai.chat.completions.create()`.
- **Instrumentation config** is static per-process; agent identity is
  per-invocation.
- **Baggage** propagates cross-service (wrong scope) and is string-only.

The context is the only in-process channel between a component that knows the
fact and a component that emits the telemetry needing it. Concretely,
`gen_ai.agent.name`, `gen_ai.agent.id`, and `gen_ai.conversation.id` are
semconv-defined attributes that plainly belong on inference telemetry and that
no code path can currently populate — a spec-defined population gap rather than
a vendor extension.

Per-signal targeting is the second half of the requirement: content that is
unsafe on a sampled, widely-read span (user identifiers, tenant data) can still
be recorded on the event.

# Semantics

- Attributes apply to GenAI telemetry emitted by this package only. Other
  instrumentation, and telemetry the application emits directly, are unaffected.
- Attributes are never propagated out of the process — they live on the context
  under a private key, not in Baggage or any wire format.
- `span_attributes` are merged into the `start_span` call, so they are visible
  to samplers.
- `log_attributes` apply to `gen_ai.client.inference.operation.details`, the only
  event this package emits — so they reach inference invocations only.
- Attributes an invocation sets itself take precedence over context-scoped ones.
- Nested calls merge, with the inner call winning for keys it sets.
- An invocation reads the context once, when it starts.
- Metrics are not supported (see below).

## Why metrics are excluded

Spans and logs absorb an extra attribute harmlessly. Metrics do not: every
distinct value forks a new time series, so one context-scoped `user.id` or
`gen_ai.conversation.id` on the inference histograms is an unbounded cardinality
explosion — expensive, and often noticed only once a backend starts dropping
series. The failure is easy to cause, hard to detect, and hard to undo.

Rather than ship a foot-gun with a warning, there is no metrics target member at
all. If a pressing need appears, the safe form is an explicit allow-list of
attributes permitted on metrics, not a free-form bag. Adding that later is
straightforward; taking a free-form bag away after users depend on it is not.

# Alternatives considered

The requirement — attributes on the inference event but not the span, set by a
layer above the instrumentation — was first attacked outside the
instrumentation, via the log pipeline. None of those hold up:

- **A custom `LogRecordProcessor` wrapping the exporting processor**
  (`add_log_record_processor(BatchLogRecordProcessor(StampingProcessor(exporter)))`).
  Requires knowing and wrapping every processor the application installs, and
  re-wrapping whenever that set changes. Fragile by construction.
- **A stamping processor installed first, relying on processor ordering.**
  Processor order is not a stability guarantee to build on.
- **A custom `LoggerProvider` overriding `emit`.** The provider is global and set
  by the application; a library cannot force its own implementation on users.
- **Installing a custom provider only on one deployment target.** Telemetry would
  then differ by where the agent runs, and deployment-specific code leaks into
  framework core.

A `SpanProcessor` counterpart to any of these is possible for the span half,
with the caveat the OTEP itself notes: `OnStart` runs after the sampler, so
those attributes would not reach sampling decisions.

- **Implementing OTEP 4931 in the Python SDK.** The right long-term home, but the
  OTEP requires the feature be off unless the user opts in per-signal on the
  provider, which is exactly the provider control a library does not have. It
  also cannot express per-attribute signal targeting (below).
- **Generalising #187 in place.** #187 stamps one hardcoded attribute at span
  *finish* — after sampling — and merges outermost-wins. Both are wrong for this
  use case; this module is the generalisation it should rebase onto.

# Relation to OTEP 4931

This borrows the vocabulary of
[OTEP 4931](https://github.com/open-telemetry/opentelemetry-specification/blob/main/oteps/4931-context-scoped-attributes.md)
but is **not** an implementation of it, and does not claim conformance.

| | OTEP 4931 | This PR |
|---|---|---|
| Who stamps telemetry | the SDK | `opentelemetry-util-genai` |
| Scope | any telemetry from any component | GenAI telemetry from this package |
| Gating | per-signal, on the provider | per-attribute, at the write site |
| Metrics | MUST, for sync instruments | not supported |

The OTEP assigns stamping exclusively to the SDK, and only when the user has
opted in per-signal; it never contemplates an instrumentation doing the
stamping, so its SDK requirements do not bind here. What this package does is
read a context variable to decide which attributes to put on its own telemetry —
ordinary instrumentation behaviour, and what
`GENERATE_CONTENT_EXTRA_ATTRIBUTES_CONTEXT_KEY` in
`opentelemetry-instrumentation-google-genai` already does today in a hardcoded,
single-package form.

The OTEP does consider a non-SDK-core stamper, in the rejected "built-in
Processor" alternative, and rejects it for two mechanical reasons: a processor's
`OnStart` runs after the sampler, and it would need the SDK's internal context
key. Neither applies here — attributes are merged into the `start_span` call, so
samplers see them, and this module owns its own key.

Two deliberate consequences worth flagging:

- **Not a stepping stone.** When the Python SDK implements 4931, this does not
  become it. 4931 cannot express "on the event, not on the span":
  `AddContextScopedAttributes(Context, Attributes)` has no signal parameter, and
  its gating is on the provider, so disabling traces would drop *every*
  context-scoped attribute from spans rather than the one that is sensitive.
- **The setter opts in, not the provider.** Nothing is stamped unless a caller
  explicitly calls `set_context_scoped_attributes`, so the feature costs nothing
  when unused and needs no provider-level configuration — which is what makes it
  usable by libraries that do not control SDK setup.

# Scope

Deliberately limited to the public API plus the two stamping sites. Follow-ups:

- Deprecating `GENERATE_CONTENT_EXTRA_ATTRIBUTES_CONTEXT_KEY` in favour of this.
- Rebasing #187 (`gen_ai.conversation_root`) onto this module.

# Open question

Should there be an env kill switch (`OTEL_INSTRUMENTATION_GENAI_CONTEXT_SCOPED_ATTRIBUTES=false`)
so an application owner can disable stamping when a dependency writes attributes
they do not want? Not included; happy to add if maintainers prefer it. This is
adjacent to the OTEP's own open question about whether instrumentation relying
on this feature must always expose it as opt-in.

# How has this been tested?

New `util/opentelemetry-util-genai/tests/test_context_attributes.py` (5 tests)
covering: per-signal targeting, invocation attributes winning over
context-scoped ones, nested inner-wins merge, visibility to a recording sampler,
and no leakage outside the attached context.

Also verified end-to-end against a live provider: `opentelemetry-instrumentation-google-genai`
calling Gemini on Vertex AI, with attributes set as in the example above and
both signals exported over OTLP to a real backend (Google Cloud). Reading the
telemetry back from the backend:

- the span carries `gen_ai.agent.name=trip-planner` and no `user.id`;
<img width="2407" height="1053" alt="image" src="https://github.com/user-attachments/assets/635476fd-ab9d-448b-9979-0a759084d595" />
<img width="2406" height="1054" alt="image" src="https://github.com/user-attachments/assets/42a742c7-ad9e-4d3a-a789-e6f76bd9bcc1" />

- the `gen_ai.client.inference.operation.details` log record carries
  `user.id=<generated>` and no `gen_ai.agent.name`;
<img width="2406" height="1054" alt="image" src="https://github.com/user-attachments/assets/42a742c7-ad9e-4d3a-a789-e6f76bd9bcc1" />
  
- both correlate to the same trace/span IDs.

So the per-signal split survives serialisation, export, and ingestion, not just
the in-process exporter assertions.

`uv run tox -e typecheck` passes. `uv run tox -e precommit` passes except the
`uv-lock` hook, which rewrites indexes in my environment for unrelated reasons.

# Checklist

- [x] Followed the style guidelines of this project
- [x] Changelog updated if the change requires an entry
- [x] Unit tests added
- [x] Documentation updated
