### PR TITLE
Create skeleton for opentelemetry-instrumentation-genai-smolagents

### DIFF
--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -15,4 +15,5 @@ langchain>=1.3.14
 llama-index-core>=0.14.23
 openai>=2.52.0
 openai-agents>=0.18.3
+smolagents>=1.24.0
 weaviate-client>=4.22.0

--- a/instrumentation/README.md
+++ b/instrumentation/README.md
@@ -9,5 +9,6 @@
 | [opentelemetry-instrumentation-genai-openai](./opentelemetry-instrumentation-genai-openai) | openai >= 1.26.0 | Yes | development
 | [opentelemetry-instrumentation-genai-openai-agents](./opentelemetry-instrumentation-genai-openai-agents) | openai-agents >= 0.3.3 | No | development
 | [opentelemetry-instrumentation-genai-qwen-agent](./opentelemetry-instrumentation-genai-qwen-agent) | qwen-agent >= 0.0.20 | No | development
+| [opentelemetry-instrumentation-genai-smolagents](./opentelemetry-instrumentation-genai-smolagents) | smolagents >= 1.24.0 | No | development
 | [opentelemetry-instrumentation-genai-weaviate-client](./opentelemetry-instrumentation-genai-weaviate-client) | weaviate-client >= 3.0.0,<5.0.0 | No | development
 | [opentelemetry-instrumentation-google-genai](./opentelemetry-instrumentation-google-genai) | google-genai >= 1.32.0, <3 | No | development

--- a/instrumentation/opentelemetry-instrumentation-genai-smolagents/.changelog/.gitignore
+++ b/instrumentation/opentelemetry-instrumentation-genai-smolagents/.changelog/.gitignore
@@ -1,0 +1,1 @@
+!.gitignore

--- a/instrumentation/opentelemetry-instrumentation-genai-smolagents/.changelog/349.added
+++ b/instrumentation/opentelemetry-instrumentation-genai-smolagents/.changelog/349.added
@@ -1,0 +1,1 @@
+Add skeleton and boilerplate for smolagents instrumentation package (``opentelemetry-instrumentation-genai-smolagents``).

--- a/instrumentation/opentelemetry-instrumentation-genai-smolagents/LICENSE
+++ b/instrumentation/opentelemetry-instrumentation-genai-smolagents/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/instrumentation/opentelemetry-instrumentation-genai-smolagents/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-genai-smolagents/README.rst
@@ -1,0 +1,52 @@
+OpenTelemetry smolagents Instrumentation
+========================================
+
+|pypi|
+
+.. |pypi| image:: https://badge.fury.io/py/opentelemetry-instrumentation-genai-smolagents.svg
+   :target: https://pypi.org/project/opentelemetry-instrumentation-genai-smolagents/
+
+This library provides OpenTelemetry instrumentation for `smolagents
+<https://github.com/huggingface/smolagents>`_.
+
+Installation
+------------
+
+::
+
+    pip install opentelemetry-instrumentation-genai-smolagents
+
+Usage
+-----
+
+.. code-block:: python
+
+    from opentelemetry.instrumentation.genai.smolagents import (
+        SmolagentsInstrumentor,
+    )
+
+    # Instrument smolagents
+    SmolagentsInstrumentor().instrument()
+
+Configuration
+-------------
+
+Capture Message Content
+***********************
+
+By default, prompts and completions are not captured. To capture message
+content, set the environment variable
+``OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT`` to one of ``NO_CONTENT``,
+``SPAN_ONLY``, ``EVENT_ONLY``, or ``SPAN_AND_EVENT``:
+
+::
+
+    export OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=SPAN_AND_EVENT
+
+References
+----------
+
+* `OpenTelemetry Project <https://opentelemetry.io/>`_
+* `OpenTelemetry GenAI semantic conventions <https://opentelemetry.io/docs/specs/semconv/gen-ai/>`_
+* `smolagents Documentation <https://huggingface.co/docs/smolagents>`_
+* `smolagents GitHub Repository <https://github.com/huggingface/smolagents>`_

--- a/instrumentation/opentelemetry-instrumentation-genai-smolagents/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-genai-smolagents/README.rst
@@ -43,6 +43,34 @@ content, set the environment variable
 
     export OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=SPAN_AND_EVENT
 
