### PR TITLE
Check that local workspace dependencies in oldest requirements match pyproject dev floor

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/requirements.oldest.txt
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/requirements.oldest.txt
@@ -21,5 +21,4 @@
 # OpenTelemetry SDK and test utilities come transitively from opentelemetry-test-util-genai, which
 # every oldest env installs. Pin here only test-only deps that nothing else already provides.
 #
-# Drop this once opentelemetry-util-genai 1.1b0 is published.
--e util/opentelemetry-util-genai
+

--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/.changelog/433.changed
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/.changelog/433.changed
@@ -1,0 +1,1 @@
+Raised `opentelemetry-util-genai` dependency floor to 1.1b0.

--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 dependencies = [
   "opentelemetry-instrumentation >= 0.64b0, <1",
-  "opentelemetry-util-genai >= 1.0b0, <2",
+  "opentelemetry-util-genai >= 1.1b0, <2",
 ]
 
 [project.optional-dependencies]

--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/tests/requirements.oldest.txt
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/tests/requirements.oldest.txt
@@ -20,11 +20,7 @@
 # pyproject floors by UV_RESOLUTION=lowest-direct on the oldest tox factor, so they are NOT pinned
 # here to avoid drift between the declared bound and the tested version.
 
-# Exception: this change depends on the fully-qualified error.type behavior added in
-# opentelemetry-util-genai 1.1b0, which is not on PyPI yet. Install it from the workspace so the
-# oldest env exercises the required behavior. Remove this once 1.1b0 is released and bump the
-# pyproject floor to >= 1.1b0.
--e ./util/opentelemetry-util-genai
+
 
 langchain-openai==0.2.0
 langchain-aws==0.2.2

--- a/instrumentation/opentelemetry-instrumentation-genai-openai/tests/requirements.oldest.txt
+++ b/instrumentation/opentelemetry-instrumentation-genai-openai/tests/requirements.oldest.txt
@@ -21,14 +21,7 @@
 # OpenTelemetry SDK and test utilities come transitively from opentelemetry-test-util-genai, which
 # every oldest env installs. Pin here only test-only deps that nothing else already provides.
 #
-# Drop this once opentelemetry-util-genai 1.1b0 is published.
--e util/opentelemetry-util-genai
 
-# Exception: this change depends on the fully-qualified error.type behavior added in
-# opentelemetry-util-genai 1.1b0, which is not on PyPI yet. Install it from the workspace so the
-# oldest env exercises the required behavior. Remove this once 1.1b0 is released and bump the
-# pyproject floor to >= 1.1b0.
--e ./util/opentelemetry-util-genai
 
 numpy==2.3.1 ; python_version >= "3.11"
 numpy==2.1.0 ; python_version == "3.10"

--- a/instrumentation/opentelemetry-instrumentation-genai-qwen-agent/tests/requirements.oldest.txt
+++ b/instrumentation/opentelemetry-instrumentation-genai-qwen-agent/tests/requirements.oldest.txt
@@ -21,8 +21,7 @@
 # OpenTelemetry SDK and test utilities come transitively from opentelemetry-test-util-genai, which
 # every oldest env installs. Pin here only test-only deps that nothing else already provides.
 
-# Drop this once opentelemetry-util-genai 1.1b0 is published.
--e util/opentelemetry-util-genai
+
 
 # qwen-agent imports numpy, dateutil, dotenv, and tqdm at import time but does
 # not declare them.

--- a/instrumentation/opentelemetry-instrumentation-genai-smolagents/tests/requirements.oldest.txt
+++ b/instrumentation/opentelemetry-instrumentation-genai-smolagents/tests/requirements.oldest.txt
@@ -24,7 +24,4 @@
 # The instrumented model classes run inference in this process and the tests stub their
 # runtimes, so there is no model backend to pin here.
 
-# The declared opentelemetry-util-genai floor carries the streaming metrics and the
-# gen_ai.request.stream attribute, which are not in a published release yet.
-# Drop this once opentelemetry-util-genai 1.1b0 is published.
--e util/opentelemetry-util-genai
+

--- a/instrumentation/opentelemetry-instrumentation-google-genai/.changelog/433.changed
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/.changelog/433.changed
@@ -1,0 +1,1 @@
+Raised `opentelemetry-util-genai` dependency floor to 1.1b0.

