### PR TITLE
ci: cancel in-progress checks on PR and branch updates

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -14,6 +14,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   changelog:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -18,7 +18,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -1,24 +1,19 @@
 name: check-links
 on:
-  push:
-    branches: [ main ]
-    paths:
-      - '**/*.md'
-      - '**/*.rst'
-      - '.github/workflows/check-links.yml'
-      - '.github/workflows/check_links_config.json'
   pull_request:
     paths:
       - '**/*.md'
       - '**/*.rst'
       - '.github/workflows/check-links.yml'
       - '.github/workflows/check_links_config.json'
+  merge_group:
+    types: [checks_requested]
 
 permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.merge_group.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -44,8 +39,8 @@ jobs:
         if: steps.changed-files.outputs.any_changed == 'true'
         run: npm install -g markdown-link-check@v3.12.2
 
-      - name: Check links on push to main
-        if: steps.changed-files.outputs.any_changed == 'true' && github.event_name == 'push'
+      - name: Check links in merge queue
+        if: steps.changed-files.outputs.any_changed == 'true' && github.event_name == 'merge_group'
         run: |
           markdown-link-check \
             --verbose \
@@ -59,7 +54,7 @@ jobs:
           # Extract URLs only from added lines in the diff to avoid
           # rate limiting when checking all links in large files like
           # CHANGELOG.md. Only new/changed links are checked on PRs;
-          # pushes to main still check all links in changed files.
+          # merge-queue runs still check all links in changed files.
           git diff "origin/${{ github.base_ref }}...HEAD" -- \
             ${{ steps.changed-files.outputs.all_changed_files }} \
             | grep '^+' | grep -v '^+++' \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches:
-    - 'main'
   pull_request:
   merge_group:
     types: [checks_requested]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.merge_group.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## What does this change do?

Configures `cancel-in-progress: true` across `ci`, `changelog`, and `check-links` workflows using a unified concurrency group (`${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}`).

## Why?

When merge queue drops PRs or new commits are pushed, checks continue running and consume runner slots. Canceling in-progress checks mitigates the impact of redundant checks that nobody is waiting for anymore.