### PR TITLE
ci: batch post-release updates into single PR for bulk releases

### DIFF
--- a/.github/workflows/_release-finalize.yml
+++ b/.github/workflows/_release-finalize.yml
@@ -13,6 +13,10 @@ on:
         required: false
         type: boolean
         default: false
+      sync_main:
+        required: false
+        type: boolean
+        default: true
       bump_after_release:
         required: false
         type: boolean
@@ -92,76 +96,61 @@ jobs:
                             "$RELEASE_TAG"
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: inputs.sync_main
         with:
           ref: main
 
+      - name: Install uv
+        if: inputs.sync_main
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+
       - name: Copy changelog updates to main
+        if: inputs.sync_main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./scripts/merge_changelog_to_main.sh
 
       - name: Regenerate instrumentations README
+        if: inputs.sync_main
         run: python ./scripts/generate_instrumentation_readme.py
 
+      - name: Bump package version on main after release
+        if: inputs.sync_main && inputs.bump_after_release && steps.target.outputs.on_main == 'true'
+        run: uv run ./scripts/version_utils.py bump --package "${PACKAGE_NAME}" --dev
+
       - name: Use CLA approved github bot
+        if: inputs.sync_main
         run: .github/scripts/use-cla-approved-github-bot.sh
 
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        if: inputs.sync_main
         id: otelbot-token
         with:
           client-id: ${{ vars.OTELBOT_CLIENT_ID }}
           private-key: ${{ secrets.OTELBOT_PRIVATE_KEY }}
 
-      - name: Open pull request for changelog updates on main
+      - name: Open pull request for post-release updates on main
+        if: inputs.sync_main
         env:
           GITHUB_TOKEN: ${{ steps.otelbot-token.outputs.token }}
         run: |
-          message="Copy changelog updates for ${PACKAGE_NAME} v${VERSION}"
-          body="Copy changelog updates for \`${PACKAGE_NAME}\` v\`${VERSION}\`."
-          branch="otelbot/changelog-${PACKAGE_NAME}-${VERSION}"
-
-          changes=0
-          if [[ -z $PRIOR_VERSION_WHEN_PATCH ]]; then
-            if ! git diff --quiet; then
-              changes=1
-            fi
-          else
-            changes=1
-          fi
-
-          if [[ $changes == 0 ]]; then
-            echo "No changelog updates needed on main"
+          if git diff --quiet; then
+            echo "No updates needed on main"
             exit 0
           fi
+
+          if [[ -n "$PRIOR_VERSION_WHEN_PATCH" ]]; then
+            message="[chore] Finalize patch release for ${PACKAGE_NAME} v${VERSION}"
+            body="Copy patch changelog updates to main and regenerate instrumentation README for \`${PACKAGE_NAME}\` v\`${VERSION}\`."
+          else
+            message="[chore] Finalize release for ${PACKAGE_NAME} v${VERSION}"
+            body="Regenerate instrumentation README and bump package version for \`${PACKAGE_NAME}\` to next dev version after releasing v\`${VERSION}\`."
+          fi
+          branch="otelbot/finalize-${PACKAGE_NAME}-${VERSION}"
 
           git commit -a -m "$message"
           git push origin HEAD:"$branch"
           gh pr create --title "$message" \
                        --body "$body" \
-                       --head "$branch" \
-                       --base main
-
-      - name: Bump package version on main after release
-        if: inputs.bump_after_release && steps.target.outputs.on_main == 'true'
-        env:
-          GITHUB_TOKEN: ${{ steps.otelbot-token.outputs.token }}
-        run: |
-          git checkout main
-          git pull origin main
-
-          uv run ./scripts/version_utils.py bump --dev
-
-          if git diff --quiet; then
-            echo "No version bump needed"
-            exit 0
-          fi
-
-          message="Bump version to next dev version after releasing v${VERSION}"
-          branch="otelbot/bump-after-v${VERSION}"
-
-          git commit -a -m "$message"
-          git push origin HEAD:"$branch"
-          gh pr create --title "$message" \
-                       --body "Bump versions to the next \`.dev\` version after releasing v\`${VERSION}\`." \
                        --head "$branch" \
                        --base main

--- a/.github/workflows/_release-finalize.yml
+++ b/.github/workflows/_release-finalize.yml
@@ -116,7 +116,7 @@ jobs:
 
       - name: Bump package version on main after release
         if: inputs.sync_main && inputs.bump_after_release && steps.target.outputs.on_main == 'true'
-        run: uv run ./scripts/version_utils.py bump --package "${PACKAGE_NAME}" --dev
+        run: uv run ./scripts/version_utils.py bump --dev
 
       - name: Use CLA approved github bot
         if: inputs.sync_main
@@ -144,7 +144,7 @@ jobs:
             body="Copy patch changelog updates to main and regenerate instrumentation README for \`${PACKAGE_NAME}\` v\`${VERSION}\`."
           else
             message="Finalize release for ${PACKAGE_NAME} v${VERSION}"
-            body="Regenerate instrumentation README and bump package version for \`${PACKAGE_NAME}\` to next dev version after releasing v\`${VERSION}\`."
+            body="Regenerate instrumentation README and bump package versions to next dev version after releasing \`${PACKAGE_NAME}\` v\`${VERSION}\`."
           fi
           branch="otelbot/finalize-${PACKAGE_NAME}-${VERSION}"
 