--- a/instrumentation/opentelemetry-instrumentation-google-genai/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
   "opentelemetry-api ~= 1.43",
   "opentelemetry-instrumentation >= 0.64b0, <1",
   "opentelemetry-semantic-conventions >= 0.64b0, <1",
-  "opentelemetry-util-genai >= 1.0b0, <2",
+  "opentelemetry-util-genai >= 1.1b0, <2",
   "wrapt >= 1.17.0, < 3.0.0",
 ]
 

--- a/instrumentation/opentelemetry-instrumentation-google-genai/tests/requirements.oldest.txt
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/tests/requirements.oldest.txt
@@ -21,10 +21,6 @@
 # OpenTelemetry SDK and test utilities come transitively from opentelemetry-test-util-genai, which
 # every oldest env installs. Pin here only test-only deps that nothing else already provides.
 
-# Exception: this change depends on the output-token behavior added in opentelemetry-util-genai
-# 1.1b0 (thinking tokens no longer auto-summed into output_tokens), which is not on PyPI yet.
-# Install it from the workspace so the oldest env exercises the required behavior. Remove this once
-# 1.1b0 is released and bump the pyproject floor to >= 1.1b0.
--e ./util/opentelemetry-util-genai
+
 
 fsspec==2025.9.0

--- a/scripts/check_deps.py
+++ b/scripts/check_deps.py
@@ -8,11 +8,18 @@
    The oldest tox envs install the lowest versions of each package's *declared* deps straight from
    pyproject.toml via ``UV_RESOLUTION=lowest-direct`` (see AGENTS.md). pyproject.toml is therefore the
    single source of truth for those floors and running the env is what validates them. This script
-   covers the two gaps a passing oldest env can't see:
+   covers gaps a passing oldest env can't see:
    - Re-introduced drift: a pyproject-declared dep hand-pinned again in tests/requirements.oldest.txt.
      Such a pin silently overrides the derived floor and can drift from the declared bound; remove it.
    - Missing coverage: a package with an oldest tox factor (a tests/requirements.latest.txt) but no
      tests/requirements.oldest.txt at all, so its declared floors are never exercised.
+   - Workspace dependency floors and local installs:
+     - If a workspace dependency floor in pyproject.toml is from a previous release cycle,
+       it resolves and tests from PyPI; it must NOT be installed from local paths in
+       oldest requirements.
+     - If a workspace dependency floor matches the current unreleased workspace dev version,
+       tests/requirements.oldest.txt must install it locally so tests can run against
+       the local development version.
 
 2. Package runtime dependency specifier invariant:
    Instrumentation packages declare their target library dependencies in [project.optional-dependencies]
@@ -33,18 +40,204 @@ except ModuleNotFoundError:  # Python < 3.11
 
 from packaging.requirements import Requirement
 from packaging.utils import canonicalize_name
