### PR TITLE
Share stream manager wrappers between instrumentations

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/src/opentelemetry/instrumentation/genai/anthropic/wrappers.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/src/opentelemetry/instrumentation/genai/anthropic/wrappers.py
@@ -4,10 +4,8 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from types import TracebackType
 from typing import (
     TYPE_CHECKING,
-    Any,
     Generic,
     Protocol,
     TypeVar,
@@ -15,8 +13,12 @@ from typing import (
 )
 
 from opentelemetry.util.genai.stream import (
+    AsyncStreamManagerWrapper,
     AsyncStreamWrapper,
+    SyncStreamManagerWrapper,
     SyncStreamWrapper,
+    finalize_on_aclose,
+    finalize_on_close,
 )
 
 from .messages_extractors import set_invocation_response_attributes
@@ -29,6 +31,7 @@ except ImportError:
     _sdk_accumulate_event = None
 
 if TYPE_CHECKING:
+    import httpx
     from anthropic._streaming import AsyncStream, Stream
     from anthropic.lib.streaming._messages import (  # pylint: disable=no-name-in-module
         AsyncMessageStream,
@@ -48,7 +51,6 @@ if TYPE_CHECKING:
     from opentelemetry.util.genai.invocation import InferenceInvocation
 
 
-ResponseT = TypeVar("ResponseT")
 ResponseFormatT = TypeVar("ResponseFormatT")
 accumulate_event = cast("Callable[..., Message] | None", _sdk_accumulate_event)
 
@@ -64,36 +66,6 @@ def _set_response_attributes(
     capture_content: bool,
 ) -> None:
     set_invocation_response_attributes(invocation, result, capture_content)
-
-
-class _ResponseProxy(Generic[ResponseT]):
-    def __init__(self, response: ResponseT, finalize: Callable[[], None]):
-        self._response: Any = response
-        self._finalize = finalize
-
-    def close(self) -> None:
-        try:
-            self._response.close()
-        finally:
-            self._finalize()
-
-    def __getattr__(self, name: str):
-        return getattr(self._response, name)
-
-
-class _AsyncResponseProxy(Generic[ResponseT]):
-    def __init__(self, response: ResponseT, finalize: Callable[[], None]):
-        self._response: Any = response
-        self._finalize = finalize
-
-    async def aclose(self) -> None:
-        try:
-            await self._response.aclose()
-        finally:
-            self._finalize()
-
-    def __getattr__(self, name: str):
-        return getattr(self._response, name)
 
 
 class MessageWrapper:
@@ -190,8 +162,8 @@ class MessagesStreamWrapper(
         self._self_message_telemetry_finalized = False
 
     @property
-    def response(self) -> _ResponseProxy[object]:
-        return _ResponseProxy(self.stream.response, self._stop)
+    def response(self) -> httpx.Response:
+        return finalize_on_close(self.stream.response, self._stop)
 
     @property
     def stream(
@@ -204,9 +176,7 @@ class MessagesStreamWrapper(
         self,
         stream: Stream[RawMessageStreamEvent] | MessageStream[ResponseFormatT],
     ) -> None:
-        self.__wrapped__ = stream
-        self._self_stream = stream
-        self._self_iterator = iter(stream)
+        self._set_stream(stream)
 
 
 class AsyncMessagesStreamWrapper(
@@ -232,8 +202,8 @@ class AsyncMessagesStreamWrapper(
         self._self_message_telemetry_finalized = False
 
     @property
-    def response(self) -> Any:
-        return _AsyncResponseProxy(self.stream.response, self._stop)
+    def response(self) -> httpx.Response:
+        return finalize_on_aclose(self.stream.response, self._stop)
 
     @property
     def stream(
@@ -250,12 +220,17 @@ class AsyncMessagesStreamWrapper(
         stream: AsyncStream[RawMessageStreamEvent]
         | AsyncMessageStream[ResponseFormatT],
     ) -> None:
-        self.__wrapped__ = stream
-        self._self_stream = stream
-        self._self_aiter = aiter(stream)
+        self._set_stream(stream)
 
 
-class MessagesStreamManagerWrapper(Generic[ResponseFormatT]):
+class MessagesStreamManagerWrapper(
+    SyncStreamManagerWrapper[
+        "MessageStream[ResponseFormatT]",
+        "InferenceInvocation",
+        "MessagesStreamWrapper[ResponseFormatT]",
+    ],
+    Generic[ResponseFormatT],
+):
     """Wrapper for sync Anthropic stream managers."""
 
     def __init__(
@@ -264,131 +239,47 @@ class MessagesStreamManagerWrapper(Generic[ResponseFormatT]):
         invocation_factory: Callable[[], InferenceInvocation],
         capture_content: bool,
     ):
-        self._manager = manager
-        self._invocation_factory = invocation_factory
-        self._invocation: InferenceInvocation | None = None
-        self._capture_content = capture_content
-        self._stream_wrapper: MessagesStreamWrapper[ResponseFormatT] | None = (
-            None
-        )
+        super().__init__(manager, invocation_factory)
+        self._self_capture_content = capture_content
 
-    def __enter__(self) -> MessagesStreamWrapper[ResponseFormatT]:
-        invocation = self._invocation_factory()
-        self._invocation = invocation
-        try:
-            stream = self._manager.__enter__()
-        except Exception as exc:
-            invocation.fail(exc)
-            raise
-        self._stream_wrapper = MessagesStreamWrapper(
-            stream,
-            invocation,
-            self._capture_content,
-        )
-        return self._stream_wrapper
-
-    def __exit__(
+    def _wrap_stream(
         self,
-        exc_type: type[BaseException] | None,
-        exc_val: BaseException | None,
-        exc_tb: TracebackType | None,
-    ) -> bool | None:
-        stream_wrapper = self._stream_wrapper
-        self._stream_wrapper = None
-        try:
-            suppressed = self._manager.__exit__(exc_type, exc_val, exc_tb)
-        except Exception as exc:
-            if stream_wrapper is not None:
-                stream_wrapper.__exit__(type(exc), exc, exc.__traceback__)
-            elif self._invocation is not None:
-                self._invocation.fail(exc)
-            raise
-        if stream_wrapper is not None:
-            if suppressed:
-                stream_wrapper.__exit__(None, None, None)
-            else:
-                stream_wrapper.__exit__(exc_type, exc_val, exc_tb)
-        return suppressed
-
-    def __getattr__(self, name: str) -> object:
-        return getattr(self._manager, name)
+        stream: MessageStream[ResponseFormatT],
+        invocation: InferenceInvocation,
+    ) -> MessagesStreamWrapper[ResponseFormatT]:
+        return MessagesStreamWrapper(
+            stream, invocation, self._self_capture_content
+        )
 
 
-class AsyncMessagesStreamManagerWrapper(Generic[ResponseFormatT]):
+class AsyncMessagesStreamManagerWrapper(
+    AsyncStreamManagerWrapper[
+        "AsyncMessageStream[ResponseFormatT]",
+        "InferenceInvocation",
+        "AsyncMessagesStreamWrapper[ResponseFormatT]",
+    ],
+    Generic[ResponseFormatT],
+):
     """Wrapper for AsyncMessageStreamManager that handles telemetry.
 
     Wraps AsyncMessageStreamManager from the Anthropic SDK:
     https://github.com/anthropics/anthropic-sdk-python/blob/05220bc1c1079fe01f5c4babc007ec7a990859d9/src/anthropic/lib/streaming/_messages.py#L294
     """
 
-    # When async Messages.stream() instrumentation is wired up, start the
-    # invocation lazily in __aenter__ to avoid opening spans for unentered
-    # managers.
-
     def __init__(
         self,
         manager: AsyncMessageStreamManager[ResponseFormatT],
-        invocation: InferenceInvocation | Callable[[], InferenceInvocation],
+        invocation_factory: Callable[[], InferenceInvocation],
         capture_content: bool,
     ):
-        self._manager = manager
-        if callable(invocation):
-            invocation_factory = invocation
-        else:
+        super().__init__(manager, invocation_factory)
+        self._self_capture_content = capture_content
 
-            def invocation_factory() -> InferenceInvocation:
-                return invocation
-
-        self._invocation_factory = invocation_factory
-        self._invocation: InferenceInvocation | None = None
-        self._capture_content = capture_content
-        self._stream_wrapper: (
-            AsyncMessagesStreamWrapper[ResponseFormatT] | None
-        ) = None
-
-    async def __aenter__(
+    def _wrap_stream(
         self,
+        stream: AsyncMessageStream[ResponseFormatT],
+        invocation: InferenceInvocation,
     ) -> AsyncMessagesStreamWrapper[ResponseFormatT]:
-        invocation = self._invocation_factory()
-        self._invocation = invocation
-        try:
-            msg_stream = await self._manager.__aenter__()
-        except Exception as exc:
-            invocation.fail(exc)
-            raise
-        self._stream_wrapper = AsyncMessagesStreamWrapper(
-            msg_stream,
-            invocation,
-            self._capture_content,
+        return AsyncMessagesStreamWrapper(
+            stream, invocation, self._self_capture_content
         )
-        return self._stream_wrapper
-
-    async def __aexit__(
-        self,
-        exc_type: type[BaseException] | None,
-        exc_val: BaseException | None,
-        exc_tb: TracebackType | None,
-    ) -> bool | None:
-        stream_wrapper = self._stream_wrapper
-        self._stream_wrapper = None
-        try:
-            suppressed = await self._manager.__aexit__(
-                exc_type, exc_val, exc_tb
-            )
-        except Exception as exc:
-            if stream_wrapper is not None:
-                await stream_wrapper.__aexit__(
-                    type(exc), exc, exc.__traceback__
-                )
-            elif self._invocation is not None:
-                self._invocation.fail(exc)
-            raise
-        if stream_wrapper is not None:
-            if suppressed:
-                await stream_wrapper.__aexit__(None, None, None)
-            else:
-                await stream_wrapper.__aexit__(exc_type, exc_val, exc_tb)
-        return suppressed
-
-    def __getattr__(self, name: str) -> object:
-        return getattr(self._manager, name)

--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/test_async_wrappers.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/test_async_wrappers.py
@@ -151,24 +151,6 @@ class _FakeAsyncManager:
         return self._suppressed
 
 
-class _FakeStreamWrapper:
-    def __init__(self):
-        self.exit_args = None
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        self.exit_args = (exc_type, exc_val, exc_tb)
-        return False
-
-
-class _FakeAsyncStreamWrapper:
-    def __init__(self):
-        self.exit_args = None
-
-    async def __aexit__(self, exc_type, exc_val, exc_tb):
-        self.exit_args = (exc_type, exc_val, exc_tb)
-        return False
-
-
 class _FakeSyncResponse:
     def __init__(self):
         self.request_id = "req_sync"
@@ -322,7 +304,6 @@ def test_sync_manager_enter_constructs_stream_wrapper():
     with wrapper as result:
         assert isinstance(result, MessagesStreamWrapper)
         assert result.stream is stream
-        assert wrapper._stream_wrapper is result
 
 
 def test_sync_manager_does_not_create_invocation_until_enter():
@@ -342,84 +323,6 @@ def test_sync_manager_does_not_create_invocation_until_enter():
         pass
 
     assert factory_calls == [True]
-
-
-def test_sync_manager_enter_fails_invocation_when_manager_raises():
-    error = RuntimeError("manager enter failure")
-    failures = []
-    invocation = _make_invocation()
-    invocation.fail = failures.append
-    wrapper = MessagesStreamManagerWrapper(
-        manager=_FakeSyncManager(
-            stream=SimpleNamespace(),
-            enter_error=error,
-        ),
-        invocation_factory=lambda: invocation,
-        capture_content=False,
-    )
-
-    with pytest.raises(RuntimeError, match="manager enter failure"):
-        with wrapper:
-            pass
-
-    assert failures == [error]
-
-
-def test_sync_manager_exit_forwards_exception_to_stream_wrapper():
-    wrapper = MessagesStreamManagerWrapper(
-        manager=_FakeSyncManager(stream=SimpleNamespace(), suppressed=False),
-        invocation_factory=_make_invocation,
-        capture_content=False,
-    )
-    stream_wrapper = _FakeStreamWrapper()
-    wrapper._stream_wrapper = stream_wrapper
-
-    error = ValueError("boom")
-    result = wrapper.__exit__(ValueError, error, None)
-
-    assert result is False
-    assert wrapper._manager.exit_args == (ValueError, error, None)
-    assert stream_wrapper.exit_args == (ValueError, error, None)
-
-
-def test_sync_manager_exit_uses_none_exception_when_manager_suppresses():
-    wrapper = MessagesStreamManagerWrapper(
-        manager=_FakeSyncManager(stream=SimpleNamespace(), suppressed=True),
-        invocation_factory=_make_invocation,
-        capture_content=False,
-    )
-    stream_wrapper = _FakeStreamWrapper()
-    wrapper._stream_wrapper = stream_wrapper
-
-    error = RuntimeError("ignored")
-    result = wrapper.__exit__(RuntimeError, error, None)
-
-    assert result is True
-    assert wrapper._manager.exit_args == (RuntimeError, error, None)
-    assert stream_wrapper.exit_args == (None, None, None)
-
-
-def test_sync_manager_exit_still_finalizes_stream_wrapper_when_manager_raises():
-    manager_error = RuntimeError("manager failure")
-    wrapper = MessagesStreamManagerWrapper(
-        manager=_FakeSyncManager(
-            stream=SimpleNamespace(),
-            suppressed=False,
-            exit_error=manager_error,
-        ),
-        invocation_factory=_make_invocation,
-        capture_content=False,
-    )
-    stream_wrapper = _FakeStreamWrapper()
-    wrapper._stream_wrapper = stream_wrapper
-
-    error = ValueError("outer")
-    with pytest.raises(RuntimeError, match="manager failure"):
-        wrapper.__exit__(ValueError, error, None)
-
-    assert wrapper._manager.exit_args == (ValueError, error, None)
-    assert stream_wrapper.exit_args[:2] == (RuntimeError, manager_error)
-    assert stream_wrapper.exit_args[2] is not None
 
 
 @pytest.mark.asyncio
@@ -572,93 +475,10 @@ async def test_async_manager_enter_constructs_async_stream_wrapper():
     stream = _FakeAsyncStream()
     wrapper = AsyncMessagesStreamManagerWrapper(
         manager=_FakeAsyncManager(stream=stream),
-        invocation=_make_invocation(),
+        invocation_factory=_make_invocation,
         capture_content=False,
     )
 
     async with wrapper as result:
         assert isinstance(result, AsyncMessagesStreamWrapper)
         assert result.stream is stream
-        assert wrapper._stream_wrapper is result
-
-
-@pytest.mark.asyncio
-async def test_async_manager_enter_fails_invocation_when_manager_raises():
-    error = RuntimeError("manager enter failure")
-    failures = []
-    invocation = _make_invocation()
-    invocation.fail = failures.append
-    wrapper = AsyncMessagesStreamManagerWrapper(
-        manager=_FakeAsyncManager(
-            stream=SimpleNamespace(),
-            enter_error=error,
-        ),
-        invocation=invocation,
-        capture_content=False,
-    )
-
-    with pytest.raises(RuntimeError, match="manager enter failure"):
-        async with wrapper:
-            pass
-
-    assert failures == [error]
-
-
-@pytest.mark.asyncio
-async def test_async_manager_exit_forwards_exception_to_stream_wrapper():
-    wrapper = AsyncMessagesStreamManagerWrapper(
-        manager=_FakeAsyncManager(stream=SimpleNamespace(), suppressed=False),
-        invocation=_make_invocation(),
-        capture_content=False,
-    )
-    stream_wrapper = _FakeAsyncStreamWrapper()
-    wrapper._stream_wrapper = stream_wrapper
-
-    error = ValueError("boom")
-    result = await wrapper.__aexit__(ValueError, error, None)
-
-    assert result is False
-    assert wrapper._manager.exit_args == (ValueError, error, None)
-    assert stream_wrapper.exit_args == (ValueError, error, None)
-
-
-@pytest.mark.asyncio
-async def test_async_manager_exit_uses_none_exception_when_manager_suppresses():
-    wrapper = AsyncMessagesStreamManagerWrapper(
-        manager=_FakeAsyncManager(stream=SimpleNamespace(), suppressed=True),
-        invocation=_make_invocation(),
-        capture_content=False,
-    )
-    stream_wrapper = _FakeAsyncStreamWrapper()
-    wrapper._stream_wrapper = stream_wrapper
-
-    error = RuntimeError("ignored")
-    result = await wrapper.__aexit__(RuntimeError, error, None)
-
-    assert result is True
-    assert wrapper._manager.exit_args == (RuntimeError, error, None)
-    assert stream_wrapper.exit_args == (None, None, None)
-
-
-@pytest.mark.asyncio
-async def test_async_manager_exit_still_finalizes_stream_wrapper_when_manager_raises():
-    manager_error = RuntimeError("manager failure")
-    wrapper = AsyncMessagesStreamManagerWrapper(
-        manager=_FakeAsyncManager(
-            stream=SimpleNamespace(),
-            suppressed=False,
-            exit_error=manager_error,
-        ),
-        invocation=_make_invocation(),
-        capture_content=False,
-    )
-    stream_wrapper = _FakeAsyncStreamWrapper()
-    wrapper._stream_wrapper = stream_wrapper
-
-    error = ValueError("outer")
-    with pytest.raises(RuntimeError, match="manager failure"):
-        await wrapper.__aexit__(ValueError, error, None)
-
-    assert wrapper._manager.exit_args == (ValueError, error, None)
-    assert stream_wrapper.exit_args[:2] == (RuntimeError, manager_error)
-    assert stream_wrapper.exit_args[2] is not None

--- a/instrumentation/opentelemetry-instrumentation-genai-openai/src/opentelemetry/instrumentation/genai/openai/response_wrappers.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-openai/src/opentelemetry/instrumentation/genai/openai/response_wrappers.py
@@ -9,11 +9,15 @@ import logging
 from collections.abc import Callable
 from contextvars import ContextVar
 from types import TracebackType
-from typing import TYPE_CHECKING, Generic, TypeVar
+from typing import TYPE_CHECKING, Generic, TypeVar, cast
 
 from opentelemetry.util.genai.stream import (
+    AsyncStreamManagerWrapper,
     AsyncStreamWrapper,
+    SyncStreamManagerWrapper,
     SyncStreamWrapper,
+    finalize_on_aclose,
+    finalize_on_close,
 )
 from opentelemetry.util.genai.types import Error
 
@@ -110,36 +114,6 @@ def _get_stream_response(stream):
             return None
 
 
-class _ResponseProxy(Generic[ResponseT]):
-    def __init__(self, response: ResponseT, finalize: Callable[[], None]):
-        self._response = response
-        self._finalize = finalize
-
-    def close(self) -> None:
-        try:
-            self._response.close()
-        finally:
-            self._finalize()
-
-    def __getattr__(self, name: str):
-        return getattr(self._response, name)
-
-
-class _AsyncResponseProxy(Generic[ResponseT]):
-    def __init__(self, response: ResponseT, finalize: Callable[[], None]):
-        self._response = response
-        self._finalize = finalize
-
-    async def aclose(self) -> None:
-        try:
-            await self._response.aclose()
-        finally:
-            self._finalize()
-
-    def __getattr__(self, name: str):
-        return getattr(self._response, name)
-
-
 class _ResponseStreamMixin(Generic[TextFormatT]):
     _self_invocation: GenAIInvocation
     _self_capture_content: bool
@@ -220,7 +194,7 @@ class _ResponseStreamMixin(Generic[TextFormatT]):
         response = _get_stream_response(self.stream)
         if response is None:
             return None
-        return _ResponseProxy(response, lambda: self._stop(None))
+        return finalize_on_close(response, lambda: self._stop(None))
 
     def process_event(self, event: ResponseStreamEvent[TextFormatT]) -> None:
         # raw-response stream can be parsed into a caller-defined event type.
@@ -284,9 +258,7 @@ class ResponseStreamWrapper(
 
     @stream.setter
     def stream(self, stream: ResponseStream[TextFormatT]) -> None:
-        self.__wrapped__ = stream
-        self._self_stream = stream
-        self._self_iterator = iter(stream)
+        self._set_stream(stream)
 
 
 class _FetchResponseStreamMixin(Generic[TextFormatT]):
@@ -322,7 +294,14 @@ class FetchResponseStreamWrapper(
     """Wrapper for a streamed ``Responses.retrieve`` replay."""
 
 
-class ResponseStreamManagerWrapper(Generic[TextFormatT]):
+class ResponseStreamManagerWrapper(
+    SyncStreamManagerWrapper[
+        "ResponseStream[TextFormatT]",
+        "GenAIInvocation",
+        "ResponseStreamWrapper[TextFormatT]",
+    ],
+    Generic[TextFormatT],
+):
     """Wrapper for OpenAI Responses API stream managers.
 
     Wraps ResponseStreamManager from the OpenAI SDK:
@@ -335,69 +314,39 @@ class ResponseStreamManagerWrapper(Generic[TextFormatT]):
         invocation_factory: Callable[[], GenAIInvocation],
         capture_content: bool,
     ):
-        self._manager = manager
-        self._invocation_factory = invocation_factory
-        self._invocation: GenAIInvocation | None = None
-        self._capture_content = capture_content
-        self._stream_wrapper: ResponseStreamWrapper[TextFormatT] | None = None
+        super().__init__(manager, invocation_factory)
+        self._self_capture_content = capture_content
 
-    def __enter__(self) -> ResponseStreamWrapper[TextFormatT]:
-        invocation = self._invocation_factory()
-        self._invocation = invocation
+    def _enter_manager(
+        self, invocation: GenAIInvocation
+    ) -> ResponseStream[TextFormatT]:
+        # The SDK manager enters by calling the patched Responses.create, which
+        # this marker tells to return the SDK stream without opening a second
+        # invocation.
         stream_context_reset = _set_responses_stream_context(
-            invocation, self._capture_content
+            invocation, self._self_capture_content
         )
         try:
-            stream = self._manager.__enter__()
-        except Exception as error:
-            invocation.fail(error)
-            raise
+            return cast(
+                "ResponseStream[TextFormatT]", self.__wrapped__.__enter__()
+            )
         finally:
             responses_stream_context.reset(stream_context_reset)
-        if getattr(stream, "_self_is_response_stream_wrapper", False):
-            self._stream_wrapper = stream
-            return stream
-        self._stream_wrapper = ResponseStreamWrapper(
-            stream,
-            invocation,
-            self._capture_content,
-        )
-        return self._stream_wrapper
 
-    def __exit__(
-        self,
-        exc_type: type[BaseException] | None,
-        exc_val: BaseException | None,
-        exc_tb: TracebackType | None,
-    ) -> bool | None:
-        stream_wrapper = self._stream_wrapper
-        self._stream_wrapper = None
-        try:
-            suppressed = self._manager.__exit__(exc_type, exc_val, exc_tb)
-        except Exception as error:
-            if stream_wrapper is not None:
-                stream_wrapper.__exit__(
-                    type(error), error, error.__traceback__
-                )
-            elif self._invocation is not None:
-                self._invocation.fail(error)
-            raise
-        if stream_wrapper is not None:
-            if suppressed:
-                stream_wrapper.__exit__(None, None, None)
-            else:
-                stream_wrapper.__exit__(exc_type, exc_val, exc_tb)
-        return suppressed
+    def _wrap_stream(
+        self, stream: ResponseStream[TextFormatT], invocation: GenAIInvocation
+    ) -> ResponseStreamWrapper[TextFormatT]:
+        if getattr(stream, "_self_is_response_stream_wrapper", False):
+            # Already wrapped by the inner patched create().
+            return cast("ResponseStreamWrapper[TextFormatT]", stream)
+        return ResponseStreamWrapper(
+            stream, invocation, self._self_capture_content
+        )
 
     def parse(self) -> ResponseStreamManagerWrapper[TextFormatT]:
         raise NotImplementedError(
             "ResponseStreamManagerWrapper.parse() is not implemented"
         )
-
-    # TODO: Replace __getattr__ passthrough with wrapt.ObjectProxy in a future
-    # cleanup once wrapt 2 typing support is available (wrapt PR #3903).
-    def __getattr__(self, name: str):
-        return getattr(self._manager, name)
 
 
 class AsyncResponseStreamWrapper(
@@ -449,16 +398,14 @@ class AsyncResponseStreamWrapper(
 
     @stream.setter
     def stream(self, stream: AsyncResponseStream[TextFormatT]) -> None:
-        self.__wrapped__ = stream
-        self._self_stream = stream
-        self._self_aiter = aiter(stream)
+        self._set_stream(stream)
 
     @property
     def response(self):
         response = _get_stream_response(self.stream)
         if response is None:
             return None
-        return _AsyncResponseProxy(response, lambda: self._stop(None))
+        return finalize_on_aclose(response, lambda: self._stop(None))
 
 
 class AsyncFetchResponseStreamWrapper(
@@ -469,7 +416,14 @@ class AsyncFetchResponseStreamWrapper(
     """Wrapper for a streamed ``AsyncResponses.retrieve`` replay."""
 
 
-class AsyncResponseStreamManagerWrapper(Generic[TextFormatT]):
+class AsyncResponseStreamManagerWrapper(
+    AsyncStreamManagerWrapper[
+        "AsyncResponseStream[TextFormatT]",
+        "GenAIInvocation",
+        "AsyncResponseStreamWrapper[TextFormatT]",
+    ],
+    Generic[TextFormatT],
+):
     """Wrapper for async OpenAI Responses API stream managers."""
 
     def __init__(
@@ -478,70 +432,37 @@ class AsyncResponseStreamManagerWrapper(Generic[TextFormatT]):
         invocation_factory: Callable[[], GenAIInvocation],
         capture_content: bool,
     ):
-        self._manager = manager
-        self._invocation_factory = invocation_factory
-        self._invocation: GenAIInvocation | None = None
-        self._capture_content = capture_content
-        self._stream_wrapper: (
-            AsyncResponseStreamWrapper[TextFormatT] | None
-        ) = None
+        super().__init__(manager, invocation_factory)
+        self._self_capture_content = capture_content
 
-    async def __aenter__(self) -> AsyncResponseStreamWrapper[TextFormatT]:
-        invocation = self._invocation_factory()
-        self._invocation = invocation
+    async def _enter_manager(
+        self, invocation: GenAIInvocation
+    ) -> AsyncResponseStream[TextFormatT]:
+        # See ResponseStreamManagerWrapper._enter_manager.
         stream_context_reset = _set_responses_stream_context(
-            invocation, self._capture_content
+            invocation, self._self_capture_content
         )
         try:
-            stream = await self._manager.__aenter__()
-        except Exception as error:
-            invocation.fail(error)
-            raise
+            return cast(
+                "AsyncResponseStream[TextFormatT]",
+                await self.__wrapped__.__aenter__(),
+            )
         finally:
             responses_stream_context.reset(stream_context_reset)
-        if getattr(stream, "_self_is_response_stream_wrapper", False):
-            self._stream_wrapper = stream
-            return stream
-        self._stream_wrapper = AsyncResponseStreamWrapper(
-            stream,
-            invocation,
-            self._capture_content,
-        )
-        return self._stream_wrapper
 
-    async def __aexit__(
+    def _wrap_stream(
         self,
-        exc_type: type[BaseException] | None,
-        exc_val: BaseException | None,
-        exc_tb: TracebackType | None,
-    ) -> bool | None:
-        stream_wrapper = self._stream_wrapper
-        self._stream_wrapper = None
-        try:
-            suppressed = await self._manager.__aexit__(
-                exc_type, exc_val, exc_tb
-            )
-        except Exception as error:
-            if stream_wrapper is not None:
-                await stream_wrapper.__aexit__(
-                    type(error), error, error.__traceback__
-                )
-            elif self._invocation is not None:
-                self._invocation.fail(error)
-            raise
-        if stream_wrapper is not None:
-            if suppressed:
-                await stream_wrapper.__aexit__(None, None, None)
-            else:
-                await stream_wrapper.__aexit__(exc_type, exc_val, exc_tb)
-        return suppressed
+        stream: AsyncResponseStream[TextFormatT],
+        invocation: GenAIInvocation,
+    ) -> AsyncResponseStreamWrapper[TextFormatT]:
+        if getattr(stream, "_self_is_response_stream_wrapper", False):
+            # Already wrapped by the inner patched create().
+            return cast("AsyncResponseStreamWrapper[TextFormatT]", stream)
+        return AsyncResponseStreamWrapper(
+            stream, invocation, self._self_capture_content
+        )
 
     def parse(self) -> AsyncResponseStreamManagerWrapper[TextFormatT]:
         raise NotImplementedError(
             "AsyncResponseStreamManagerWrapper.parse() is not implemented"
         )
-
-    # TODO: Replace __getattr__ passthrough with wrapt.ObjectProxy in a future
-    # cleanup once wrapt 2 typing support is available (wrapt PR #3903).
-    def __getattr__(self, name: str):
-        return getattr(self._manager, name)

--- a/instrumentation/opentelemetry-instrumentation-genai-openai/tests/test_response_wrappers.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-openai/tests/test_response_wrappers.py
@@ -136,24 +136,6 @@ def _make_async_stream_wrapper(stream, invocation=None):
     )
 
 
-class _FakeStreamWrapper:
-    def __init__(self):
-        self.exit_args = None
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        self.exit_args = (exc_type, exc_val, exc_tb)
-        return False
-
-
-class _FakeAsyncStreamWrapper:
-    def __init__(self):
-        self.exit_args = None
-
-    async def __aexit__(self, exc_type, exc_val, exc_tb):
-        self.exit_args = (exc_type, exc_val, exc_tb)
-        return False
-
-
 class _FakeAsyncResponse:
     def __init__(self):
         self.aclose_calls = 0
@@ -219,21 +201,6 @@ class _FakeAsyncStream:
         return self._final_response
 
 
-def test_manager_exit_forwards_exception_to_stream_wrapper():
-    manager = _FakeManager(stream=SimpleNamespace(), suppressed=False)
-    wrapper = _make_wrapper(manager)
-    stream_wrapper = _FakeStreamWrapper()
-    wrapper._stream_wrapper = stream_wrapper
-
-    error = ValueError("boom")
-    result = wrapper.__exit__(ValueError, error, None)
-
-    assert result is False
-    assert manager.exit_args == (ValueError, error, None)
-    assert stream_wrapper.exit_args == (ValueError, error, None)
-    assert wrapper._stream_wrapper is None
-
-
 def test_manager_enter_failure_fails_invocation_and_reraises():
     error = RuntimeError("enter failure")
     manager = _FakeManager(stream=SimpleNamespace(), enter_error=error)
@@ -256,38 +223,23 @@ def test_manager_enter_failure_fails_invocation_and_reraises():
     assert failures == [error]
 
 
-def test_manager_exit_uses_none_exception_when_manager_suppresses():
-    manager = _FakeManager(stream=SimpleNamespace(), suppressed=True)
-    wrapper = _make_wrapper(manager)
-    stream_wrapper = _FakeStreamWrapper()
-    wrapper._stream_wrapper = stream_wrapper
+def test_manager_enter_reuses_stream_wrapper_from_inner_create():
+    stream_wrapper = _make_stream_wrapper(_FakeSyncStream())
+    wrapper = _make_wrapper(_FakeManager(stream=stream_wrapper))
 
-    error = RuntimeError("ignored")
-    result = wrapper.__exit__(RuntimeError, error, None)
-
-    assert result is True
-    assert manager.exit_args == (RuntimeError, error, None)
-    assert stream_wrapper.exit_args == (None, None, None)
-    assert wrapper._stream_wrapper is None
+    with wrapper as result:
+        assert result is stream_wrapper
 
 
-def test_manager_exit_still_finalizes_stream_wrapper_when_manager_raises():
-    manager_error = RuntimeError("manager failure")
-    manager = _FakeManager(
-        stream=SimpleNamespace(), suppressed=False, exit_error=manager_error
+@pytest.mark.asyncio
+async def test_async_manager_enter_reuses_stream_wrapper_from_inner_create():
+    stream_wrapper = _make_async_stream_wrapper(_FakeAsyncStream())
+    wrapper = _make_async_manager_wrapper(
+        _FakeAsyncManager(stream=stream_wrapper)
     )
-    wrapper = _make_wrapper(manager)
-    stream_wrapper = _FakeStreamWrapper()
-    wrapper._stream_wrapper = stream_wrapper
 
-    error = ValueError("outer")
-    with pytest.raises(RuntimeError, match="manager failure"):
-        wrapper.__exit__(ValueError, error, None)
-
-    assert manager.exit_args == (ValueError, error, None)
-    assert stream_wrapper.exit_args[:2] == (RuntimeError, manager_error)
-    assert stream_wrapper.exit_args[2] is not None
-    assert wrapper._stream_wrapper is None
+    async with wrapper as result:
+        assert result is stream_wrapper
 
 
 def test_stream_wrapper_response_falls_back_to_public_response_attr():
@@ -305,22 +257,6 @@ def test_stream_wrapper_response_falls_back_to_public_response_attr():
 
 
 @pytest.mark.asyncio
-async def test_async_manager_exit_forwards_exception_to_stream_wrapper():
-    manager = _FakeAsyncManager(stream=SimpleNamespace(), suppressed=False)
-    wrapper = _make_async_manager_wrapper(manager)
-    stream_wrapper = _FakeAsyncStreamWrapper()
-    wrapper._stream_wrapper = stream_wrapper
-
-    error = ValueError("boom")
-    result = await wrapper.__aexit__(ValueError, error, None)
-
-    assert result is False
-    assert manager.exit_args == (ValueError, error, None)
-    assert stream_wrapper.exit_args == (ValueError, error, None)
-    assert wrapper._stream_wrapper is None
-
-
-@pytest.mark.asyncio
 async def test_async_manager_enter_constructs_async_stream_wrapper():
     stream = _FakeAsyncStream()
     manager = _FakeAsyncManager(stream=stream)
@@ -329,7 +265,6 @@ async def test_async_manager_enter_constructs_async_stream_wrapper():
     async with wrapper as result:
         assert isinstance(result, AsyncResponseStreamWrapper)
         assert result.stream is stream
-        assert wrapper._stream_wrapper is result
 
 
 @pytest.mark.asyncio
@@ -353,42 +288,6 @@ async def test_async_manager_enter_failure_fails_invocation_and_reraises():
         await wrapper.__aenter__()
 
     assert failures == [error]
-
-
-@pytest.mark.asyncio
-async def test_async_manager_exit_uses_none_exception_when_manager_suppresses():
-    manager = _FakeAsyncManager(stream=SimpleNamespace(), suppressed=True)
-    wrapper = _make_async_manager_wrapper(manager)
-    stream_wrapper = _FakeAsyncStreamWrapper()
-    wrapper._stream_wrapper = stream_wrapper
-
-    error = RuntimeError("ignored")
-    result = await wrapper.__aexit__(RuntimeError, error, None)
-
-    assert result is True
-    assert manager.exit_args == (RuntimeError, error, None)
-    assert stream_wrapper.exit_args == (None, None, None)
-    assert wrapper._stream_wrapper is None
-
-
-@pytest.mark.asyncio
-async def test_async_manager_exit_still_finalizes_stream_wrapper_when_manager_raises():
-    manager_error = RuntimeError("manager failure")
-    manager = _FakeAsyncManager(
-        stream=SimpleNamespace(), suppressed=False, exit_error=manager_error
-    )
-    wrapper = _make_async_manager_wrapper(manager)
-    stream_wrapper = _FakeAsyncStreamWrapper()
-    wrapper._stream_wrapper = stream_wrapper
-
-    error = ValueError("outer")
-    with pytest.raises(RuntimeError, match="manager failure"):
-        await wrapper.__aexit__(ValueError, error, None)
-
-    assert manager.exit_args == (ValueError, error, None)
-    assert stream_wrapper.exit_args[:2] == (RuntimeError, manager_error)
-    assert stream_wrapper.exit_args[2] is not None
-    assert wrapper._stream_wrapper is None
 
 
 @pytest.mark.asyncio

--- a/instrumentation/opentelemetry-instrumentation-google-genai/.changelog/390.fixed
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/.changelog/390.fixed
@@ -1,0 +1,1 @@
+Finalize the span successfully when an async `generate_content_stream` is closed before being drained, instead of recording it as an error

--- a/instrumentation/opentelemetry-instrumentation-google-genai/tests/generate_content/test_async_streaming.py
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/tests/generate_content/test_async_streaming.py
@@ -3,6 +3,9 @@
 
 import asyncio
 
+from opentelemetry.trace import StatusCode
+
+from .base import TestCase
 from .nonstreaming_base import NonStreamingTestCase
 from .streaming_base import StreamingTestCase
 
@@ -42,3 +45,26 @@ class TestGenerateContentAsyncStreamingWithStreamedResults(
 ):
     def generate_content(self, *args, **kwargs):
         return self.generate_content_stream(*args, **kwargs)
+
+
+class TestGenerateContentAsyncStreamingAbandoned(TestCase):
+    """The SDK hands back an async generator, which has ``aclose``, not ``close``."""
+
+    def test_aclose_finalizes_span_successfully(self):
+        self.configure_valid_response(text="First response")
+        self.configure_valid_response(text="Second response")
+
+        async def _run():
+            stream = await self.client.aio.models.generate_content_stream(
+                model="gemini-2.0-flash", contents="Does this work?"
+            )
+            async for _ in stream:
+                break
+            await stream.aclose()
+
+        asyncio.run(_run())
+
+        self.otel.assert_has_span_named("generate_content gemini-2.0-flash")
+        span = self.otel.get_span_named("generate_content gemini-2.0-flash")
+        self.assertNotEqual(span.status.status_code, StatusCode.ERROR)
+        self.assertNotIn("error.type", span.attributes)

--- a/util/opentelemetry-util-genai/.changelog/390.added
+++ b/util/opentelemetry-util-genai/.changelog/390.added
@@ -1,0 +1,1 @@
+Add `SyncStreamManagerWrapper` / `AsyncStreamManagerWrapper` bases and `finalize_on_close` / `finalize_on_aclose` helpers to `opentelemetry.util.genai.stream`

--- a/util/opentelemetry-util-genai/.changelog/390.changed
+++ b/util/opentelemetry-util-genai/.changelog/390.changed
@@ -1,0 +1,1 @@
+Finalize stream telemetry for streams that expose `aclose` instead of `close`

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/stream.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/stream.py
@@ -6,20 +6,24 @@ from __future__ import annotations
 import logging
 import timeit
 from abc import ABCMeta, abstractmethod
-from collections.abc import AsyncIterable, Iterable
+from collections.abc import AsyncIterable, Callable, Iterable
 from types import TracebackType
 from typing import (
     TYPE_CHECKING,
+    Any,
     Generic,
     Literal,
     Protocol,
     TypeVar,
+    cast,
 )
 
 if TYPE_CHECKING:
     from opentelemetry.util.genai._invocation import GenAIInvocation
 
     class _ObjectProxy:
+        __wrapped__: Any
+
         def __init__(self, wrapped: object) -> None: ...
 
 else:
@@ -27,6 +31,15 @@ else:
 
 
 ChunkT = TypeVar("ChunkT")
+WrappedT = TypeVar("WrappedT")
+SyncStreamWrapperT = TypeVar(
+    "SyncStreamWrapperT", bound="SyncStreamWrapper[Any]"
+)
+AsyncStreamWrapperT = TypeVar(
+    "AsyncStreamWrapperT", bound="AsyncStreamWrapper[Any]"
+)
+StreamT = TypeVar("StreamT")
+InvocationT = TypeVar("InvocationT", bound="GenAIInvocation")
 _ChunkT_co = TypeVar("_ChunkT_co", covariant=True)
 _logger = logging.getLogger(__name__)
 
@@ -42,12 +55,46 @@ class _SyncStream(Iterable[_ChunkT_co], Protocol[_ChunkT_co]):
 
 
 class _AsyncStream(AsyncIterable[_ChunkT_co], Protocol[_ChunkT_co]):
-    """Structural type for streams accepted by ``AsyncStreamWrapper``."""
+    """Structural type for streams accepted by ``AsyncStreamWrapper``.
 
-    async def close(self) -> None: ...
+    No close method is required: SDK streams spell it ``close``, async
+    generators spell it ``aclose``, and either is resolved at runtime by
+    ``AsyncStreamWrapper._close_stream``.
+    """
+
+
+class _StreamTelemetry(Generic[ChunkT], metaclass=ABCMeta):
+    """Finalize-once bookkeeping and telemetry hooks shared by both wrappers."""
+
+    _self_finalized: bool
+
+    def _finalize_success(self) -> None:
+        if self._self_finalized:
+            return
+        self._self_finalized = True
+        self._on_stream_end()
+
+    def _finalize_failure(self, error: BaseException) -> None:
+        if self._self_finalized:
+            return
+        self._self_finalized = True
+        self._on_stream_error(error)
+
+    @abstractmethod
+    def _process_chunk(self, chunk: ChunkT) -> None:
+        """Process one stream chunk for telemetry."""
+
+    @abstractmethod
+    def _on_stream_end(self) -> None:
+        """Finalize the stream successfully."""
+
+    @abstractmethod
+    def _on_stream_error(self, error: BaseException) -> None:
+        """Finalize the stream with failure."""
 
 
 class SyncStreamWrapper(
+    _StreamTelemetry[ChunkT],
     _ObjectProxy,
     Generic[ChunkT],
     metaclass=_StreamWrapperMeta,
@@ -71,14 +118,31 @@ class SyncStreamWrapper(
         invocation: GenAIInvocation | None = None,
     ):
         super().__init__(stream)
-        self._self_stream = stream
-        self._self_iterator = iter(stream)
         self._self_finalized = False
         # Marks the request as streamed (gen_ai.request.stream) and receives
         # per-chunk timing via _on_stream_chunk.
         self._self_invocation = invocation
         if invocation is not None:
             invocation._request_stream = True
+        self._bind_stream(stream)
+
+    # The SDK stream, held loosely typed: subclasses re-expose it through a
+    # ``stream`` property carrying the SDK's own type.
+    _self_stream: Any
+
+    def _bind_stream(self, stream: _SyncStream[ChunkT]) -> None:
+        self._self_stream = stream
+        self._self_iterator = iter(stream)
+
+    def _set_stream(self, stream: _SyncStream[ChunkT]) -> None:
+        """Point the wrapper at ``stream``, rebinding proxy and iterator.
+
+        Subclasses exposing a settable ``stream`` property (SDKs that swap the
+        underlying stream after construction) delegate to this so the proxy
+        target and the iterator driving ``__next__`` stay in sync.
+        """
+        self.__wrapped__ = stream
+        self._bind_stream(stream)
 
     def __enter__(self):
         return self
@@ -134,32 +198,9 @@ class SyncStreamWrapper(
             invocation._on_stream_chunk(chunk_at)
         return chunk
 
-    def _finalize_success(self) -> None:
-        if self._self_finalized:
-            return
-        self._self_finalized = True
-        self._on_stream_end()
-
-    def _finalize_failure(self, error: BaseException) -> None:
-        if self._self_finalized:
-            return
-        self._self_finalized = True
-        self._on_stream_error(error)
-
-    @abstractmethod
-    def _process_chunk(self, chunk: ChunkT) -> None:
-        """Process one stream chunk for telemetry."""
-
-    @abstractmethod
-    def _on_stream_end(self) -> None:
-        """Finalize the stream successfully."""
-
-    @abstractmethod
-    def _on_stream_error(self, error: BaseException) -> None:
-        """Finalize the stream with failure."""
-
 
 class AsyncStreamWrapper(
+    _StreamTelemetry[ChunkT],
     _ObjectProxy,
     Generic[ChunkT],
     metaclass=_StreamWrapperMeta,
@@ -184,14 +225,28 @@ class AsyncStreamWrapper(
         invocation: GenAIInvocation | None = None,
     ):
         super().__init__(stream)
-        self._self_stream = stream
-        self._self_aiter = aiter(stream)
         self._self_finalized = False
         # Marks the request as streamed (gen_ai.request.stream) and receives
         # per-chunk timing via _on_stream_chunk.
         self._self_invocation = invocation
         if invocation is not None:
             invocation._request_stream = True
+        self._bind_stream(stream)
+
+    # See ``SyncStreamWrapper._self_stream``.
+    _self_stream: Any
+
+    def _bind_stream(self, stream: _AsyncStream[ChunkT]) -> None:
+        self._self_stream = stream
+        self._self_aiter = aiter(stream)
+
+    def _set_stream(self, stream: _AsyncStream[ChunkT]) -> None:
+        """Point the wrapper at ``stream``, rebinding proxy and iterator.
+
+        See ``SyncStreamWrapper._set_stream``.
+        """
+        self.__wrapped__ = stream
+        self._bind_stream(stream)
 
     async def __aenter__(self):
         return self
@@ -205,7 +260,7 @@ class AsyncStreamWrapper(
         if exc_val is not None:
             self._finalize_failure(exc_val)
             try:
-                await self._self_stream.close()
+                await self._close_stream()
             except Exception:  # pylint: disable=broad-exception-caught
                 _logger.debug(
                     "GenAI stream close error after user exception",
@@ -213,14 +268,37 @@ class AsyncStreamWrapper(
                 )
             return False
 
-        await self.close()
+        await self._close()
         return False
 
-    async def close(self) -> None:
-        # Named ``close`` (not ``aclose``) to match OpenAI's ``AsyncStream``.
-        # Revisit when migrating SDKs that expose ``aclose`` instead.
+    async def _close_stream(self) -> None:
+        """Close the wrapped stream, whichever close method it exposes.
+
+        SDK streams (OpenAI's and Anthropic's ``AsyncStream``) expose an async
+        ``close``; async generators -- what Google's async
+        ``generate_content_stream`` hands back -- expose ``aclose`` instead.
+        ``aclose`` is preferred for an object carrying both, because a pairing
+        of the two names is how objects with a *sync* ``close`` spell their
+        async one, and awaiting the sync one would raise.
+
+        A stream exposing neither is left alone; there is nothing to close, and
+        the caller's iteration has already ended.
+        """
+        close = getattr(self._self_stream, "aclose", None)
+        if close is None:
+            close = getattr(self._self_stream, "close", None)
+        if close is None:
+            return
+        await close()
+
+    async def _close(self) -> None:
+        """Close the stream and finalize telemetry.
+
+        Reached through whichever of ``close`` / ``aclose`` the wrapped stream
+        exposes; see ``__getattr__``.
+        """
         try:
-            await self._self_stream.close()
+            await self._close_stream()
         except Exception as error:
             self._finalize_failure(error)
             _logger.debug(
@@ -229,6 +307,32 @@ class AsyncStreamWrapper(
             )
             raise
         self._finalize_success()
+
+    if TYPE_CHECKING:
+        # Declared for type checkers only. Defining them for real would make
+        # the wrapper advertise both names at runtime, and a ``__getattr__``
+        # visible to the checker would type every forwarded attribute as
+        # ``Any`` -- silently disabling attribute checking on every subclass.
+        async def close(self) -> None: ...
+
+        async def aclose(self) -> None: ...
+
+    else:
+
+        def __getattr__(self, name):
+            # Forwards to the wrapped stream like
+            # ``wrapt.ObjectProxy.__getattr__``, except for the close method the
+            # stream itself exposes: that one is served from here so the call
+            # finalizes telemetry instead of reaching the stream directly.
+            # Serving it here rather than defining ``close`` / ``aclose`` on the
+            # class keeps the wrapper from advertising the name its stream
+            # doesn't have -- async streams are routinely duck-typed on exactly
+            # that shape (an ``AsyncStream`` has ``close``, an async generator
+            # has ``aclose``).
+            wrapped = object.__getattribute__(self, "__wrapped__")
+            if name in ("close", "aclose") and hasattr(wrapped, name):
+                return self._close
+            return getattr(wrapped, name)
 
     def __aiter__(self):
         # Override ``ObjectProxy.__aiter__`` so iteration drives ``__anext__``
@@ -254,32 +358,205 @@ class AsyncStreamWrapper(
             invocation._on_stream_chunk(chunk_at)
         return chunk
 
-    def _finalize_success(self) -> None:
-        if self._self_finalized:
-            return
-        self._self_finalized = True
-        self._on_stream_end()
 
-    def _finalize_failure(self, error: BaseException) -> None:
-        if self._self_finalized:
-            return
-        self._self_finalized = True
-        self._on_stream_error(error)
+class _CloseFinalizingProxy(_ObjectProxy):
+    def __init__(self, wrapped: object, finalize: Callable[[], None]) -> None:
+        super().__init__(wrapped)
+        self._self_finalize = finalize
+
+    def close(self) -> None:
+        try:
+            self.__wrapped__.close()
+        finally:
+            self._self_finalize()
+
+
+class _AcloseFinalizingProxy(_ObjectProxy):
+    def __init__(self, wrapped: object, finalize: Callable[[], None]) -> None:
+        super().__init__(wrapped)
+        self._self_finalize = finalize
+
+    async def aclose(self) -> None:
+        try:
+            await self.__wrapped__.aclose()
+        finally:
+            self._self_finalize()
+
+
+def finalize_on_close(
+    wrapped: WrappedT, finalize: Callable[[], None]
+) -> WrappedT:
+    """Proxy ``wrapped`` so closing it also finalizes telemetry.
+
+    Used for objects an SDK stream exposes to callers as a way to end the
+    operation early -- typically the underlying HTTP response behind
+    ``stream.response`` -- where a ``close()`` means the caller is done and the
+    invocation should be finalized. Everything but ``close`` forwards
+    unchanged.
+    """
+    return cast(WrappedT, _CloseFinalizingProxy(wrapped, finalize))
+
+
+def finalize_on_aclose(
+    wrapped: WrappedT, finalize: Callable[[], None]
+) -> WrappedT:
+    """Async counterpart of ``finalize_on_close``, hooking ``aclose``."""
+    return cast(WrappedT, _AcloseFinalizingProxy(wrapped, finalize))
+
+
+class SyncStreamManagerWrapper(
+    _ObjectProxy,
+    Generic[StreamT, InvocationT, SyncStreamWrapperT],
+    metaclass=_StreamWrapperMeta,
+):
+    """Base class for wrappers of SDK stream *managers*.
+
+    A stream manager is the context manager an SDK returns from a ``stream()``
+    style API: entering it opens the HTTP request and yields the stream, and
+    exiting it closes the stream. The invocation is created on entry -- not
+    when the manager is constructed -- so a manager that is never entered opens
+    no span.
+
+    Subclasses implement ``_wrap_stream`` to return the instrumented stream
+    wrapper for the SDK stream, and may override ``_enter_manager`` when the
+    SDK's entry needs to run inside instrumentation-specific state. The type
+    parameters are the SDK's stream type, the invocation type the factory
+    produces, and the stream wrapper type, so neither hook needs a cast.
+    """
+
+    def __init__(
+        self,
+        manager: object,
+        invocation_factory: Callable[[], InvocationT],
+    ) -> None:
+        super().__init__(manager)
+        self._self_invocation_factory = invocation_factory
+        self._self_invocation: InvocationT | None = None
+        self._self_stream_wrapper: SyncStreamWrapperT | None = None
+
+    def _enter_manager(self, invocation: InvocationT) -> StreamT:
+        """Enter the wrapped SDK manager and return its stream."""
+        return cast(StreamT, self.__wrapped__.__enter__())
 
     @abstractmethod
-    def _process_chunk(self, chunk: ChunkT) -> None:
-        """Process one stream chunk for telemetry."""
+    def _wrap_stream(
+        self, stream: StreamT, invocation: InvocationT
+    ) -> SyncStreamWrapperT:
+        """Return the instrumented wrapper for the SDK's stream."""
+
+    def __enter__(self) -> SyncStreamWrapperT:
+        invocation = self._self_invocation_factory()
+        self._self_invocation = invocation
+        try:
+            stream = self._enter_manager(invocation)
+        except Exception as error:
+            invocation.fail(error)
+            raise
+        stream_wrapper = self._wrap_stream(stream, invocation)
+        self._self_stream_wrapper = stream_wrapper
+        return stream_wrapper
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> bool | None:
+        stream_wrapper = self._self_stream_wrapper
+        self._self_stream_wrapper = None
+        try:
+            suppressed = self.__wrapped__.__exit__(exc_type, exc_val, exc_tb)
+        except Exception as error:
+            if stream_wrapper is not None:
+                stream_wrapper.__exit__(
+                    type(error), error, error.__traceback__
+                )
+            elif self._self_invocation is not None:
+                self._self_invocation.fail(error)
+            raise
+        if stream_wrapper is not None:
+            if suppressed:
+                # The manager swallowed the caller's exception, so the stream
+                # ended successfully as far as telemetry is concerned.
+                stream_wrapper.__exit__(None, None, None)
+            else:
+                stream_wrapper.__exit__(exc_type, exc_val, exc_tb)
+        return suppressed
+
+
+class AsyncStreamManagerWrapper(
+    _ObjectProxy,
+    Generic[StreamT, InvocationT, AsyncStreamWrapperT],
+    metaclass=_StreamWrapperMeta,
+):
+    """Async counterpart of ``SyncStreamManagerWrapper``."""
+
+    def __init__(
+        self,
+        manager: object,
+        invocation_factory: Callable[[], InvocationT],
+    ) -> None:
+        super().__init__(manager)
+        self._self_invocation_factory = invocation_factory
+        self._self_invocation: InvocationT | None = None
+        self._self_stream_wrapper: AsyncStreamWrapperT | None = None
+
+    async def _enter_manager(self, invocation: InvocationT) -> StreamT:
+        """Enter the wrapped SDK manager and return its stream."""
+        return cast(StreamT, await self.__wrapped__.__aenter__())
 
     @abstractmethod
-    def _on_stream_end(self) -> None:
-        """Finalize the stream successfully."""
+    def _wrap_stream(
+        self, stream: StreamT, invocation: InvocationT
+    ) -> AsyncStreamWrapperT:
+        """Return the instrumented wrapper for the SDK's stream."""
 
-    @abstractmethod
-    def _on_stream_error(self, error: BaseException) -> None:
-        """Finalize the stream with failure."""
+    async def __aenter__(self) -> AsyncStreamWrapperT:
+        invocation = self._self_invocation_factory()
+        self._self_invocation = invocation
+        try:
+            stream = await self._enter_manager(invocation)
+        except Exception as error:
+            invocation.fail(error)
+            raise
+        stream_wrapper = self._wrap_stream(stream, invocation)
+        self._self_stream_wrapper = stream_wrapper
+        return stream_wrapper
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> bool | None:
+        stream_wrapper = self._self_stream_wrapper
+        self._self_stream_wrapper = None
+        try:
+            suppressed = await self.__wrapped__.__aexit__(
+                exc_type, exc_val, exc_tb
+            )
+        except Exception as error:
+            if stream_wrapper is not None:
+                await stream_wrapper.__aexit__(
+                    type(error), error, error.__traceback__
+                )
+            elif self._self_invocation is not None:
+                self._self_invocation.fail(error)
+            raise
+        if stream_wrapper is not None:
+            if suppressed:
+                # See SyncStreamManagerWrapper.__exit__.
+                await stream_wrapper.__aexit__(None, None, None)
+            else:
+                await stream_wrapper.__aexit__(exc_type, exc_val, exc_tb)
+        return suppressed
 
 
 __all__ = [
+    "AsyncStreamManagerWrapper",
     "AsyncStreamWrapper",
+    "SyncStreamManagerWrapper",
     "SyncStreamWrapper",
+    "finalize_on_aclose",
+    "finalize_on_close",
 ]

--- a/util/opentelemetry-util-genai/tests/test_stream.py
+++ b/util/opentelemetry-util-genai/tests/test_stream.py
@@ -11,8 +11,12 @@ from unittest.mock import patch
 import pytest
 
 from opentelemetry.util.genai.stream import (
+    AsyncStreamManagerWrapper,
     AsyncStreamWrapper,
+    SyncStreamManagerWrapper,
     SyncStreamWrapper,
+    finalize_on_aclose,
+    finalize_on_close,
 )
 
 
@@ -69,8 +73,8 @@ class _FakeSyncIterable:
 
 
 class _TestSyncStreamWrapper(SyncStreamWrapper):
-    def __init__(self, stream):
-        super().__init__(stream)
+    def __init__(self, stream, invocation=None):
+        super().__init__(stream, invocation=invocation)
         self._self_processed = []
         self._self_stop_count = 0
         self._self_failures = []
@@ -80,26 +84,13 @@ class _TestSyncStreamWrapper(SyncStreamWrapper):
 
     def _on_stream_end(self):
         self._self_stop_count += 1
+        if self._self_invocation is not None:
+            self._self_invocation.stop()
 
     def _on_stream_error(self, error):
         self._self_failures.append(error)
-
-
-class _FailingSyncProcessStreamWrapper(_TestSyncStreamWrapper):
-    def _process_chunk(self, chunk):
-        raise ValueError("instrumentation failed")
-
-
-class _FailingSyncStopStreamWrapper(_TestSyncStreamWrapper):
-    def _on_stream_end(self):
-        self._self_stop_count += 1
-        raise ValueError("instrumentation failed")
-
-
-class _FailingSyncFailStreamWrapper(_TestSyncStreamWrapper):
-    def _on_stream_error(self, error):
-        self._self_failures.append(error)
-        raise ValueError("instrumentation failed")
+        if self._self_invocation is not None:
+            self._self_invocation.fail(error)
 
 
 def test_sync_stream_wrapper_processes_chunks_and_stops():
@@ -249,8 +240,8 @@ class _FakeAsyncIterable:
 
 
 class _TestAsyncStreamWrapper(AsyncStreamWrapper):
-    def __init__(self, stream):
-        super().__init__(stream)
+    def __init__(self, stream, invocation=None):
+        super().__init__(stream, invocation=invocation)
         self._self_processed = []
         self._self_stop_count = 0
         self._self_failures = []
@@ -260,9 +251,13 @@ class _TestAsyncStreamWrapper(AsyncStreamWrapper):
 
     def _on_stream_end(self):
         self._self_stop_count += 1
+        if self._self_invocation is not None:
+            self._self_invocation.stop()
 
     def _on_stream_error(self, error):
         self._self_failures.append(error)
+        if self._self_invocation is not None:
+            self._self_invocation.fail(error)
 
 
 def test_async_stream_wrapper_processes_chunks_and_stops():
@@ -542,5 +537,579 @@ def test_async_wrapper_without_invocation_skips_timing():
 
         assert chunks == ["a", "b"]
         timer.assert_not_called()
+
+    asyncio.run(exercise())
+
+
+class _FakeAcloseOnlyStream:
+    """An async generator style stream: ``aclose``, no ``close``."""
+
+    def __init__(self, chunks=None):
+        self._chunks = list(chunks or [])
+        self.aclose_count = 0
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if self._chunks:
+            return self._chunks.pop(0)
+        raise StopAsyncIteration
+
+    async def aclose(self):
+        self.aclose_count += 1
+
+
+def test_async_stream_wrapper_aclose_finalizes_telemetry():
+    async def exercise():
+        stream = _FakeAcloseOnlyStream(chunks=["a"])
+        wrapper = _TestAsyncStreamWrapper(stream)
+
+        await wrapper.aclose()
+
+        assert stream.aclose_count == 1
+        assert wrapper._self_stop_count == 1
+
+    asyncio.run(exercise())
+
+
+def test_async_stream_wrapper_only_exposes_the_streams_own_close_method():
+    close_only = _TestAsyncStreamWrapper(_FakeAsyncStream(chunks=["a"]))
+    aclose_only = _TestAsyncStreamWrapper(_FakeAcloseOnlyStream(chunks=["a"]))
+
+    assert not hasattr(close_only, "aclose")
+    assert not hasattr(aclose_only, "close")
+
+
+class _FakeBothCloseStream(_FakeAcloseOnlyStream):
+    """A stream pairing a sync ``close`` with an async ``aclose``."""
+
+    def __init__(self, chunks=None):
+        super().__init__(chunks=chunks)
+        self.close_count = 0
+
+    def close(self):
+        self.close_count += 1
+
+
+def test_async_stream_wrapper_prefers_aclose_over_sync_close():
+    async def exercise():
+        stream = _FakeBothCloseStream(chunks=["a"])
+        wrapper = _TestAsyncStreamWrapper(stream)
+
+        await wrapper.close()
+
+        assert stream.aclose_count == 1
+        assert stream.close_count == 0
+        assert wrapper._self_stop_count == 1
+
+    asyncio.run(exercise())
+
+
+class _FakeClosable:
+    def __init__(self, close_error=None):
+        self.close_count = 0
+        self.attribute = "passthrough"
+        self._close_error = close_error
+
+    def close(self):
+        self.close_count += 1
+        if self._close_error is not None:
+            raise self._close_error
+
+    async def aclose(self):
+        self.close_count += 1
+        if self._close_error is not None:
+            raise self._close_error
+
+
+def test_finalize_on_close_finalizes_and_forwards():
+    closable = _FakeClosable()
+    finalized = []
+
+    proxy = finalize_on_close(closable, lambda: finalized.append(True))
+
+    assert proxy.attribute == "passthrough"
+    proxy.close()
+
+    assert closable.close_count == 1
+    assert finalized == [True]
+
+
+def test_finalize_on_close_finalizes_when_close_raises():
+    closable = _FakeClosable(close_error=RuntimeError("close failure"))
+    finalized = []
+
+    proxy = finalize_on_close(closable, lambda: finalized.append(True))
+
+    with pytest.raises(RuntimeError, match="close failure"):
+        proxy.close()
+
+    assert finalized == [True]
+
+
+def test_finalize_on_aclose_finalizes_and_forwards():
+    async def exercise():
+        closable = _FakeClosable()
+        finalized = []
+
+        proxy = finalize_on_aclose(closable, lambda: finalized.append(True))
+
+        assert proxy.attribute == "passthrough"
+        await proxy.aclose()
+
+        assert closable.close_count == 1
+        assert finalized == [True]
+
+    asyncio.run(exercise())
+
+
+def test_finalize_on_aclose_finalizes_when_aclose_raises():
+    async def exercise():
+        closable = _FakeClosable(close_error=RuntimeError("close failure"))
+        finalized = []
+
+        proxy = finalize_on_aclose(closable, lambda: finalized.append(True))
+
+        with pytest.raises(RuntimeError, match="close failure"):
+            await proxy.aclose()
+
+        assert finalized == [True]
+
+    asyncio.run(exercise())
+
+
+class _FakeInvocation:
+    def __init__(self):
+        self.stop_count = 0
+        self.failures = []
+        self._request_stream = False
+
+    def stop(self):
+        self.stop_count += 1
+
+    def fail(self, error):
+        self.failures.append(error)
+
+    def _on_stream_chunk(self, chunk_at):
+        pass
+
+
+class _FakeSyncManager:
+    def __init__(
+        self, stream, *, suppressed=False, enter_error=None, exit_error=None
+    ):
+        self._stream = stream
+        self._suppressed = suppressed
+        self._enter_error = enter_error
+        self._exit_error = exit_error
+        self.exit_args = None
+        self.attribute = "passthrough"
+
+    def __enter__(self):
+        if self._enter_error is not None:
+            raise self._enter_error
+        return self._stream
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.exit_args = (exc_type, exc_val, exc_tb)
+        if self._exit_error is not None:
+            raise self._exit_error
+        return self._suppressed
+
+
+class _FakeAsyncManager(_FakeSyncManager):
+    async def __aenter__(self):
+        return self.__enter__()
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        return _FakeSyncManager.__exit__(self, exc_type, exc_val, exc_tb)
+
+
+class _TestSyncManagerWrapper(SyncStreamManagerWrapper):
+    def _wrap_stream(self, stream, invocation):
+        return _TestSyncStreamWrapper(stream, invocation=invocation)
+
+
+class _TestAsyncManagerWrapper(AsyncStreamManagerWrapper):
+    def _wrap_stream(self, stream, invocation):
+        return _TestAsyncStreamWrapper(stream, invocation=invocation)
+
+
+class _ScopedEnterSyncManagerWrapper(_TestSyncManagerWrapper):
+    """Runs the SDK entry inside instrumentation-owned state."""
+
+    def _enter_manager(self, invocation):
+        self._self_scope.append("enter")
+        try:
+            return super()._enter_manager(invocation)
+        finally:
+            self._self_scope.append("exit")
+
+
+class _ScopedEnterAsyncManagerWrapper(_TestAsyncManagerWrapper):
+    async def _enter_manager(self, invocation):
+        self._self_scope.append("enter")
+        try:
+            return await super()._enter_manager(invocation)
+        finally:
+            self._self_scope.append("exit")
+
+
+def test_sync_manager_wrapper_enters_and_finalizes_stream():
+    stream = _FakeSyncStream(chunks=["a"])
+    manager = _FakeSyncManager(stream)
+    wrapper = _TestSyncManagerWrapper(manager, _FakeInvocation)
+
+    with wrapper as stream_wrapper:
+        assert stream_wrapper.__wrapped__ is stream
+
+    assert manager.exit_args == (None, None, None)
+    assert stream_wrapper._self_stop_count == 1
+
+
+def test_sync_manager_wrapper_defers_invocation_until_enter():
+    factory_calls = []
+
+    def factory():
+        factory_calls.append(True)
+        return _FakeInvocation()
+
+    wrapper = _TestSyncManagerWrapper(
+        _FakeSyncManager(_FakeSyncStream()), factory
+    )
+
+    assert not factory_calls
+
+    with wrapper:
+        pass
+
+    assert factory_calls == [True]
+
+
+def test_sync_manager_wrapper_forwards_attributes():
+    wrapper = _TestSyncManagerWrapper(
+        _FakeSyncManager(_FakeSyncStream()), _FakeInvocation
+    )
+
+    assert wrapper.attribute == "passthrough"
+
+
+def test_sync_manager_wrapper_fails_invocation_when_enter_raises():
+    error = RuntimeError("manager enter failure")
+    invocation = _FakeInvocation()
+    wrapper = _TestSyncManagerWrapper(
+        _FakeSyncManager(_FakeSyncStream(), enter_error=error),
+        lambda: invocation,
+    )
+
+    with pytest.raises(RuntimeError, match="manager enter failure"):
+        with wrapper:
+            pass
+
+    assert invocation.failures == [error]
+
+
+def test_sync_manager_wrapper_forwards_caller_error_to_stream_wrapper():
+    manager = _FakeSyncManager(_FakeSyncStream())
+    wrapper = _TestSyncManagerWrapper(manager, _FakeInvocation)
+    error = ValueError("caller failure")
+
+    with pytest.raises(ValueError, match="caller failure"):
+        with wrapper as stream_wrapper:
+            raise error
+
+    assert manager.exit_args[:2] == (ValueError, error)
+    assert stream_wrapper._self_failures == [error]
+
+
+def test_sync_manager_wrapper_stops_stream_when_manager_suppresses():
+    manager = _FakeSyncManager(_FakeSyncStream(), suppressed=True)
+    wrapper = _TestSyncManagerWrapper(manager, _FakeInvocation)
+
+    with wrapper as stream_wrapper:
+        raise ValueError("suppressed")
+
+    assert stream_wrapper._self_stop_count == 1
+    assert not stream_wrapper._self_failures
+
+
+def test_sync_manager_wrapper_finalizes_stream_when_exit_raises():
+    manager_error = RuntimeError("manager failure")
+    manager = _FakeSyncManager(_FakeSyncStream(), exit_error=manager_error)
+    wrapper = _TestSyncManagerWrapper(manager, _FakeInvocation)
+
+    stream_wrapper = wrapper.__enter__()
+    with pytest.raises(RuntimeError, match="manager failure"):
+        wrapper.__exit__(None, None, None)
+
+    assert stream_wrapper._self_failures == [manager_error]
+
+
+def test_sync_manager_wrapper_fails_invocation_when_exit_raises_before_enter():
+    manager_error = RuntimeError("manager failure")
+    invocation = _FakeInvocation()
+    wrapper = _TestSyncManagerWrapper(
+        _FakeSyncManager(_FakeSyncStream(), exit_error=manager_error),
+        lambda: invocation,
+    )
+    wrapper._self_invocation = invocation
+
+    with pytest.raises(RuntimeError, match="manager failure"):
+        wrapper.__exit__(None, None, None)
+
+    assert invocation.failures == [manager_error]
+
+
+def test_async_manager_wrapper_enters_and_finalizes_stream():
+    async def exercise():
+        stream = _FakeAsyncStream(chunks=["a"])
+        manager = _FakeAsyncManager(stream)
+        wrapper = _TestAsyncManagerWrapper(manager, _FakeInvocation)
+
+        async with wrapper as stream_wrapper:
+            assert stream_wrapper.__wrapped__ is stream
+
+        assert manager.exit_args == (None, None, None)
+        assert stream_wrapper._self_stop_count == 1
+
+    asyncio.run(exercise())
+
+
+def test_async_manager_wrapper_fails_invocation_when_enter_raises():
+    async def exercise():
+        error = RuntimeError("manager enter failure")
+        invocation = _FakeInvocation()
+        wrapper = _TestAsyncManagerWrapper(
+            _FakeAsyncManager(_FakeAsyncStream(), enter_error=error),
+            lambda: invocation,
+        )
+
+        with pytest.raises(RuntimeError, match="manager enter failure"):
+            async with wrapper:
+                pass
+
+        assert invocation.failures == [error]
+
+    asyncio.run(exercise())
+
+
+def test_async_manager_wrapper_forwards_caller_error_to_stream_wrapper():
+    async def exercise():
+        manager = _FakeAsyncManager(_FakeAsyncStream())
+        wrapper = _TestAsyncManagerWrapper(manager, _FakeInvocation)
+        error = ValueError("caller failure")
+
+        with pytest.raises(ValueError, match="caller failure"):
+            async with wrapper as stream_wrapper:
+                raise error
+
+        assert manager.exit_args[:2] == (ValueError, error)
+        assert stream_wrapper._self_failures == [error]
+
+    asyncio.run(exercise())
+
+
+def test_async_manager_wrapper_stops_stream_when_manager_suppresses():
+    async def exercise():
+        manager = _FakeAsyncManager(_FakeAsyncStream(), suppressed=True)
+        wrapper = _TestAsyncManagerWrapper(manager, _FakeInvocation)
+
+        async with wrapper as stream_wrapper:
+            raise ValueError("suppressed")
+
+        assert stream_wrapper._self_stop_count == 1
+        assert not stream_wrapper._self_failures
+
+    asyncio.run(exercise())
+
+
+def test_async_manager_wrapper_finalizes_stream_when_exit_raises():
+    async def exercise():
+        manager_error = RuntimeError("manager failure")
+        manager = _FakeAsyncManager(
+            _FakeAsyncStream(), exit_error=manager_error
+        )
+        wrapper = _TestAsyncManagerWrapper(manager, _FakeInvocation)
+
+        stream_wrapper = await wrapper.__aenter__()
+        with pytest.raises(RuntimeError, match="manager failure"):
+            await wrapper.__aexit__(None, None, None)
+
+        assert stream_wrapper._self_failures == [manager_error]
+
+    asyncio.run(exercise())
+
+
+def test_sync_manager_wrapper_hands_factory_invocation_to_stream_wrapper():
+    invocation = _FakeInvocation()
+    wrapper = _TestSyncManagerWrapper(
+        _FakeSyncManager(_FakeSyncStream(chunks=["a"])), lambda: invocation
+    )
+
+    with wrapper as stream_wrapper:
+        assert stream_wrapper._self_invocation is invocation
+        assert invocation._request_stream is True
+        assert invocation.stop_count == 0
+
+    assert invocation.stop_count == 1
+    assert not invocation.failures
+
+
+def test_sync_manager_wrapper_fails_factory_invocation_on_caller_error():
+    invocation = _FakeInvocation()
+    wrapper = _TestSyncManagerWrapper(
+        _FakeSyncManager(_FakeSyncStream()), lambda: invocation
+    )
+    error = ValueError("caller failure")
+
+    with pytest.raises(ValueError, match="caller failure"):
+        with wrapper:
+            raise error
+
+    assert invocation.failures == [error]
+    assert invocation.stop_count == 0
+
+
+def test_sync_manager_wrapper_scopes_custom_enter_manager():
+    wrapper = _ScopedEnterSyncManagerWrapper(
+        _FakeSyncManager(_FakeSyncStream()), _FakeInvocation
+    )
+    wrapper._self_scope = []
+
+    with wrapper:
+        pass
+
+    assert wrapper._self_scope == ["enter", "exit"]
+
+
+def test_sync_manager_wrapper_unscopes_custom_enter_manager_on_failure():
+    wrapper = _ScopedEnterSyncManagerWrapper(
+        _FakeSyncManager(
+            _FakeSyncStream(), enter_error=RuntimeError("enter failure")
+        ),
+        _FakeInvocation,
+    )
+    wrapper._self_scope = []
+
+    with pytest.raises(RuntimeError, match="enter failure"):
+        wrapper.__enter__()
+
+    assert wrapper._self_scope == ["enter", "exit"]
+
+
+def test_async_manager_wrapper_hands_factory_invocation_to_stream_wrapper():
+    async def exercise():
+        invocation = _FakeInvocation()
+        wrapper = _TestAsyncManagerWrapper(
+            _FakeAsyncManager(_FakeAsyncStream(chunks=["a"])),
+            lambda: invocation,
+        )
+
+        async with wrapper as stream_wrapper:
+            assert stream_wrapper._self_invocation is invocation
+            assert invocation.stop_count == 0
+
+        assert invocation.stop_count == 1
+        assert not invocation.failures
+
+    asyncio.run(exercise())
+
+
+def test_async_manager_wrapper_scopes_custom_enter_manager():
+    async def exercise():
+        wrapper = _ScopedEnterAsyncManagerWrapper(
+            _FakeAsyncManager(_FakeAsyncStream()), _FakeInvocation
+        )
+        wrapper._self_scope = []
+
+        async with wrapper:
+            pass
+
+        assert wrapper._self_scope == ["enter", "exit"]
+
+    asyncio.run(exercise())
+
+
+def test_async_manager_wrapper_unscopes_custom_enter_manager_on_failure():
+    async def exercise():
+        wrapper = _ScopedEnterAsyncManagerWrapper(
+            _FakeAsyncManager(
+                _FakeAsyncStream(), enter_error=RuntimeError("enter failure")
+            ),
+            _FakeInvocation,
+        )
+        wrapper._self_scope = []
+
+        with pytest.raises(RuntimeError, match="enter failure"):
+            await wrapper.__aenter__()
+
+        assert wrapper._self_scope == ["enter", "exit"]
+
+    asyncio.run(exercise())
+
+
+def test_async_manager_wrapper_defers_invocation_until_enter():
+    async def exercise():
+        factory_calls = []
+
+        def factory():
+            factory_calls.append(True)
+            return _FakeInvocation()
+
+        wrapper = _TestAsyncManagerWrapper(
+            _FakeAsyncManager(_FakeAsyncStream()), factory
+        )
+
+        assert not factory_calls
+
+        async with wrapper:
+            pass
+
+        assert factory_calls == [True]
+
+    asyncio.run(exercise())
+
+
+def test_async_manager_wrapper_forwards_attributes():
+    wrapper = _TestAsyncManagerWrapper(
+        _FakeAsyncManager(_FakeAsyncStream()), _FakeInvocation
+    )
+
+    assert wrapper.attribute == "passthrough"
+
+
+def test_async_manager_wrapper_fails_factory_invocation_on_caller_error():
+    async def exercise():
+        invocation = _FakeInvocation()
+        wrapper = _TestAsyncManagerWrapper(
+            _FakeAsyncManager(_FakeAsyncStream()), lambda: invocation
+        )
+        error = ValueError("caller failure")
+
+        with pytest.raises(ValueError, match="caller failure"):
+            async with wrapper:
+                raise error
+
+        assert invocation.failures == [error]
+        assert invocation.stop_count == 0
+
+    asyncio.run(exercise())
+
+
+def test_async_manager_wrapper_fails_invocation_when_exit_raises_before_enter():
+    async def exercise():
+        manager_error = RuntimeError("manager failure")
+        invocation = _FakeInvocation()
+        wrapper = _TestAsyncManagerWrapper(
+            _FakeAsyncManager(_FakeAsyncStream(), exit_error=manager_error),
+            lambda: invocation,
+        )
+        wrapper._self_invocation = invocation
+
+        with pytest.raises(RuntimeError, match="manager failure"):
+            await wrapper.__aexit__(None, None, None)
+
+        assert invocation.failures == [manager_error]
 
     asyncio.run(exercise())


### PR DESCRIPTION
The openai and anthropic instrumentations each had their own copy of the stream-manager lifecycle, a close-finalizing proxy for `stream.response`, and the stream/iterator rebind. This moves them into `opentelemetry.util.genai.stream` as `SyncStreamManagerWrapper` / `AsyncStreamManagerWrapper` and `finalize_on_close` / `finalize_on_aclose`, and onboards both packages.

Also fixes a span leak for streams exposing `aclose` instead of `close` — Google's async `generate_content_stream` emitted no span when closed before being drained.

Follow-ups: the duplicated `with_raw_response` proxy moves to the util next, then generator-backed stream support for #386.