### PR TITLE
ci: install uv before dev version bump in release workflows

### DIFF
--- a/.github/workflows/_release-finalize.yml
+++ b/.github/workflows/_release-finalize.yml
@@ -103,6 +103,9 @@ jobs:
       - name: Regenerate instrumentations README
         run: python ./scripts/generate_instrumentation_readme.py
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+
       - name: Use CLA approved github bot
         run: .github/scripts/use-cla-approved-github-bot.sh
 
@@ -150,6 +153,7 @@ jobs:
           git pull origin main
 
           uv run ./scripts/version_utils.py bump --dev
+          uv run tox -e generate
 
           if git diff --quiet; then
             echo "No version bump needed"
@@ -163,5 +167,6 @@ jobs:
           git push origin HEAD:"$branch"
           gh pr create --title "$message" \
                        --body "Bump versions to the next \`.dev\` version after releasing v\`${VERSION}\`." \
+                       --label "Skip Changelog" \
                        --head "$branch" \
                        --base main

--- a/.github/workflows/release-all.yml
+++ b/.github/workflows/release-all.yml
@@ -128,6 +128,9 @@ jobs:
         with:
           ref: main
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+
       - name: Use CLA approved github bot
         run: .github/scripts/use-cla-approved-github-bot.sh
 
@@ -142,6 +145,7 @@ jobs:
           GITHUB_TOKEN: ${{ steps.otelbot-token.outputs.token }}
         run: |
           uv run ./scripts/version_utils.py bump --dev
+          uv run tox -e generate
 
           if git diff --quiet; then
             echo "No version bump needed"
@@ -156,5 +160,6 @@ jobs:
           git push origin HEAD:"$branch"
           gh pr create --title "$message" \
                        --body "$body" \
+                       --label "Skip Changelog" \
                        --head "$branch" \
                        --base main