+from packaging.version import Version
+
+scripts_dir = Path(__file__).resolve().parent
+if str(scripts_dir) not in sys.path:
+    sys.path.insert(0, str(scripts_dir))
+
+from version_utils import get_version_file_path, get_version_from_file
+
+
+def get_declared_requirements(pyproject: dict) -> list[Requirement]:
+    """Return all Requirements declared in [project.dependencies] and optional-dependencies."""
+    project = pyproject.get("project", {})
+    reqs: list[Requirement] = []
+    for dep in project.get("dependencies", []):
+        reqs.append(Requirement(dep))
+    for deps in project.get("optional-dependencies", {}).values():
+        for dep in deps:
+            reqs.append(Requirement(dep))
+    return reqs
+
+
+def get_workspace_packages(repo_root: Path) -> dict[str, tuple[Path, str]]:
+    """Return map of canonical_name -> (package_dir, current_version_str)."""
+    packages: dict[str, tuple[Path, str]] = {}
+    pyprojects = sorted(
+        repo_root.glob("instrumentation/*/pyproject.toml")
+    ) + sorted(repo_root.glob("util/*/pyproject.toml"))
+    for pyproject_path in pyprojects:
+        pkg_dir = pyproject_path.parent
+        try:
+            pyproject = tomllib.loads(
+                pyproject_path.read_text(encoding="utf-8")
+            )
+            name = pyproject.get("project", {}).get("name")
+            if not name:
+                continue
+            v_path = get_version_file_path(pkg_dir)
+            if v_path and v_path.exists():
+                version_str = get_version_from_file(v_path)
+                packages[canonicalize_name(name)] = (pkg_dir, version_str)
+        except Exception:
+            continue
+    return packages
+
+
+def parse_local_workspace_lines(
+    oldest_path: Path,
+    repo_root: Path,
+    workspace_packages: dict[str, tuple[Path, str]],
+) -> dict[str, str]:
+    """Find lines in a requirements file that install local workspace packages."""
+    workspace_dirs = {
+        pkg_dir.resolve(): name
+        for name, (pkg_dir, _) in workspace_packages.items()
+    }
+    local_pkgs: dict[str, str] = {}
+
+    for raw in oldest_path.read_text(encoding="utf-8").splitlines():
+        line = raw.split("#", 1)[0].strip()
+        if not line:
+            continue
+
+        path_str = line
+        is_editable = line.startswith(("-e", "--editable"))
+        if is_editable:
+            parts = line.split(maxsplit=1)
+            path_str = parts[1].strip() if len(parts) > 1 else ""
+
+        path_clean = (
+            path_str.split("[", 1)[0]
+            .strip()
+            .replace("{toxinidir}", str(repo_root))
+        )
+
+        matched_pkg: str | None = None
+        for base in (oldest_path.parent, oldest_path.parent.parent, repo_root):
+            resolved = (base / path_clean).resolve()
+            if resolved in workspace_dirs:
+                matched_pkg = workspace_dirs[resolved]
+                break
+            if (resolved / "pyproject.toml").is_file():
+                try:
+                    data = tomllib.loads(
+                        (resolved / "pyproject.toml").read_text(
+                            encoding="utf-8"
+                        )
+                    )
+                    name = data.get("project", {}).get("name")
+                    if name:
+                        matched_pkg = canonicalize_name(name)
+                        break
+                except Exception:
+                    pass
+
+        if matched_pkg:
+            local_pkgs[matched_pkg] = line
+        elif is_editable:
+            local_pkgs[line] = line
+
+    return local_pkgs
+
+
+def check_workspace_dependencies(
+    pkg_dir: Path,
+    pyproject: dict,
+    oldest_path: Path | None,
+    repo_root: Path,
+    workspace_packages: dict[str, tuple[Path, str]],
+) -> list[str]:
+    """Verify declared workspace dependency floors match PyPI release state or current .dev version."""
+    errors: list[str] = []
+
+    local_pkgs = (
+        parse_local_workspace_lines(oldest_path, repo_root, workspace_packages)
+        if oldest_path and oldest_path.exists()
+        else {}
+    )
+    valid_locals: set[str] = set()
+    reported_locals: set[str] = set()
+
+    declared_reqs = get_declared_requirements(pyproject)
+    pkg_name = canonicalize_name(pyproject.get("project", {}).get("name", ""))
+
+    for req in declared_reqs:
+        canonical_name = canonicalize_name(req.name)
+        if (
+            canonical_name not in workspace_packages
+            or canonical_name == pkg_name
+        ):
+            continue
+
+        target_dir, current_version_str = workspace_packages[canonical_name]
+        try:
+            current_version = Version(current_version_str)
+        except Exception:
+            continue
+
+        lower_bound_str: str | None = None
+        for spec in req.specifier:
+            if spec.operator in (">=", "==", "~="):
+                lower_bound_str = spec.version
+                break
+
+        if lower_bound_str is None:
+            errors.append(
+                f"{pkg_dir.name}: workspace dependency '{req.name}' is missing a lower bound (e.g. '>= {current_version_str}')."
+            )
+            continue
+
+        try:
+            floor_version = Version(lower_bound_str)
+        except Exception:
+            errors.append(
+                f"{pkg_dir.name}: invalid version specifier '{lower_bound_str}' for workspace dependency '{req.name}'."
+            )
+            continue
+
+        # Floor is from a previous cycle, published on PyPI (e.g. 1.0b0, 1.1b0, 1.1b0.dev)
+        if floor_version < current_version:
+            if canonical_name in local_pkgs:
+                reported_locals.add(canonical_name)
+                errors.append(
+                    f"{pkg_dir.name}: '{req.name}' declared floor is '{lower_bound_str}' (released version on PyPI), "
+                    f"but tests/requirements.oldest.txt installs it locally with '{local_pkgs[canonical_name]}'. "
+                    f"Remove the local/editable install so tests run against the declared floor from PyPI."
+                )
+        # Floor is the current unreleased workspace dev version (e.g. 1.2b0.dev)
+        elif floor_version == current_version:
+            if canonical_name not in local_pkgs:
+                errors.append(
+                    f"{pkg_dir.name}: declared floor for '{req.name}' is unreleased '{lower_bound_str}', "
+                    f"but tests/requirements.oldest.txt is missing a local/editable install (-e). "
+                    f"Add local/editable install to tests/requirements.oldest.txt while under development."
+                )
+            else:
+                valid_locals.add(canonical_name)
+        # Floor is higher than current workspace version
+        else:
+            errors.append(
+                f"{pkg_dir.name}: declared floor '{lower_bound_str}' for '{req.name}' exceeds "
+                f"current workspace version '{current_version_str}'."
+            )
+
+    for name, line in local_pkgs.items():
+        if name not in valid_locals and name not in reported_locals:
+            errors.append(
+                f"{pkg_dir.name}: '{line}' in tests/requirements.oldest.txt is not permitted. "
+                f"Local/editable installs in oldest requirements are only allowed for workspace dependencies declaring an unreleased .dev floor."
+            )
+
+    return errors
 
 
 def declared_dep_names(pyproject: dict) -> set[str]:
     """Canonical names of every dep declared in [project.dependencies] and optional-dependencies."""