+Uploading Content to External Storage
+*************************************
+
+Captured prompt and completion content can be forwarded to external storage
+through a completion hook instead of being recorded inline. Select the built-in
+``upload`` hook and point it at a destination:
+
+::
+
+    export OTEL_INSTRUMENTATION_GENAI_COMPLETION_HOOK=upload
+    export OTEL_INSTRUMENTATION_GENAI_UPLOAD_BASE_PATH=/path/to/prompts  # or gs://my_bucket
+
+The ``upload`` hook is provided by ``opentelemetry-util-genai`` and requires its
+``[upload]`` extra. See the `opentelemetry-util-genai README
+<https://github.com/open-telemetry/opentelemetry-python-genai/blob/main/util/opentelemetry-util-genai/README.rst>`_
+for the other content-capture and upload options it owns.
+
+You can also pass a hook programmatically, which takes precedence over the
+environment variable:
+
+.. code-block:: python
+
+    from opentelemetry.instrumentation.genai.smolagents import (
+        SmolagentsInstrumentor,
+    )
+
+    SmolagentsInstrumentor().instrument(completion_hook=my_hook)
+
 References
 ----------
 

--- a/instrumentation/opentelemetry-instrumentation-genai-smolagents/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-genai-smolagents/pyproject.toml
@@ -1,0 +1,88 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "opentelemetry-instrumentation-genai-smolagents"
+dynamic = ["version"]
+description = "OpenTelemetry smolagents instrumentation"
+readme = "README.rst"
+license = "Apache-2.0"
+requires-python = ">=3.10"
+authors = [
+  { name = "OpenTelemetry Authors", email = "cncf-opentelemetry-contributors@lists.cncf.io" },
+]
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: Apache Software License",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
+]
+dependencies = [
+  "opentelemetry-api ~= 1.43",
+  "opentelemetry-instrumentation >= 0.64b0, <1",
+  "opentelemetry-semantic-conventions >= 0.64b0, <1",
+  "opentelemetry-util-genai >= 1.0b0, <2",
+]
+
+[project.optional-dependencies]
+instruments = ["smolagents >= 1.24.0"]
+
+[project.entry-points.opentelemetry_instrumentor]
+smolagents = "opentelemetry.instrumentation.genai.smolagents:SmolagentsInstrumentor"
+
+[project.urls]
+Homepage = "https://github.com/open-telemetry/opentelemetry-python-genai/tree/main/instrumentation/opentelemetry-instrumentation-genai-smolagents"
+Repository = "https://github.com/open-telemetry/opentelemetry-python-genai"
+
+[tool.hatch.version]
+path = "src/opentelemetry/instrumentation/genai/smolagents/version.py"
+
+[tool.hatch.build.targets.sdist]
+include = ["/src", "/tests"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/opentelemetry"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+
+[tool.towncrier]
+directory = ".changelog"
+filename = "CHANGELOG.md"
+start_string = "<!-- changelog start -->\n"
+template = "../../scripts/changelog_template.j2"
+issue_format = "[#{issue}](https://github.com/open-telemetry/opentelemetry-python-genai/pull/{issue})"
+wrap = true
+issue_pattern = "^(\\d+)"
+
+[[tool.towncrier.type]]
+directory = "added"
+name = "Added"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "changed"
+name = "Changed"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "deprecated"
+name = "Deprecated"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "removed"
+name = "Removed"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "fixed"
+name = "Fixed"
+showcontent = true

--- a/instrumentation/opentelemetry-instrumentation-genai-smolagents/src/opentelemetry/instrumentation/genai/smolagents/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-smolagents/src/opentelemetry/instrumentation/genai/smolagents/__init__.py
@@ -1,0 +1,73 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+OpenTelemetry smolagents Instrumentation
+========================================
+
+Instrumentation for `smolagents <https://github.com/huggingface/smolagents>`_.
+
+Usage
+-----
+
+.. code-block:: python
+
+    from opentelemetry.instrumentation.genai.smolagents import (
+        SmolagentsInstrumentor,
+    )
+
+    # Enable instrumentation
+    SmolagentsInstrumentor().instrument()
+
+Configuration
+-------------
+
+Message content capture can be configured by setting the environment variable
+``OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT``. Supported values are
+``NO_CONTENT``, ``SPAN_ONLY``, ``EVENT_ONLY``, and ``SPAN_AND_EVENT``.
+
+API
+---
+"""
+
+from __future__ import annotations
+
+from typing import Any, Collection
+
+from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
+from opentelemetry.util.genai.completion_hook import load_completion_hook
+from opentelemetry.util.genai.handler import TelemetryHandler
+
+from .package import _instruments
+
+__all__ = ["SmolagentsInstrumentor"]
+
+
+class SmolagentsInstrumentor(BaseInstrumentor):
+    """An instrumentor for smolagents."""
+
+    def instrumentation_dependencies(self) -> Collection[str]:
+        return _instruments
+
+    def _instrument(self, **kwargs: Any) -> None:
+        """Enable smolagents instrumentation.
+
+        Args:
+            **kwargs: Optional arguments
+                - tracer_provider: TracerProvider instance
+                - meter_provider: MeterProvider instance
+                - logger_provider: LoggerProvider instance
+                - completion_hook: CompletionHook instance
+        """
+        TelemetryHandler(
+            tracer_provider=kwargs.get("tracer_provider"),
+            meter_provider=kwargs.get("meter_provider"),
+            logger_provider=kwargs.get("logger_provider"),
+            completion_hook=kwargs.get("completion_hook")
+            or load_completion_hook(),
+        )
+        # Patching will be added in follow-up PRs.
+
+    def _uninstrument(self, **kwargs: Any) -> None:
+        """Disable smolagents instrumentation and restore patched originals."""
+        # Unpatching will be added in follow-up PRs.

--- a/instrumentation/opentelemetry-instrumentation-genai-smolagents/src/opentelemetry/instrumentation/genai/smolagents/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-smolagents/src/opentelemetry/instrumentation/genai/smolagents/__init__.py
@@ -26,6 +26,12 @@ Message content capture can be configured by setting the environment variable
 ``OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT``. Supported values are
 ``NO_CONTENT``, ``SPAN_ONLY``, ``EVENT_ONLY``, and ``SPAN_AND_EVENT``.
 
+Captured content can be forwarded to external storage with a completion hook.
+Set ``OTEL_INSTRUMENTATION_GENAI_COMPLETION_HOOK=upload`` (with
+``OTEL_INSTRUMENTATION_GENAI_UPLOAD_BASE_PATH``), or pass one programmatically
+via ``instrument(completion_hook=...)`` which takes precedence over the
+environment variable.
+
 API
 ---
 """

--- a/instrumentation/opentelemetry-instrumentation-genai-smolagents/src/opentelemetry/instrumentation/genai/smolagents/package.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-smolagents/src/opentelemetry/instrumentation/genai/smolagents/package.py
@@ -1,0 +1,4 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+_instruments = ("smolagents >= 1.24.0",)

--- a/instrumentation/opentelemetry-instrumentation-genai-smolagents/src/opentelemetry/instrumentation/genai/smolagents/version.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-smolagents/src/opentelemetry/instrumentation/genai/smolagents/version.py
@@ -1,0 +1,4 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+__version__ = "1.1b0.dev"

--- a/instrumentation/opentelemetry-instrumentation-genai-smolagents/tests/conftest.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-smolagents/tests/conftest.py
@@ -1,0 +1,26 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Test configuration and fixtures for smolagents instrumentation tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from opentelemetry.instrumentation.genai.smolagents import (
+    SmolagentsInstrumentor,
+)
+from opentelemetry.test_util_genai.instrumentor import instrument
+
+pytest_plugins = ["opentelemetry.test_util_genai.fixtures"]
+
+
+@pytest.fixture
+def instrument_smolagents(tracer_provider, logger_provider, meter_provider):
+    with instrument(
+        SmolagentsInstrumentor(),
+        tracer_provider=tracer_provider,
+        logger_provider=logger_provider,
+        meter_provider=meter_provider,
+    ) as instrumentor:
+        yield instrumentor

--- a/instrumentation/opentelemetry-instrumentation-genai-smolagents/tests/requirements.latest.txt
+++ b/instrumentation/opentelemetry-instrumentation-genai-smolagents/tests/requirements.latest.txt
@@ -27,7 +27,6 @@
 # supported version of external dependencies.
 
 smolagents
-wrapt>=2.2.2
 
 -e util/opentelemetry-util-genai
 -e instrumentation/opentelemetry-instrumentation-genai-smolagents

--- a/instrumentation/opentelemetry-instrumentation-genai-smolagents/tests/requirements.latest.txt
+++ b/instrumentation/opentelemetry-instrumentation-genai-smolagents/tests/requirements.latest.txt
@@ -1,0 +1,33 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# ********************************
+# WARNING: NOT HERMETIC !!!!!!!!!!
+# ********************************
+#
+# This "requirements.txt" is installed in conjunction with multiple other
+# dependencies in the top-level "tox.ini" file. In particular, please see:
+#
+#   smolagents-latest: {[testenv]test_deps}
+#   smolagents-latest: -r {toxinidir}/instrumentation/opentelemetry-instrumentation-genai-smolagents/tests/requirements.latest.txt
+#
+# This variant of the requirements aims to test the system using the newest
+# supported version of external dependencies.
+
+smolagents
+wrapt>=2.2.2
+
+-e util/opentelemetry-util-genai
+-e instrumentation/opentelemetry-instrumentation-genai-smolagents

--- a/instrumentation/opentelemetry-instrumentation-genai-smolagents/tests/requirements.oldest.txt
+++ b/instrumentation/opentelemetry-instrumentation-genai-smolagents/tests/requirements.oldest.txt
@@ -1,0 +1,25 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Oldest test-only dependency pins.
+#
+# The package's own declared deps (smolagents via the instruments extra,
+# opentelemetry-api, opentelemetry-instrumentation, opentelemetry-semantic-conventions,
+# opentelemetry-util-genai) resolve to their pyproject.toml floors via
+# UV_RESOLUTION=lowest-direct on the oldest tox factor, so they are NOT pinned here —
+# pyproject.toml is the single source of truth. The OpenTelemetry SDK and test utilities
+# come transitively from opentelemetry-test-util-genai.
+#
+# There is nothing to pin yet: the lifecycle tests need no model backend. The pins for
+# the backends the model tests drive arrive with those tests.

--- a/instrumentation/opentelemetry-instrumentation-genai-smolagents/tests/test_instrumentor.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-smolagents/tests/test_instrumentor.py
@@ -1,0 +1,97 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Entry-point and instrument/uninstrument lifecycle tests.
+
+The instrumentor patches nothing yet, so these cover the parts of its contract
+that hold before any patching lands: the entry point resolves, the declared
+dependency is reported, and repeated instrument/uninstrument cycles stay quiet.
+"""
+
+from __future__ import annotations
+
+from opentelemetry.instrumentation.genai.smolagents import (
+    SmolagentsInstrumentor,
+)
+from opentelemetry.util._importlib_metadata import entry_points
+
+
+def test_entrypoint_loads_instrumentor() -> None:
+    (entrypoint,) = entry_points(
+        group="opentelemetry_instrumentor", name="smolagents"
+    )
+    instrumentor = entrypoint.load()()
+    assert isinstance(instrumentor, SmolagentsInstrumentor)
+
+
+def test_instrumentation_dependencies() -> None:
+    dependencies = SmolagentsInstrumentor().instrumentation_dependencies()
+    assert "smolagents >= 1.24.0" in dependencies
+
+
+def test_instrument_uninstrument_cycle(
+    tracer_provider, logger_provider, meter_provider
+) -> None:
+    instrumentor = SmolagentsInstrumentor()
+    instrumentor.instrument(
+        tracer_provider=tracer_provider,
+        logger_provider=logger_provider,
+        meter_provider=meter_provider,
+    )
+    assert instrumentor.is_instrumented_by_opentelemetry
+
+    instrumentor.uninstrument()
+    assert not instrumentor.is_instrumented_by_opentelemetry
+
+
+def test_repeated_instrument_uninstrument(
+    tracer_provider, logger_provider, meter_provider
+) -> None:
+    # BaseInstrumentor returns a per-class singleton, so the lifecycle has to
+    # survive being driven more than once.
+    instrumentor = SmolagentsInstrumentor()
+    for _ in range(2):
+        instrumentor.instrument(
+            tracer_provider=tracer_provider,
+            logger_provider=logger_provider,
+            meter_provider=meter_provider,
+        )
+        assert instrumentor.is_instrumented_by_opentelemetry
+        instrumentor.uninstrument()
+        assert not instrumentor.is_instrumented_by_opentelemetry
+
+
+def test_uninstrument_through_a_new_constructor_call(
+    tracer_provider, logger_provider, meter_provider
+) -> None:
+    # BaseInstrumentor.__new__ returns a per-class singleton but Python still
+    # runs __init__ on every construction, so the documented
+    # SmolagentsInstrumentor().instrument() / SmolagentsInstrumentor()
+    # .uninstrument() form has to work on the live instance.
+    SmolagentsInstrumentor().instrument(
+        tracer_provider=tracer_provider,
+        logger_provider=logger_provider,
+        meter_provider=meter_provider,
+    )
+    SmolagentsInstrumentor().uninstrument()
+
+    assert not SmolagentsInstrumentor().is_instrumented_by_opentelemetry
+
+
+def test_uninstrument_without_instrument() -> None:
+    # BaseInstrumentor.uninstrument() short-circuits, but _uninstrument() must
+    # also be a no-op on its own: the rollback path in _instrument() calls it
+    # after a partial patch.
+    SmolagentsInstrumentor().uninstrument()
+    SmolagentsInstrumentor()._uninstrument()  # noqa: SLF001
+
+
+def test_instrument_with_no_providers() -> None:
+    # Without providers the handler falls back to the globals; instrumenting
+    # must not require a caller to pass them.
+    instrumentor = SmolagentsInstrumentor()
+    instrumentor.instrument()
+    try:
+        assert instrumentor.is_instrumented_by_opentelemetry
+    finally:
+        instrumentor.uninstrument()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
   "opentelemetry-instrumentation-genai-openai[instruments]",
   "opentelemetry-instrumentation-genai-openai-agents[instruments]",
   "opentelemetry-instrumentation-genai-qwen-agent[instruments]",
+  "opentelemetry-instrumentation-genai-smolagents[instruments]",
   "opentelemetry-instrumentation-genai-weaviate-client[instruments]",
 ]
 
@@ -42,6 +43,7 @@ opentelemetry-instrumentation-genai-llama-index = { workspace = true }
 opentelemetry-instrumentation-genai-openai = { workspace = true }
 opentelemetry-instrumentation-genai-openai-agents = { workspace = true }
 opentelemetry-instrumentation-genai-qwen-agent = { workspace = true }
+opentelemetry-instrumentation-genai-smolagents = { workspace = true }
 opentelemetry-instrumentation-genai-weaviate-client = { workspace = true }
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -36,6 +36,11 @@ envlist =
     py314-test-instrumentation-genai-agno-conformance
     lint-instrumentation-genai-agno
 
+    ; instrumentation-genai-smolagents
+    py3{10,11,12,13,14}-test-instrumentation-genai-smolagents-latest
+    py310-test-instrumentation-genai-smolagents-oldest
+    lint-instrumentation-genai-smolagents
+
     ; instrumentation-genai-anthropic
     py3{10,11,12,13,14}-test-instrumentation-genai-anthropic-latest
     py310-test-instrumentation-genai-anthropic-oldest
@@ -142,6 +147,13 @@ deps =
   agno-conformance: {[testenv]pytest_deps}
   agno-conformance: -r {toxinidir}/instrumentation/opentelemetry-instrumentation-genai-agno/tests/requirements.latest.txt
 
+  smolagents-oldest: {[testenv]pytest_deps}
+  smolagents-oldest: -e {toxinidir}/instrumentation/opentelemetry-instrumentation-genai-smolagents[instruments]
+  smolagents-oldest: -r {toxinidir}/instrumentation/opentelemetry-instrumentation-genai-smolagents/tests/requirements.oldest.txt
+  smolagents-latest: {[testenv]test_deps}
+  smolagents-latest: {[testenv]pytest_deps}
+  smolagents-latest: -r {toxinidir}/instrumentation/opentelemetry-instrumentation-genai-smolagents/tests/requirements.latest.txt
+
   anthropic-oldest: {[testenv]pytest_deps}
   anthropic-oldest: -e {toxinidir}/instrumentation/opentelemetry-instrumentation-genai-anthropic[instruments]
   anthropic-oldest: -r {toxinidir}/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/requirements.oldest.txt
@@ -231,6 +243,9 @@ commands =
   test-instrumentation-genai-agno-{oldest,latest}: pytest --ignore={toxinidir}/instrumentation/opentelemetry-instrumentation-genai-agno/tests/test_conformance.py {toxinidir}/instrumentation/opentelemetry-instrumentation-genai-agno/tests --vcr-record=none {posargs}
   test-instrumentation-genai-agno-conformance: pytest {toxinidir}/instrumentation/opentelemetry-instrumentation-genai-agno/tests/test_conformance.py --vcr-record=none {posargs}
   lint-instrumentation-genai-agno: sh -c "cd instrumentation && ruff check opentelemetry-instrumentation-genai-agno"
+
+  test-instrumentation-genai-smolagents-{oldest,latest}: pytest --ignore={toxinidir}/instrumentation/opentelemetry-instrumentation-genai-smolagents/tests/test_conformance.py {toxinidir}/instrumentation/opentelemetry-instrumentation-genai-smolagents/tests --vcr-record=none {posargs}
+  lint-instrumentation-genai-smolagents: sh -c "cd instrumentation && ruff check opentelemetry-instrumentation-genai-smolagents"
 
   test-instrumentation-genai-anthropic-{oldest,latest}: pytest --ignore={toxinidir}/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/test_conformance.py {toxinidir}/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests --vcr-record=none {posargs}
   test-instrumentation-genai-anthropic-conformance: pytest {toxinidir}/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/test_conformance.py --vcr-record=none {posargs}
@@ -337,6 +352,7 @@ deps =
   -e {toxinidir}/util/opentelemetry-util-genai[upload]
   -e {toxinidir}/instrumentation/opentelemetry-instrumentation-google-genai[instruments]
   -e {toxinidir}/instrumentation/opentelemetry-instrumentation-genai-agno[instruments]
+  -e {toxinidir}/instrumentation/opentelemetry-instrumentation-genai-smolagents[instruments]
   -e {toxinidir}/instrumentation/opentelemetry-instrumentation-genai-anthropic[instruments]
   -e {toxinidir}/instrumentation/opentelemetry-instrumentation-genai-langchain[instruments]
   -e {toxinidir}/instrumentation/opentelemetry-instrumentation-genai-llama-index[instruments]

--- a/uv.lock
+++ b/uv.lock
@@ -22,6 +22,7 @@ members = [
     "opentelemetry-instrumentation-genai-openai",
     "opentelemetry-instrumentation-genai-openai-agents",
     "opentelemetry-instrumentation-genai-qwen-agent",
+    "opentelemetry-instrumentation-genai-smolagents",
     "opentelemetry-instrumentation-genai-weaviate-client",
     "opentelemetry-instrumentation-google-genai",
     "opentelemetry-python-genai",
@@ -779,7 +780,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1178,6 +1179,30 @@ wheels = [
 ]
 
 [[package]]
+name = "hf-xet"
+version = "1.5.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/39/67be8d71f900d9a55761b6022821d6679fb56c64f1b6063d5af2c2606727/hf_xet-1.5.2.tar.gz", hash = "sha256:73044bd31bae33c984af832d19c752a0dffb67518fee9ddbd91d616e1101cf47", size = 903674, upload-time = "2026-07-16T17:29:56.833Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/be/525eabac5d1736b679c39e342ecd4292534012546a2d18f0043c8e3b6021/hf_xet-1.5.2-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:4a5ecb9cda8512ba2aa8ee5d37c87a1422992165892d653098c7b90247481c3b", size = 4064284, upload-time = "2026-07-16T17:29:29.907Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/3f/699749dd78442480eda4e4fca494284b0e3542e4063cc37654d5fdc929e6/hf_xet-1.5.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:8764488197c1d7b1378c8438c18d2eea902e150dbca0b0f0d2d32603fb9b5576", size = 3828537, upload-time = "2026-07-16T17:29:31.549Z" },
+    { url = "https://files.pythonhosted.org/packages/22/d7/2658ac0a5b9f4664ca27ce31bd015044fe9dea50ed455fb5197aba819c11/hf_xet-1.5.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8d7446f72abbf7e01ca5ff131786bc2e74a56393462c17a6bf1e303fbab81db4", size = 4417133, upload-time = "2026-07-16T17:29:33.391Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/58/8343f3cb63c8fa058d576136df3871550f7d5214a8f048a7ea2eab6ac906/hf_xet-1.5.2-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:580e59e29bf37aece1f2b68537de1e3fb04f43a23d910dcf6f128280b5bfbba4", size = 4212613, upload-time = "2026-07-16T17:29:34.989Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/33/a968f4e4535037b36941ec00714625fb60e026302407e7e26ca9f3e65f4e/hf_xet-1.5.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bee28c619622d36968056532fd49cf2b35ca75099b1d616c31a618a893491380", size = 4412710, upload-time = "2026-07-16T17:29:36.646Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/d9/9e33981173dbaf194ba0015202b02d467b624d44d4eba89e1bf06c0d2995/hf_xet-1.5.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:e396ab0faf6298199ad7a95305c3ca8498cb825978a6485be6d00587ee4ec577", size = 4628455, upload-time = "2026-07-16T17:29:38.352Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/4b/cc682832de4264a03880a2d1b5ec3e1fab3bf307f508817250baafdb9996/hf_xet-1.5.2-cp314-cp314t-win_amd64.whl", hash = "sha256:fd3add255549e8ef58fa35b2e42dc016961c050600444e7d77d030ba6b57120e", size = 3979044, upload-time = "2026-07-16T17:29:40.329Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/09/b2cdf2a0fb39a08af3222b96092a36bd3b40c54123eef07de4422e870971/hf_xet-1.5.2-cp314-cp314t-win_arm64.whl", hash = "sha256:d6f9c58549407b84b9a5383afd68db0acc42345326a3159990b36a5ca8a20e4e", size = 3808037, upload-time = "2026-07-16T17:29:42.357Z" },
+    { url = "https://files.pythonhosted.org/packages/de/ba/2b70603c7552db82baeb2623e2336898304a17328845151be4fe1f48d420/hf_xet-1.5.2-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:f922b8f5fb84f1dd3d7ab7a1316354a1bca9b1c73ecfc19c76e51a2a49d29799", size = 4033760, upload-time = "2026-07-16T17:29:43.884Z" },
+    { url = "https://files.pythonhosted.org/packages/60/ac/b097a86a1e4a6098f3a79382643ab09d5733d87ccc864877ad1e12b49b70/hf_xet-1.5.2-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:045f84440c55cdeb659cf1a1dd48c77bcd0d2e93632e2fea8f2c3bdee79f38ed", size = 3841438, upload-time = "2026-07-16T17:29:45.539Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/35/db860aa3a0780660324a506ad4b3d322ddc6ecbba4b9340aed0942cbf21c/hf_xet-1.5.2-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:db78c39c83d6279daddc98e2238f373ab8980685556d42472b4ec51abcf03e8c", size = 4428006, upload-time = "2026-07-16T17:29:46.996Z" },
+    { url = "https://files.pythonhosted.org/packages/af/6b/832dd980af4b0c3ae0660e309285f2ffcdff2faa38129390dbb47aa4a3f9/hf_xet-1.5.2-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:7db73c810500c54c6760be8c39d4b2e476974de85424c50063efc22fdda13025", size = 4221099, upload-time = "2026-07-16T17:29:48.525Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/05/ae50f0d34e3254e6c3e208beb2519f6b8673016fc4b3643badaf6450d186/hf_xet-1.5.2-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:6395cfe3c9cbead4f16b31808b0e67eac428b66c656f856e99636adaddea878f", size = 4420766, upload-time = "2026-07-16T17:29:50.092Z" },
+    { url = "https://files.pythonhosted.org/packages/07/a9/c050bc2743a2bcd68928bfee157b08681667a164a24ec95fbfcfcd717e08/hf_xet-1.5.2-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:cde8cd167126bb6109b2ceb19b844433a4988643e8f3e01dd9dd0e4a34535097", size = 4636716, upload-time = "2026-07-16T17:29:51.62Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/f8/68b01c5c2edb56ac9a67b3d076ffddcb90867abaee923923eb34e7a14e76/hf_xet-1.5.2-cp38-abi3-win_amd64.whl", hash = "sha256:ecf63d1cb69a9a7319910f8f83fcf9b46e7a32dfcf4b8f8eeddb55f647306e65", size = 3988373, upload-time = "2026-07-16T17:29:53.395Z" },
+    { url = "https://files.pythonhosted.org/packages/39/c6/988383e9dc17294d536fcbcd6fd16eed882e411ad16c954984a53e47b09c/hf_xet-1.5.2-cp38-abi3-win_arm64.whl", hash = "sha256:1da28519496eb7c8094c11e4d25509b4a468457a0302d58136099db2fd9a671d", size = 3816957, upload-time = "2026-07-16T17:29:54.991Z" },
+]
+
+[[package]]
 name = "hpack"
 version = "4.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1226,6 +1251,26 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
+name = "huggingface-hub"
+version = "1.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
+    { name = "httpx" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/82/db/3582597f8be0d34bd6881365a26d390854f12893eabdd62dd36de9df5a47/huggingface_hub-1.26.0.tar.gz", hash = "sha256:c8cd4e2df1ba9402f77fce9b509ec1d52debb502551789473f34016acc14e361", size = 936665, upload-time = "2026-07-30T14:12:04.156Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/bb/63a644c75b545f3ff394b822e9bd1c4a9586489c618b77a4d8a44a33a23b/huggingface_hub-1.26.0-py3-none-any.whl", hash = "sha256:e8cca670caa5d8dfa7e45bf45e86b466698198cd8150c021bcdb4a86b9252364", size = 780357, upload-time = "2026-07-30T14:12:01.998Z" },
 ]
 
 [[package]]
@@ -2486,6 +2531,31 @@ requires-dist = [
 provides-extras = ["instruments"]
 
 [[package]]
+name = "opentelemetry-instrumentation-genai-smolagents"
+source = { editable = "instrumentation/opentelemetry-instrumentation-genai-smolagents" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-genai" },
+]
+
+[package.optional-dependencies]
+instruments = [
+    { name = "smolagents" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "opentelemetry-api", specifier = "~=1.43" },
+    { name = "opentelemetry-instrumentation", specifier = ">=0.64b0,<1" },
+    { name = "opentelemetry-semantic-conventions", specifier = ">=0.64b0,<1" },
+    { name = "opentelemetry-util-genai", editable = "util/opentelemetry-util-genai" },
+    { name = "smolagents", marker = "extra == 'instruments'", specifier = ">=1.24.0" },
+]
+provides-extras = ["instruments"]
+
+[[package]]
 name = "opentelemetry-instrumentation-genai-weaviate-client"
 source = { editable = "instrumentation/opentelemetry-instrumentation-genai-weaviate-client" }
 dependencies = [
@@ -2550,6 +2620,7 @@ dependencies = [
     { name = "opentelemetry-instrumentation-genai-openai", extra = ["instruments"] },
     { name = "opentelemetry-instrumentation-genai-openai-agents", extra = ["instruments"] },
     { name = "opentelemetry-instrumentation-genai-qwen-agent", extra = ["instruments"] },
+    { name = "opentelemetry-instrumentation-genai-smolagents", extra = ["instruments"] },
     { name = "opentelemetry-instrumentation-genai-weaviate-client", extra = ["instruments"] },
     { name = "opentelemetry-instrumentation-google-genai", extra = ["instruments"] },
     { name = "opentelemetry-sdk" },
@@ -2579,6 +2650,7 @@ requires-dist = [
     { name = "opentelemetry-instrumentation-genai-openai", extras = ["instruments"], editable = "instrumentation/opentelemetry-instrumentation-genai-openai" },
     { name = "opentelemetry-instrumentation-genai-openai-agents", extras = ["instruments"], editable = "instrumentation/opentelemetry-instrumentation-genai-openai-agents" },
     { name = "opentelemetry-instrumentation-genai-qwen-agent", extras = ["instruments"], editable = "instrumentation/opentelemetry-instrumentation-genai-qwen-agent" },
+    { name = "opentelemetry-instrumentation-genai-smolagents", extras = ["instruments"], editable = "instrumentation/opentelemetry-instrumentation-genai-smolagents" },
     { name = "opentelemetry-instrumentation-genai-weaviate-client", extras = ["instruments"], editable = "instrumentation/opentelemetry-instrumentation-genai-weaviate-client" },
     { name = "opentelemetry-instrumentation-google-genai", extras = ["instruments"], editable = "instrumentation/opentelemetry-instrumentation-google-genai" },
     { name = "opentelemetry-sdk" },
@@ -3934,6 +4006,23 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
+name = "smolagents"
+version = "1.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+    { name = "jinja2" },
+    { name = "pillow" },
+    { name = "python-dotenv" },
+    { name = "requests" },
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bd/85/3ca67bb57743434ac321821ea54cbdbf0d3dcc8d55f37199709e83141340/smolagents-1.26.0.tar.gz", hash = "sha256:4ec92313265f9cfbcabfc88e192b4bc4505f8475dc5f33dc872062fc567037bd", size = 239034, upload-time = "2026-05-29T05:08:44.732Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/8c/72bd5edc13288e3f27d4d9c1ef65adc0a68c950ee1fc6d3be270e1110f6c/smolagents-1.26.0-py3-none-any.whl", hash = "sha256:70e1cfb1576f782da93190ee31d9bb2659e5ca4bd84fda0c412e1f20498f28b6", size = 161466, upload-time = "2026-05-29T05:08:43.28Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Description

Add the package scaffold for porting openinference-instrumentation-smolagents: pyproject, entry point, a no-op instrumentor that builds the TelemetryHandler, lifecycle tests, and the workspace, tox and docs wiring.

Part of https://github.com/open-telemetry/opentelemetry-python-genai/issues/141

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)