### PR TITLE
Fix failing anthropic tests in the CI pipeline due to new version of anthropic depending on httpx2 instead of httpx

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/.changelog/434.fixed
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/.changelog/434.fixed
@@ -1,0 +1,1 @@
+Anthropic version 1.0.0 depends on httpx2 instead of httpx. Modified the imports to support the updated dependencies.

--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/src/opentelemetry/instrumentation/genai/anthropic/_raw_response.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/src/opentelemetry/instrumentation/genai/anthropic/_raw_response.py
@@ -11,7 +11,7 @@ import logging
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Any, cast
 
-import httpx
+import httpx2
 from anthropic._models import construct_type
 from anthropic.types import Message as AnthropicMessage
 
@@ -429,7 +429,7 @@ def _body_was_read(http_response: Any) -> bool:
         return False
     try:
         http_response.content  # pylint: disable=pointless-statement
-    except httpx.ResponseNotRead:
+    except httpx2.ResponseNotRead:
         return False
     return True
 

--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/src/opentelemetry/instrumentation/genai/anthropic/messages_extractors.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/src/opentelemetry/instrumentation/genai/anthropic/messages_extractors.py
@@ -33,7 +33,7 @@ from .utils import (
 if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping
 
-    import httpx
+    import httpx2
     from anthropic.resources.messages import AsyncMessages, Messages
     from anthropic.types import (
         Message,
@@ -194,7 +194,7 @@ def extract_params(  # pylint: disable=too-many-locals
     extra_headers: Mapping[str, str] | None = None,
     extra_query: Mapping[str, object] | None = None,
     extra_body: object | None = None,
-    timeout: float | httpx.Timeout | None = None,
+    timeout: float | httpx2.Timeout | None = None,
     **_kwargs: object,
 ) -> MessageRequestParams:
     return MessageRequestParams(

--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/src/opentelemetry/instrumentation/genai/anthropic/wrappers.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/src/opentelemetry/instrumentation/genai/anthropic/wrappers.py
@@ -31,10 +31,8 @@ except ImportError:
     _sdk_accumulate_event = None
 
 if TYPE_CHECKING:
-    try:
-        import httpx2 as httpx
-    except ImportError:
-        import httpx
+    
+    import httpx2
     from anthropic._streaming import AsyncStream, Stream
     from anthropic.lib.streaming._messages import (  # pylint: disable=no-name-in-module
         AsyncMessageStream,
@@ -165,7 +163,7 @@ class MessagesStreamWrapper(
         self._self_message_telemetry_finalized = False
 
     @property
-    def response(self) -> httpx.Response:
+    def response(self) -> httpx2.Response:
         return finalize_on_close(self.stream.response, self._stop)
 
     @property
@@ -205,7 +203,7 @@ class AsyncMessagesStreamWrapper(
         self._self_message_telemetry_finalized = False
 
     @property
-    def response(self) -> httpx.Response:
+    def response(self) -> httpx2.Response:
         return finalize_on_aclose(self.stream.response, self._stop)
 
     @property

--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/src/opentelemetry/instrumentation/genai/anthropic/wrappers.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/src/opentelemetry/instrumentation/genai/anthropic/wrappers.py
@@ -31,7 +31,6 @@ except ImportError:
     _sdk_accumulate_event = None
 
 if TYPE_CHECKING:
-    
     import httpx2
     from anthropic._streaming import AsyncStream, Stream
     from anthropic.lib.streaming._messages import (  # pylint: disable=no-name-in-module

--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/src/opentelemetry/instrumentation/genai/anthropic/wrappers.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/src/opentelemetry/instrumentation/genai/anthropic/wrappers.py
@@ -31,7 +31,10 @@ except ImportError:
     _sdk_accumulate_event = None
 
 if TYPE_CHECKING:
-    import httpx
+    try:
+        import httpx2 as httpx
+    except ImportError:
+        import httpx
     from anthropic._streaming import AsyncStream, Stream
     from anthropic.lib.streaming._messages import (  # pylint: disable=no-name-in-module
         AsyncMessageStream,

--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/test_async_messages.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/test_async_messages.py
@@ -6,7 +6,7 @@
 import inspect
 import json
 
-import httpx
+import httpx2
 import pytest
 from anthropic import APIConnectionError, AsyncAnthropic, NotFoundError
 from anthropic._legacy_response import LegacyAPIResponse
@@ -1488,9 +1488,9 @@ async def test_async_messages_raw_response_parse_to_honors_cast_target(
         messages=[{"role": "user", "content": "Say hello in one word."}],
     ) as raw_response:
         await raw_response.parse()
-        as_httpx = await raw_response.parse(to=httpx.Response)
+        as_httpx = await raw_response.parse(to=httpx2.Response)
 
-    assert isinstance(as_httpx, httpx.Response)
+    assert isinstance(as_httpx, httpx2.Response)
 
 
 @pytest.mark.cassette("test_async_messages_create_with_raw_response")

--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/test_instrumentor.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/test_instrumentor.py
@@ -64,7 +64,7 @@ def test_instrumentation_dependencies():
 
     assert dependencies is not None
     assert len(dependencies) > 0
-    assert "anthropic >= 0.51.0" in dependencies
+    assert "anthropic >= 1.0.0, <2" in dependencies
 
 
 def test_instrument_uninstrument_cycle(

--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/test_sync_messages.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/test_sync_messages.py
@@ -9,7 +9,7 @@ import json
 import os
 from pathlib import Path
 
-import httpx
+import httpx2
 import pytest
 from anthropic import Anthropic, APIConnectionError, NotFoundError
 from anthropic._legacy_response import LegacyAPIResponse
@@ -1670,9 +1670,9 @@ def test_sync_messages_raw_response_parse_to_honors_cast_target(
         messages=[{"role": "user", "content": "Say hello in one word."}],
     ) as raw_response:
         raw_response.parse()
-        as_httpx = raw_response.parse(to=httpx.Response)
+        as_httpx = raw_response.parse(to=httpx2.Response)
 
-    assert isinstance(as_httpx, httpx.Response)
+    assert isinstance(as_httpx, httpx2.Response)
 
 
 @pytest.mark.vcr()


### PR DESCRIPTION
## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. List any relevant details for your test
configuration.

- [x]uv run tox -e py312-test-instrumentation-genai-anthropic-latest -- -ra

# Checklist

See [CONTRIBUTING.md](https://github.com/open-telemetry/opentelemetry-python-genai/blob/main/CONTRIBUTING.md)
for the style guide, changelog guidance, and more.

- [x] Followed the style guidelines of this project
- [x] Changelog updated if the change requires an entry
- [ ] Unit tests added
- [ ] Documentation updated