-    project = pyproject.get("project", {})
-    names: set[str] = set()
-    for dep in project.get("dependencies", []):
-        names.add(canonicalize_name(Requirement(dep).name))
-    for deps in project.get("optional-dependencies", {}).values():
-        for dep in deps:
-            names.add(canonicalize_name(Requirement(dep).name))
-    return names
+    return {
+        canonicalize_name(r.name) for r in get_declared_requirements(pyproject)
+    }
 
 
 def pinned_names(oldest_req_path: Path) -> set[str]:
@@ -169,6 +362,8 @@ def main() -> int:
     repo_root = Path(__file__).resolve().parent.parent
     errors: list[str] = []
 
+    workspace_packages = get_workspace_packages(repo_root)
+
     pyprojects = sorted(
         repo_root.glob("instrumentation/*/pyproject.toml"),
     ) + sorted(repo_root.glob("util/*/pyproject.toml"))
@@ -201,6 +396,17 @@ def main() -> int:
                 f"the pyproject.toml floor via UV_RESOLUTION=lowest-direct."
             )
 
+        # Check 3: workspace dependencies floor and editable install validation
+        errors.extend(
+            check_workspace_dependencies(
+                pkg_dir,
+                pyproject,
+                oldest,
+                repo_root,
+                workspace_packages,
+            )
+        )
+
     if errors:
         print("Dependency check failed:\n", file=sys.stderr)
         for err in errors:
@@ -208,7 +414,7 @@ def main() -> int:
         return 1
 
     print(
-        "Dependency checks passed: package.py matches pyproject.toml, no declared deps re-pinned, no missing coverage."
+        "Dependency checks passed: package.py matches pyproject.toml, no declared deps re-pinned, no missing coverage, workspace dependency floors validated."
     )
     return 0
 

