### PR TITLE
Delete towncrier fragments in previous patch release of google-genai. Update workflow to do this in the future

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-google-genai/.changelog/232.added
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/.changelog/232.added
@@ -1,1 +1,0 @@
-Add Weaver conformance test scenarios for ``generate_content``, ``interactions.create``, and ``embed_content``.

--- a/instrumentation/opentelemetry-instrumentation-google-genai/.changelog/244.changed
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/.changelog/244.changed
@@ -1,1 +1,0 @@
-Bump dependencies: opentelemetry-api from ~= 1.40 to ~= 1.43, opentelemetry-instrumentation and opentelemetry-semantic-conventions from >= 0.61b0 to >= 0.64b0, and opentelemetry-util-genai from >= 0.4b0 to >= 1.0b0.

--- a/instrumentation/opentelemetry-instrumentation-google-genai/.changelog/248.fixed
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/.changelog/248.fixed
@@ -1,1 +1,0 @@
-Fix minimum version of `opentelemetry-util-genai` dependency.

--- a/instrumentation/opentelemetry-instrumentation-google-genai/.changelog/254.changed
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/.changelog/254.changed
@@ -1,1 +1,0 @@
-Bump minimum required version of ``opentelemetry-api`` to ``1.43.0``, ``opentelemetry-instrumentation``/``opentelemetry-semantic-conventions`` to ``0.64b0``, and ``wrapt`` to ``1.17.0``.

--- a/instrumentation/opentelemetry-instrumentation-google-genai/.changelog/260.fixed
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/.changelog/260.fixed
@@ -1,1 +1,0 @@
-Ensure ``__code__.co_filename`` on wrapped functions matches the instrumentation file path.

--- a/scripts/merge_changelog_to_main.sh
+++ b/scripts/merge_changelog_to_main.sh
@@ -58,8 +58,8 @@ if [[ -d "$changelog_dir" && -f /tmp/CHANGELOG_SECTION.md ]]; then
             frag_name=$(basename "$fragment")
             if [[ "$frag_name" != .* ]]; then
                 pr_num="${frag_name%%.*}"
-                if grep -q "\[#${pr_num}\]" /tmp/CHANGELOG_SECTION.md; then
-                    rm "$fragment"
+                if grep -Fq "[#${pr_num}]" /tmp/CHANGELOG_SECTION.md; then
+                    rm -f -- "$fragment"
                 fi
             fi
         fi

--- a/scripts/merge_changelog_to_main.sh
+++ b/scripts/merge_changelog_to_main.sh
@@ -49,3 +49,19 @@ else
     # update the real CHANGELOG.md
     cp /tmp/CHANGELOG.md ${CHANGELOG}
 fi
+
+# remove any changelog fragments on main that were included in this release section
+changelog_dir="$(dirname "${CHANGELOG}")/.changelog"
+if [[ -d "$changelog_dir" && -f /tmp/CHANGELOG_SECTION.md ]]; then
+    for fragment in "$changelog_dir"/*; do
+        if [[ -f "$fragment" ]]; then
+            frag_name=$(basename "$fragment")
+            if [[ "$frag_name" != .* ]]; then
+                pr_num="${frag_name%%.*}"
+                if grep -q "\[#${pr_num}\]" /tmp/CHANGELOG_SECTION.md; then
+                    rm "$fragment"
+                fi
+            fi
+        fi
+    done
+fi


### PR DESCRIPTION
Delete towncrier fragments in previous patch release of google-genai (https://github.com/open-telemetry/opentelemetry-python-genai/pull/262). Update workflow to do this in the future


Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

Not a code change

# Checklist

See [CONTRIBUTING.md](https://github.com/open-telemetry/opentelemetry-python-genai/blob/main/CONTRIBUTING.md)
for the style guide, changelog guidance, and more.

- [x] Followed the style guidelines of this project
- [x] Changelog updated if the change requires an entry
- [x] Unit tests added
- [x] Documentation updated