--- a/README.md
+++ b/README.md
@@ -13,22 +13,22 @@ All instrumentations use [opentelemetry-util-genai](./util/opentelemetry-util-ge
 
 | Instrumentation | Supported Package | Version |
 | --------------- | ----------------- | ------- |
-| [opentelemetry-instrumentation-genai-anthropic](./instrumentation/opentelemetry-instrumentation-genai-anthropic) | anthropic >= 0.51.0 | [1.0b0](https://pypi.org/project/opentelemetry-instrumentation-genai-anthropic/) |
-| [opentelemetry-instrumentation-genai-langchain](./instrumentation/opentelemetry-instrumentation-genai-langchain) | langchain >= 0.3.21 | [1.0b0](https://pypi.org/project/opentelemetry-instrumentation-genai-langchain/) |
-| [opentelemetry-instrumentation-genai-openai](./instrumentation/opentelemetry-instrumentation-genai-openai) | openai >= 1.26.0, < 4 | [1.0b0](https://pypi.org/project/opentelemetry-instrumentation-genai-openai/) |
-| [opentelemetry-instrumentation-genai-openai-agents](./instrumentation/opentelemetry-instrumentation-genai-openai-agents) | openai-agents >= 0.3.3 | [1.0b0](https://pypi.org/project/opentelemetry-instrumentation-genai-openai-agents/) |
-| [opentelemetry-instrumentation-google-genai](./instrumentation/opentelemetry-instrumentation-google-genai) | google-genai >= 1.32.0, <3 | [1.0b1](https://pypi.org/project/opentelemetry-instrumentation-google-genai/) |
+| [opentelemetry-instrumentation-genai-agno](./instrumentation/opentelemetry-instrumentation-genai-agno) | agno >= 2.0.0 | [1.1b0](https://pypi.org/project/opentelemetry-instrumentation-genai-agno/) |
+| [opentelemetry-instrumentation-genai-anthropic](./instrumentation/opentelemetry-instrumentation-genai-anthropic) | anthropic >= 0.51.0 | [1.1b0](https://pypi.org/project/opentelemetry-instrumentation-genai-anthropic/) |
+| [opentelemetry-instrumentation-genai-langchain](./instrumentation/opentelemetry-instrumentation-genai-langchain) | langchain >= 0.3.21 | [1.1b0](https://pypi.org/project/opentelemetry-instrumentation-genai-langchain/) |
+| [opentelemetry-instrumentation-genai-openai](./instrumentation/opentelemetry-instrumentation-genai-openai) | openai >= 1.26.0, < 4 | [1.1b0](https://pypi.org/project/opentelemetry-instrumentation-genai-openai/) |
+| [opentelemetry-instrumentation-genai-openai-agents](./instrumentation/opentelemetry-instrumentation-genai-openai-agents) | openai-agents >= 0.3.3 | [1.1b0](https://pypi.org/project/opentelemetry-instrumentation-genai-openai-agents/) |
+| [opentelemetry-instrumentation-genai-qwen-agent](./instrumentation/opentelemetry-instrumentation-genai-qwen-agent) | qwen-agent >= 0.0.20 | [1.1b0](https://pypi.org/project/opentelemetry-instrumentation-genai-qwen-agent/) |
+| [opentelemetry-instrumentation-genai-smolagents](./instrumentation/opentelemetry-instrumentation-genai-smolagents) | smolagents >= 1.24.0 | [1.1b0](https://pypi.org/project/opentelemetry-instrumentation-genai-smolagents/) |
+| [opentelemetry-instrumentation-google-genai](./instrumentation/opentelemetry-instrumentation-google-genai) | google-genai >= 1.32.0, <3 | [1.1b0](https://pypi.org/project/opentelemetry-instrumentation-google-genai/) |
 
 ## Unreleased Instrumentations
 
 | Instrumentation | Supported Package | Version | Status |
 | --------------- | ----------------- | ------- | ------ |
-| [opentelemetry-instrumentation-genai-agno](./instrumentation/opentelemetry-instrumentation-genai-agno) | agno >= 2.0.0 | 1.1b0 | to be released |
 | [opentelemetry-instrumentation-genai-claude-agent-sdk](./instrumentation/opentelemetry-instrumentation-genai-claude-agent-sdk) | claude-agent-sdk >= 0.1.14 | 1.1b0.dev | skeleton |
 | [opentelemetry-instrumentation-genai-crewai](./instrumentation/opentelemetry-instrumentation-genai-crewai) | crewai >= 1.10.1 | 1.1b0.dev | skeleton |
 | [opentelemetry-instrumentation-genai-llama-index](./instrumentation/opentelemetry-instrumentation-genai-llama-index) | llama-index-core >= 0.14.19 | 1.1b0.dev | skeleton |
-| [opentelemetry-instrumentation-genai-qwen-agent](./instrumentation/opentelemetry-instrumentation-genai-qwen-agent) | qwen-agent >= 0.0.20 | 1.1b0 | to be released |
-| [opentelemetry-instrumentation-genai-smolagents](./instrumentation/opentelemetry-instrumentation-genai-smolagents) | smolagents >= 1.24.0 | 1.1b0 | to be released |
 | [opentelemetry-instrumentation-genai-weaviate-client](./instrumentation/opentelemetry-instrumentation-genai-weaviate-client) | weaviate-client >= 3.0.0, <5.0.0 | 1.1b0.dev | skeleton |
 <!-- end -->
 


### PR DESCRIPTION
# Description

Add the `setup-uv` step to the `bump-main` job in `release-all.yml` and `_release-finalize.yml`.

This fixes the post-release version bump step failing due to `uv` not being installed on the runner (see failed job in https://github.com/open-telemetry/opentelemetry-python-genai/actions/runs/32396642158/job/96532431301).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

- [x] Ran precommit hooks (`uv run tox -e precommit`)
- [x] Verified action hash and version against other workflows (`ci.yml`, `prepare-release.yml`)

# Checklist

- [x] Followed the style guidelines of this project
- [ ] Changelog updated if the change requires an entry
- [ ] Unit tests added
- [ ] Documentation updated
