### PR TITLE
Add guidance on what to instrument: don't instrument inference in agentic frameworks

### DIFF
--- a/.github/instructions/instrumentation.instructions.md
+++ b/.github/instructions/instrumentation.instructions.md
@@ -58,7 +58,19 @@ prefer opt-in or additive. Breaking changes need explicit justification in the P
   always reachable — prefer the least intrusive option that works.
 - If a capability is missing in `opentelemetry-util-genai`, land it in the util first.
 
-## 3. Semantic conventions
+## 3. Operation scope
+
+Investigate the library's real API and apply the litmus tests in
+[`instrumentation/AGENTS.md`](../../instrumentation/AGENTS.md).
+Flag, with a link to the rule:
+
+- An operation the library delegates to another instrumentable library (e.g. a framework calling
+  `openai`/`anthropic`/`google-genai` under the hood) — it belongs to that library, not here.
+- An operation the library has no concept of: inference/embeddings unless the library is itself the
+  model-call boundary; `invoke_agent` unless it models agents; `invoke_workflow` unless it models
+  workflows/graphs/complex agents.
+
+## 4. Semantic conventions
 
 - Attributes, spans, events, and metrics must match the
   [GenAI semantic conventions](https://github.com/open-telemetry/semantic-conventions-genai/tree/main/docs/gen-ai).
@@ -77,13 +89,13 @@ prefer opt-in or additive. Breaking changes need explicit justification in the P
   must be extended instead.
 - If a signal is not in semconv, wait until semconv lands.
 
-## 4. Exception handling
+## 5. Exception handling
 
 - When catching exceptions from the underlying library to record telemetry, always re-raise the
   original exception unmodified.
 - Do not raise **new** exceptions in instrumentation/telemetry code.
 
-## 5. Tests
+## 6. Tests
 
 - For every public API instrumented, cover sync/async variants when both exist.
 - Cover streaming and non-streaming variants when both exist.
@@ -114,12 +126,12 @@ prefer opt-in or additive. Breaking changes need explicit justification in the P
   `tests/test_conformance.py` that runs them via
   `opentelemetry.test_util_genai.conformance.run_conformance`.
 
-## 6. Examples
+## 7. Examples
 
 New instrumentations must ship a minimal example under the package's `examples/`, with both a
 `manual/` and a `zero-code/` (auto-instrumentation) variant.
 
-## 7. README
+## 8. README
 
 - Each package's `README.rst` is published as its PyPI long description. Flag PRs that make
   user-visible changes to the public API, configuration (env vars, `instrument()` keyword
@@ -127,12 +139,12 @@ New instrumentations must ship a minimal example under the package's `examples/`
   `README.rst` to match.
 - README claims must be accurate — reject documented options, span types, or metrics the code does not actually emit.
 
-## 8. PR description
+## 9. PR description
 
 - Cover which part of the GenAI semconv the change implements or follows (when applicable) and
   how instrumentations should consume it.
 
-## 9. Package naming and versioning
+## 10. Package naming and versioning
 
 - Instrumentation packages must be named `opentelemetry-instrumentation-genai-{lib}` and import
   as `opentelemetry.instrumentation.genai.{lib}` (`opentelemetry-instrumentation-google-genai`
@@ -140,7 +152,7 @@ New instrumentations must ship a minimal example under the package's `examples/`
 - Versions use the OpenTelemetry beta versioning format `MAJOR.MINORbN` (e.g. `1.0b0`);
   `version.py` carries a `.dev` suffix during development.
 
-## 10. Dependency versioning and compatibility
+## 11. Dependency versioning and compatibility
 
 - Reject dependency changes in `pyproject.toml` that unnecessarily pin versions to exact patch ranges (like `== x.y.z` or `~= x.y.z`).
 - Prefer ranges that allow minor updates (e.g., `~= x.y` or `>= x.y.z, < (x+1)`).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -200,6 +200,31 @@ The absence of compatible native instrumentation is just one factor. Whether we
 add an instrumentation here also depends on things like the library's popularity
 and whether it's actively maintained.
 
+## Which operations an instrumentation should emit
+
+An instrumentation emits telemetry only for the operations the library itself
+performs. Two principles:
+
+- **Don't re-emit another library's telemetry.** If the library delegates an
+  operation to another instrumentable library (for example a framework that
+  calls `openai`, `anthropic`, or `google-genai` under the hood), instrumentation
+  for that operation belongs to the underlying library, and the two correlate
+  through standard context propagation.
+- **Emit an operation only when the library has that concept.** Emit inference or
+  embeddings only when the library is itself the model-call boundary, an
+  `invoke_agent` span only when it models agents, an `invoke_workflow` span only
+  when it models workflows or graphs, `execute_tool` only when it runs the tool
+  itself, and so on. Calling the provider's REST API directly (with no separate
+  instrumentable client library in between) makes the library the model-call
+  boundary, so it is a valid reason to emit inference.
+
+Agent-framework instrumentation SHOULD NOT emit inference spans by default; the
+underlying LLM library owns them. The exception is a framework that issues the
+model call in a way no other instrumentable library can observe — it calls the
+REST API directly, embeds a vendored model library, or similar. In that case the
+framework is the only place the inference call is visible, so it SHOULD emit the
+span.
+
 ## Keep PRs small
 
 One logical change per PR. Don't bundle unrelated fixes, refactors, or

--- a/instrumentation/AGENTS.md
+++ b/instrumentation/AGENTS.md
@@ -1,4 +1,4 @@
-## Decide what the library supports
+# Decide what the library supports
 
 An instrumentation emits telemetry only for operations the instrumented library itself performs. If
 library A delegates an operation to another (also instrumentable) library B, do **not** emit that

--- a/instrumentation/AGENTS.md
+++ b/instrumentation/AGENTS.md
@@ -1,0 +1,67 @@
+## Decide what the library supports
+
+An instrumentation emits telemetry only for operations the instrumented library itself performs. If
+library A delegates an operation to another (also instrumentable) library B, do **not** emit that
+operation from A's instrumentation — it belongs to B, and the two correlate through standard context
+propagation.
+
+**Fact-check against the library's real API reference.** Do not guess what a library does or doesn't
+support from its name or reputation. Before deciding an operation is in or out of scope, confirm it
+against the library's official API docs — many SDKs cover more than their obvious use case (e.g.
+`openai` has retrieval via vector stores / file search and conversation state, not just inference).
+Describe each operation in terms of the concrete API that backs it.
+
+Run each litmus test to decide which operations apply.
+
+### Model call (inference / embeddings)
+
+Before emitting an inference (`chat`) or `embeddings` span, ask:
+
+> Does this library delegate the actual model call to another instrumentable library
+> (e.g. `openai`, `litellm`, `google-genai`)?
+
+- **Yes** → do **not** emit inference or embeddings. It belongs to the underlying LLM library. Emit
+  only framework-owned operations (`invoke_agent`, `invoke_workflow`, `execute_tool`, `retrieval`).
+- **No** (the library is itself the model-call boundary — it calls the model directly, or owns it
+  across a process boundary no in-process instrumentable library can observe) → emit it, and
+  correlate via standard context propagation.
+
+### Tool execution
+
+> Does the library execute the tool itself — i.e. does it provide a tool-execution helper
+> (automatic function calling, an agent/tool runner) that invokes the tool and feeds the result
+> back?
+
+- **Yes** (e.g. `google-genai` automatic function calling, agent frameworks that run tools) →
+  `execute_tool` is instrumentable here; emit it.
+- **No** (the client only returns tool calls and the tool runs in application code the library never
+  sees) → `execute_tool` is **not instrumentable** by this library. Do not emit it from a
+  model-client scenario; a span around the app's own function is not something generic
+  instrumentation of the client could produce.
+
+### Client invoke / create agent
+
+> Does this library create and invoke remote AI agents (e.g. AWS Bedrock Agent or OpenAI
+> Assistants)?
+
+- **Yes** → emit client spans for the create-agent and invoke-agent operations.
+- **No** → do not emit client agent spans. If the library implements agentic scenarios in-process,
+  check the internal invoke-agent test below instead.
+
+### Internal invoke agent
+
+> Does the library have a concept of an AI agent?
+
+- **Yes** → emit an `invoke_agent` span only for scenarios that use the library's agent API.
+- **No** (no formal agent concept, or the AI scenario doesn't involve agents) → check the workflow
+  test instead.
+
+### Workflow
+
+> Does the library have a concept of an AI workflow or graph — an operation that combines arbitrary
+> AI-related operations such as agent invocations, chained LLM calls, and other auxiliary
+> operations?
+
+- **Yes** → emit an `invoke_workflow` span around the library API that runs the workflow.
+- **No** → don't emit a workflow span. A single agent run or a plain chain of calls is not an AI
+  workflow.

--- a/instrumentation/CLAUDE.md
+++ b/instrumentation/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
Adopt guidance from semantic conventions reference: https://github.com/open-telemetry/semantic-conventions-genai/blob/main/reference/AGENTS.md#step-1--decide-what-the-library-supports

Only instrument operations performed by this library. If a library calls into openai, anthropic, google-genai, etc, to do inference we **should not** emit inference spans at the caller level - openai, etc instrumentation should take care of them.

If library call something not-yet-instrumented consider instrumenting it directly.
If library does REST API / RPC calls directly to provider - instrument them inside that library.