--- a/.github/workflows/_release-finalize.yml
+++ b/.github/workflows/_release-finalize.yml
@@ -140,10 +140,10 @@ jobs:
           fi
 
           if [[ -n "$PRIOR_VERSION_WHEN_PATCH" ]]; then
-            message="[chore] Finalize patch release for ${PACKAGE_NAME} v${VERSION}"
+            message="Finalize patch release for ${PACKAGE_NAME} v${VERSION}"
             body="Copy patch changelog updates to main and regenerate instrumentation README for \`${PACKAGE_NAME}\` v\`${VERSION}\`."
           else
-            message="[chore] Finalize release for ${PACKAGE_NAME} v${VERSION}"
+            message="Finalize release for ${PACKAGE_NAME} v${VERSION}"
             body="Regenerate instrumentation README and bump package version for \`${PACKAGE_NAME}\` to next dev version after releasing v\`${VERSION}\`."
           fi
           branch="otelbot/finalize-${PACKAGE_NAME}-${VERSION}"
@@ -153,4 +153,5 @@ jobs:
           gh pr create --title "$message" \
                        --body "$body" \
                        --head "$branch" \
-                       --base main
+                       --base main \
+                       --label "Skip Changelog"

--- a/.github/workflows/release-all.yml
+++ b/.github/workflows/release-all.yml
@@ -101,7 +101,7 @@ jobs:
           packages-dir: dist/
           skip-existing: true
 
-  finalize:
+  github-release:
     needs: [enumerate, publish]
     permissions:
       contents: write
@@ -114,12 +114,13 @@ jobs:
       package: ${{ matrix.package }}
       ref: ${{ needs.enumerate.outputs.ref }}
       on_main: true
+      sync_main: false
       bump_after_release: false
     secrets: inherit
 
-  bump-main:
-    needs: [enumerate, publish, finalize]
-    if: always() && needs.enumerate.result == 'success'
+  finalize:
+    needs: [enumerate, publish, github-release]
+    if: always() && needs.enumerate.result == 'success' && needs.publish.result == 'success'
     permissions:
       contents: write
     runs-on: cncf-ubuntu-2-8-x86
@@ -127,6 +128,15 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: main
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+
+      - name: Regenerate instrumentations README
+        run: python ./scripts/generate_instrumentation_readme.py
+
+      - name: Bump repository version to next dev version
+        run: uv run ./scripts/version_utils.py bump --dev
 
       - name: Use CLA approved github bot
         run: .github/scripts/use-cla-approved-github-bot.sh
@@ -137,19 +147,17 @@ jobs:
           client-id: ${{ vars.OTELBOT_CLIENT_ID }}
           private-key: ${{ secrets.OTELBOT_PRIVATE_KEY }}
 
-      - name: Bump repository version to next dev version
+      - name: Open pull request for post-release updates on main
         env:
           GITHUB_TOKEN: ${{ steps.otelbot-token.outputs.token }}
         run: |
-          uv run ./scripts/version_utils.py bump --dev
-
           if git diff --quiet; then
-            echo "No version bump needed"
+            echo "No updates needed on main"
             exit 0
           fi
 
-          message="Bump packages to next dev versions after release"
-          body="Bump package versions in eachdist.ini and all package version.py files to the next \`.dev\` version."
+          message="[chore] Post-release version bump and updates"
+          body="Regenerate instrumentation README and bump package versions in eachdist.ini and all package version.py files to the next \`.dev\` version."
           branch="otelbot/bump-after-release-all-$(date +%Y%m%d)"
 
           git commit -a -m "$message"

--- a/.github/workflows/release-all.yml
+++ b/.github/workflows/release-all.yml
@@ -156,7 +156,7 @@ jobs:
             exit 0
           fi
 
-          message="[chore] Post-release version bump and updates"
+          message="Post-release version bump and updates"
           body="Regenerate instrumentation README and bump package versions in eachdist.ini and all package version.py files to the next \`.dev\` version."
           branch="otelbot/bump-after-release-all-$(date +%Y%m%d)"
 
@@ -165,4 +165,5 @@ jobs:
           gh pr create --title "$message" \
                        --body "$body" \
                        --head "$branch" \
-                       --base main
+                       --base main \
+                       --label "Skip Changelog"

--- a/.github/workflows/release-all.yml
+++ b/.github/workflows/release-all.yml
@@ -101,7 +101,7 @@ jobs:
           packages-dir: dist/
           skip-existing: true
 
-  github-release:
+  github_release:
     needs: [enumerate, publish]
     permissions:
       contents: write
@@ -119,8 +119,8 @@ jobs:
     secrets: inherit
 
   finalize:
-    needs: [enumerate, publish, github-release]
-    if: always() && needs.enumerate.result == 'success' && needs.publish.result == 'success'
+    needs: [enumerate, publish, github_release]
+    if: always() && needs.enumerate.result == 'success' && needs.publish.result == 'success' && needs.github_release.result == 'success'
     permissions:
       contents: write
     runs-on: cncf-ubuntu-2-8-x86


### PR DESCRIPTION
Consolidates post-release updates (README generation and dev version bumps) into a single PR when running bulk releases, while keeping dedicated flows for individual package patches.

Prevents duplicate PRs per package and fixes the version bump step in bulk release which failed previously due to missing `uv`.