### PR TITLE
Migrate CI jobs to CNCF runners

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - cncf-ubuntu-2-8-x86

--- a/.github/workflows/_release-build.yml
+++ b/.github/workflows/_release-build.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: cncf-ubuntu-2-8-x86
     steps:
       - name: Resolve release target
         id: target

--- a/.github/workflows/_release-finalize.yml
+++ b/.github/workflows/_release-finalize.yml
@@ -25,7 +25,7 @@ jobs:
   finalize:
     permissions:
       contents: write
-    runs-on: ubuntu-latest
+    runs-on: cncf-ubuntu-2-8-x86
     steps:
       - name: Resolve release target
         id: target

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   changelog:
-    runs-on: ubuntu-latest
+    runs-on: cncf-ubuntu-2-8-x86
     if: >-
       ${{
         !contains(github.event.pull_request.labels.*.name, 'dependencies') &&

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -23,7 +23,7 @@ concurrency:
 
 jobs:
   check-links:
-    runs-on: ubuntu-latest
+    runs-on: cncf-ubuntu-2-8-x86
     if: ${{ github.actor != 'dependabot[bot]' && github.actor != 'otelbot[bot]' }}
     timeout-minutes: 15
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
   # new tox env automatically extends CI without editing workflow YAML.
   prepare:
     name: prepare-matrix
-    runs-on: ubuntu-latest
+    runs-on: cncf-ubuntu-2-8-x86
     timeout-minutes: 10
     outputs:
       test_matrix: ${{ steps.gen.outputs.test_matrix }}
@@ -62,7 +62,7 @@ jobs:
       - misc
       - lint
       - tests
-    runs-on: ubuntu-latest
+    runs-on: cncf-ubuntu-2-8-x86
     steps:
       - if: |
           needs.prepare.result != 'success' ||

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -21,7 +21,7 @@ jobs:
   CodeQL-Build:
     permissions:
       security-events: write # for github/codeql-action/analyze to upload SARIF results
-    runs-on: ubuntu-latest
+    runs-on: cncf-ubuntu-2-8-x86
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,7 +31,7 @@ jobs:
 
   lint:
     name: ${{ matrix.name }}
-    runs-on: ubuntu-latest
+    runs-on: cncf-ubuntu-2-8-x86
     timeout-minutes: 30
     strategy:
       fail-fast: false

--- a/.github/workflows/misc.yml
+++ b/.github/workflows/misc.yml
@@ -23,7 +23,7 @@ jobs:
 
   spellcheck:
     name: spellcheck
-    runs-on: ubuntu-latest
+    runs-on: cncf-ubuntu-2-8-x86
     timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
@@ -42,7 +42,7 @@ jobs:
 
   docs:
     name: docs
-    runs-on: ubuntu-latest
+    runs-on: cncf-ubuntu-2-8-x86
     timeout-minutes: 30
     if: |
       github.event.pull_request.user.login != 'otelbot[bot]' && github.event_name == 'pull_request'
@@ -63,7 +63,7 @@ jobs:
 
   generate:
     name: generate
-    runs-on: ubuntu-latest
+    runs-on: cncf-ubuntu-2-8-x86
     timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
@@ -85,7 +85,7 @@ jobs:
 
   readme:
     name: readme
-    runs-on: ubuntu-latest
+    runs-on: cncf-ubuntu-2-8-x86
     timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
@@ -104,7 +104,7 @@ jobs:
 
   shellcheck:
     name: shellcheck
-    runs-on: ubuntu-latest
+    runs-on: cncf-ubuntu-2-8-x86
     timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
@@ -123,7 +123,7 @@ jobs:
 
   precommit:
     name: precommit
-    runs-on: ubuntu-latest
+    runs-on: cncf-ubuntu-2-8-x86
     timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
@@ -142,7 +142,7 @@ jobs:
 
   typecheck:
     name: typecheck
-    runs-on: ubuntu-latest
+    runs-on: cncf-ubuntu-2-8-x86
     timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
@@ -161,7 +161,7 @@ jobs:
 
   oldest-deps-check:
     name: oldest-deps-check
-    runs-on: ubuntu-latest
+    runs-on: cncf-ubuntu-2-8-x86
     timeout-minutes: 10
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}

--- a/.github/workflows/prepare-backport-patch.yml
+++ b/.github/workflows/prepare-backport-patch.yml
@@ -28,7 +28,7 @@ jobs:
   prepare:
     permissions:
       contents: write
-    runs-on: ubuntu-latest
+    runs-on: cncf-ubuntu-2-8-x86
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -32,7 +32,7 @@ jobs:
   prepare:
     permissions:
       contents: write
-    runs-on: ubuntu-latest
+    runs-on: cncf-ubuntu-2-8-x86
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/.github/workflows/release-all.yml
+++ b/.github/workflows/release-all.yml
@@ -16,7 +16,7 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (github.event.pull_request.merged == true &&
        contains(github.event.pull_request.labels.*.name, 'release'))
-    runs-on: ubuntu-latest
+    runs-on: cncf-ubuntu-2-8-x86
     outputs:
       packages: ${{ steps.enumerate.outputs.packages }}
       ref: ${{ steps.release_ref.outputs.ref }}
@@ -81,7 +81,7 @@ jobs:
 
   publish:
     needs: [enumerate, build]
-    runs-on: ubuntu-latest
+    runs-on: cncf-ubuntu-2-8-x86
     strategy:
       fail-fast: false
       matrix:
@@ -122,7 +122,7 @@ jobs:
     if: always() && needs.enumerate.result == 'success'
     permissions:
       contents: write
-    runs-on: ubuntu-latest
+    runs-on: cncf-ubuntu-2-8-x86
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -29,7 +29,7 @@ jobs:
 
   publish:
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: cncf-ubuntu-2-8-x86
     environment: pypi
     permissions:
       id-token: write

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -16,4 +16,6 @@ jobs:
       contents: read # for actions/checkout
       id-token: write # for Scorecard to publish results
       security-events: write # for the SARIF upload to code scanning
-    uses: open-telemetry/shared-workflows/.github/workflows/scorecard.yml@8079110d7e793bd38b1a5219ef8f8280dab9139e # v0.7.0
+    uses: open-telemetry/shared-workflows/.github/workflows/scorecard.yml@9ba7b96740beb68158e4f1cdfd10a3b794364711 # v0.8.0
+    with:
+      use-cncf-hosted-runner: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,7 +14,7 @@ jobs:
       contents: read
       issues: write
       pull-requests: write
-    runs-on: ubuntu-latest
+    runs-on: cncf-ubuntu-2-8-x86
     steps:
       - uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93 # v11.0.0
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
 
   test:
     name: ${{ matrix.name }}
-    runs-on: ubuntu-latest
+    runs-on: cncf-ubuntu-2-8-x86
     timeout-minutes: 30
     strategy:
       fail-fast: false


### PR DESCRIPTION
## What does this change do?
Migrates CI workflow jobs from `ubuntu-latest` to CNCF self-hosted runners (`cncf-ubuntu-2-8-x86`). Also updates `scorecard.yml` to use `open-telemetry/shared-workflows` v0.8.0 with `use-cncf-hosted-runner: true`, and adds `.github/actionlint.yaml` for runner label recognition.

## Why?
https://github.com/open-telemetry/community/issues/3622