--- a/util/opentelemetry-util-genai/tests/test_check_deps.py
+++ b/util/opentelemetry-util-genai/tests/test_check_deps.py
@@ -1,0 +1,254 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+# Add scripts directory to sys.path to import check_deps
+repo_root = Path(__file__).resolve().parent.parent.parent.parent
+scripts_dir = str(repo_root / "scripts")
+sys.path.insert(0, scripts_dir)
+try:
+    from check_deps import check_workspace_dependencies
+finally:
+    if scripts_dir in sys.path:
+        sys.path.remove(scripts_dir)
+
+
+class TestCheckWorkspaceDependencies(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.repo_root = Path(self.temp_dir.name)
+
+        # Setup workspace packages
+        self.util_dir = self.repo_root / "util" / "opentelemetry-util-genai"
+        self.util_dir.mkdir(parents=True, exist_ok=True)
+        (self.util_dir / "pyproject.toml").write_text(
+            '[project]\nname = "opentelemetry-util-genai"\n',
+            encoding="utf-8",
+        )
+
+        self.workspace_packages = {
+            "opentelemetry-util-genai": (self.util_dir, "1.2b0.dev"),
+        }
+
+        self.pkg_dir = (
+            self.repo_root
+            / "instrumentation"
+            / "opentelemetry-instrumentation-test"
+        )
+        self.pkg_dir.mkdir(parents=True, exist_ok=True)
+        self.tests_dir = self.pkg_dir / "tests"
+        self.tests_dir.mkdir(parents=True, exist_ok=True)
+        self.oldest_path = self.tests_dir / "requirements.oldest.txt"
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def test_released_floor_without_editable_passes(self):
+        pyproject = {
+            "project": {
+                "name": "opentelemetry-instrumentation-test",
+                "dependencies": ["opentelemetry-util-genai >= 1.1b0, < 2"],
+            }
+        }
+        errors = check_workspace_dependencies(
+            self.pkg_dir,
+            pyproject,
+            None,
+            self.repo_root,
+            self.workspace_packages,
+        )
+        self.assertEqual(errors, [])
+
+    def test_released_floor_with_editable_fails(self):
+        pyproject = {
+            "project": {
+                "name": "opentelemetry-instrumentation-test",
+                "dependencies": ["opentelemetry-util-genai >= 1.1b0, < 2"],
+            }
+        }
+        self.oldest_path.write_text(
+            "-e ../../util/opentelemetry-util-genai\n",
+            encoding="utf-8",
+        )
+        errors = check_workspace_dependencies(
+            self.pkg_dir,
+            pyproject,
+            self.oldest_path,
+            self.repo_root,
+            self.workspace_packages,
+        )
+        self.assertEqual(len(errors), 1)
+        self.assertIn("released version on PyPI", errors[0])
+        self.assertIn("Remove the local/editable install", errors[0])
+
+    def test_released_floor_with_non_editable_local_path_fails(self):
+        pyproject = {
+            "project": {
+                "name": "opentelemetry-instrumentation-test",
+                "dependencies": ["opentelemetry-util-genai >= 1.1b0, < 2"],
+            }
+        }
+        self.oldest_path.write_text(
+            "../../util/opentelemetry-util-genai\n",
+            encoding="utf-8",
+        )
+        errors = check_workspace_dependencies(
+            self.pkg_dir,
+            pyproject,
+            self.oldest_path,
+            self.repo_root,
+            self.workspace_packages,
+        )
+        self.assertEqual(len(errors), 1)
+        self.assertIn("released version on PyPI", errors[0])
+        self.assertIn("Remove the local/editable install", errors[0])
+
+    def test_matching_dev_floor_with_editable_passes(self):
+        pyproject = {
+            "project": {
+                "name": "opentelemetry-instrumentation-test",
+                "dependencies": ["opentelemetry-util-genai >= 1.2b0.dev, < 2"],
+            }
+        }
+        self.oldest_path.write_text(
+            "-e ../../util/opentelemetry-util-genai\n",
+            encoding="utf-8",
+        )
+        errors = check_workspace_dependencies(
+            self.pkg_dir,
+            pyproject,
+            self.oldest_path,
+            self.repo_root,
+            self.workspace_packages,
+        )
+        self.assertEqual(errors, [])
+
+    def test_matching_dev_floor_with_non_editable_local_path_passes(self):
+        pyproject = {
+            "project": {
+                "name": "opentelemetry-instrumentation-test",
+                "dependencies": ["opentelemetry-util-genai >= 1.2b0.dev, < 2"],
+            }
+        }
+        self.oldest_path.write_text(
+            "../../util/opentelemetry-util-genai\n",
+            encoding="utf-8",
+        )
+        errors = check_workspace_dependencies(
+            self.pkg_dir,
+            pyproject,
+            self.oldest_path,
+            self.repo_root,
+            self.workspace_packages,
+        )
+        self.assertEqual(errors, [])
+
+    def test_matching_dev_floor_missing_editable_fails(self):
+        pyproject = {
+            "project": {
+                "name": "opentelemetry-instrumentation-test",
+                "dependencies": ["opentelemetry-util-genai >= 1.2b0.dev, < 2"],
+            }
+        }
+        errors = check_workspace_dependencies(
+            self.pkg_dir,
+            pyproject,
+            None,
+            self.repo_root,
+            self.workspace_packages,
+        )
+        self.assertEqual(len(errors), 1)
+        self.assertIn("unreleased '1.2b0.dev'", errors[0])
+        self.assertIn("missing a local/editable install", errors[0])
+
+    def test_previous_dev_floor_without_editable_passes(self):
+        pyproject = {
+            "project": {
+                "name": "opentelemetry-instrumentation-test",
+                "dependencies": ["opentelemetry-util-genai >= 1.1b0.dev, < 2"],
+            }
+        }
+        errors = check_workspace_dependencies(
+            self.pkg_dir,
+            pyproject,
+            None,
+            self.repo_root,
+            self.workspace_packages,
+        )
+        self.assertEqual(errors, [])
+
+    def test_exceeding_dev_floor_fails(self):
+        pyproject = {
+            "project": {
+                "name": "opentelemetry-instrumentation-test",
+                "dependencies": ["opentelemetry-util-genai >= 1.3b0.dev, < 2"],
+            }
+        }
+        errors = check_workspace_dependencies(
+            self.pkg_dir,
+            pyproject,
+            None,
+            self.repo_root,
+            self.workspace_packages,
+        )
+        self.assertEqual(len(errors), 1)
+        self.assertIn("exceeds current workspace version", errors[0])
+
+    def test_extraneous_editable_fails(self):
+        pyproject = {
+            "project": {
+                "name": "opentelemetry-instrumentation-test",
+                "dependencies": ["opentelemetry-util-genai >= 1.1b0, < 2"],
+            }
+        }
+        # Another workspace package not in declared deps
+        other_dir = self.repo_root / "util" / "other-pkg"
+        other_dir.mkdir(parents=True, exist_ok=True)
+        (other_dir / "pyproject.toml").write_text(
+            '[project]\nname = "other-pkg"\n',
+            encoding="utf-8",
+        )
+        self.oldest_path.write_text(
+            "-e ../../util/other-pkg\n",
+            encoding="utf-8",
+        )
+        errors = check_workspace_dependencies(
+            self.pkg_dir,
+            pyproject,
+            self.oldest_path,
+            self.repo_root,
+            self.workspace_packages,
+        )
+        self.assertEqual(len(errors), 1)
+        self.assertIn("is not permitted", errors[0])
+
+    def test_extraneous_non_editable_local_path_fails(self):
+        pyproject = {
+            "project": {
+                "name": "opentelemetry-instrumentation-test",
+                "dependencies": ["opentelemetry-util-genai >= 1.1b0, < 2"],
+            }
+        }
+        other_dir = self.repo_root / "util" / "other-pkg"
+        other_dir.mkdir(parents=True, exist_ok=True)
+        (other_dir / "pyproject.toml").write_text(
+            '[project]\nname = "other-pkg"\n',
+            encoding="utf-8",
+        )
+        self.oldest_path.write_text(
+            "../../util/other-pkg\n",
+            encoding="utf-8",
+        )
+        errors = check_workspace_dependencies(
+            self.pkg_dir,
+            pyproject,
+            self.oldest_path,
+            self.repo_root,
+            self.workspace_packages,
+        )
+        self.assertEqual(len(errors), 1)
+        self.assertIn("is not permitted", errors[0])


### PR DESCRIPTION
- Adds a check to `check_deps.py` verifying that local/editable workspace dependencies in `tests/requirements.oldest.txt` only occur when `pyproject.toml` declares an unreleased `.dev` floor.
- Removes stale local installs from `tests/requirements.oldest.txt` for released `opentelemetry-util-genai` 1.1b0 and updates floors for `google-genai` and `langchain`.

This check identified a discrepancy for google-genai and langchain, which declared an incompatible floor. I'll start a patch as a follow-up once this lands.