### PR TITLE
Enforce bounds on instruments dependencies and pin latest test requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,22 +13,22 @@ All instrumentations use [opentelemetry-util-genai](./util/opentelemetry-util-ge
 
 | Instrumentation | Supported Package | Version |
 | --------------- | ----------------- | ------- |
-| [opentelemetry-instrumentation-genai-agno](./instrumentation/opentelemetry-instrumentation-genai-agno) | agno >= 2.0.0 | [1.1b0](https://pypi.org/project/opentelemetry-instrumentation-genai-agno/) |
-| [opentelemetry-instrumentation-genai-anthropic](./instrumentation/opentelemetry-instrumentation-genai-anthropic) | anthropic >= 0.51.0 | [1.1b0](https://pypi.org/project/opentelemetry-instrumentation-genai-anthropic/) |
-| [opentelemetry-instrumentation-genai-langchain](./instrumentation/opentelemetry-instrumentation-genai-langchain) | langchain >= 0.3.21 | [1.1b0](https://pypi.org/project/opentelemetry-instrumentation-genai-langchain/) |
+| [opentelemetry-instrumentation-genai-agno](./instrumentation/opentelemetry-instrumentation-genai-agno) | agno >= 2.0.0, < 3 | [1.1b0](https://pypi.org/project/opentelemetry-instrumentation-genai-agno/) |
+| [opentelemetry-instrumentation-genai-anthropic](./instrumentation/opentelemetry-instrumentation-genai-anthropic) | anthropic >= 0.51.0, < 2 | [1.1b0](https://pypi.org/project/opentelemetry-instrumentation-genai-anthropic/) |
+| [opentelemetry-instrumentation-genai-langchain](./instrumentation/opentelemetry-instrumentation-genai-langchain) | langchain >= 0.3.21, < 1 | [1.1b0](https://pypi.org/project/opentelemetry-instrumentation-genai-langchain/) |
 | [opentelemetry-instrumentation-genai-openai](./instrumentation/opentelemetry-instrumentation-genai-openai) | openai >= 1.26.0, < 4 | [1.1b0](https://pypi.org/project/opentelemetry-instrumentation-genai-openai/) |
-| [opentelemetry-instrumentation-genai-openai-agents](./instrumentation/opentelemetry-instrumentation-genai-openai-agents) | openai-agents >= 0.3.3 | [1.1b0](https://pypi.org/project/opentelemetry-instrumentation-genai-openai-agents/) |
-| [opentelemetry-instrumentation-genai-qwen-agent](./instrumentation/opentelemetry-instrumentation-genai-qwen-agent) | qwen-agent >= 0.0.20 | [1.1b0](https://pypi.org/project/opentelemetry-instrumentation-genai-qwen-agent/) |
-| [opentelemetry-instrumentation-genai-smolagents](./instrumentation/opentelemetry-instrumentation-genai-smolagents) | smolagents >= 1.24.0 | [1.1b0](https://pypi.org/project/opentelemetry-instrumentation-genai-smolagents/) |
+| [opentelemetry-instrumentation-genai-openai-agents](./instrumentation/opentelemetry-instrumentation-genai-openai-agents) | openai-agents >= 0.3.3, < 1 | [1.1b0](https://pypi.org/project/opentelemetry-instrumentation-genai-openai-agents/) |
+| [opentelemetry-instrumentation-genai-qwen-agent](./instrumentation/opentelemetry-instrumentation-genai-qwen-agent) | qwen-agent >= 0.0.20, < 1 | [1.1b0](https://pypi.org/project/opentelemetry-instrumentation-genai-qwen-agent/) |
+| [opentelemetry-instrumentation-genai-smolagents](./instrumentation/opentelemetry-instrumentation-genai-smolagents) | smolagents >= 1.24.0, < 2 | [1.1b0](https://pypi.org/project/opentelemetry-instrumentation-genai-smolagents/) |
 | [opentelemetry-instrumentation-google-genai](./instrumentation/opentelemetry-instrumentation-google-genai) | google-genai >= 1.32.0, <3 | [1.1b0](https://pypi.org/project/opentelemetry-instrumentation-google-genai/) |
 
 ## Unreleased Instrumentations
 
 | Instrumentation | Supported Package | Version | Status |
 | --------------- | ----------------- | ------- | ------ |
-| [opentelemetry-instrumentation-genai-claude-agent-sdk](./instrumentation/opentelemetry-instrumentation-genai-claude-agent-sdk) | claude-agent-sdk >= 0.1.14 | 1.2b0.dev | skeleton |
-| [opentelemetry-instrumentation-genai-crewai](./instrumentation/opentelemetry-instrumentation-genai-crewai) | crewai >= 1.10.1 | 1.2b0.dev | skeleton |
-| [opentelemetry-instrumentation-genai-llama-index](./instrumentation/opentelemetry-instrumentation-genai-llama-index) | llama-index-core >= 0.14.19 | 1.2b0.dev | skeleton |
+| [opentelemetry-instrumentation-genai-claude-agent-sdk](./instrumentation/opentelemetry-instrumentation-genai-claude-agent-sdk) | claude-agent-sdk >= 0.1.14, < 1 | 1.2b0.dev | skeleton |
+| [opentelemetry-instrumentation-genai-crewai](./instrumentation/opentelemetry-instrumentation-genai-crewai) | crewai >= 1.10.1, < 2 | 1.2b0.dev | skeleton |
+| [opentelemetry-instrumentation-genai-llama-index](./instrumentation/opentelemetry-instrumentation-genai-llama-index) | llama-index-core >= 0.14.19, < 1 | 1.2b0.dev | skeleton |
 | [opentelemetry-instrumentation-genai-weaviate-client](./instrumentation/opentelemetry-instrumentation-genai-weaviate-client) | weaviate-client >= 3.0.0, <5.0.0 | 1.2b0.dev | skeleton |
 <!-- end -->
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ All instrumentations use [opentelemetry-util-genai](./util/opentelemetry-util-ge
 | Instrumentation | Supported Package | Version |
 | --------------- | ----------------- | ------- |
 | [opentelemetry-instrumentation-genai-agno](./instrumentation/opentelemetry-instrumentation-genai-agno) | agno >= 2.0.0, < 3 | [1.1b0](https://pypi.org/project/opentelemetry-instrumentation-genai-agno/) |
-| [opentelemetry-instrumentation-genai-anthropic](./instrumentation/opentelemetry-instrumentation-genai-anthropic) | anthropic >= 0.51.0, < 2 | [1.1b0](https://pypi.org/project/opentelemetry-instrumentation-genai-anthropic/) |
-| [opentelemetry-instrumentation-genai-langchain](./instrumentation/opentelemetry-instrumentation-genai-langchain) | langchain >= 0.3.21, < 1 | [1.1b0](https://pypi.org/project/opentelemetry-instrumentation-genai-langchain/) |
+| [opentelemetry-instrumentation-genai-anthropic](./instrumentation/opentelemetry-instrumentation-genai-anthropic) | anthropic >= 0.51.0, < 1 | [1.1b0](https://pypi.org/project/opentelemetry-instrumentation-genai-anthropic/) |
+| [opentelemetry-instrumentation-genai-langchain](./instrumentation/opentelemetry-instrumentation-genai-langchain) | langchain >= 0.3.21, < 2 | [1.1b0](https://pypi.org/project/opentelemetry-instrumentation-genai-langchain/) |
 | [opentelemetry-instrumentation-genai-openai](./instrumentation/opentelemetry-instrumentation-genai-openai) | openai >= 1.26.0, < 4 | [1.1b0](https://pypi.org/project/opentelemetry-instrumentation-genai-openai/) |
 | [opentelemetry-instrumentation-genai-openai-agents](./instrumentation/opentelemetry-instrumentation-genai-openai-agents) | openai-agents >= 0.3.3, < 1 | [1.1b0](https://pypi.org/project/opentelemetry-instrumentation-genai-openai-agents/) |
 | [opentelemetry-instrumentation-genai-qwen-agent](./instrumentation/opentelemetry-instrumentation-genai-qwen-agent) | qwen-agent >= 0.0.20, < 1 | [1.1b0](https://pypi.org/project/opentelemetry-instrumentation-genai-qwen-agent/) |

--- a/instrumentation/opentelemetry-instrumentation-genai-agno/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-genai-agno/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-instruments = ["agno >= 2.0.0"]
+instruments = ["agno >= 2.0.0, < 3"]
 
 [project.entry-points.opentelemetry_instrumentor]
 agno = "opentelemetry.instrumentation.genai.agno:AgnoInstrumentor"

--- a/instrumentation/opentelemetry-instrumentation-genai-agno/src/opentelemetry/instrumentation/genai/agno/package.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-agno/src/opentelemetry/instrumentation/genai/agno/package.py
@@ -1,4 +1,4 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-_instruments = ("agno >= 2.0.0",)
+_instruments = ("agno >= 2.0.0, < 3",)

--- a/instrumentation/opentelemetry-instrumentation-genai-agno/tests/requirements.latest.txt
+++ b/instrumentation/opentelemetry-instrumentation-genai-agno/tests/requirements.latest.txt
@@ -37,7 +37,7 @@
 # This variant of the requirements aims to test the system using
 # the newest supported version of external dependencies.
 
-agno
+agno~=2.9.0
 wrapt>=2.2.2
 # test with the latest version of opentelemetry-api, sdk, semantic conventions, and instrumentation
 

--- a/instrumentation/opentelemetry-instrumentation-genai-agno/tests/test_instrumentor.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-agno/tests/test_instrumentor.py
@@ -24,7 +24,7 @@ def test_instrumentation_dependencies() -> None:
 
     assert dependencies is not None
     assert len(dependencies) > 0
-    assert "agno >= 2.0.0" in dependencies
+    assert "agno >= 2.0.0, < 3" in dependencies
 
 
 def test_instrument_uninstrument_cycle(

--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-instruments = ["anthropic >= 0.51.0"]
+instruments = ["anthropic >= 0.51.0, < 2"]
 
 [project.entry-points.opentelemetry_instrumentor]
 anthropic = "opentelemetry.instrumentation.genai.anthropic:AnthropicInstrumentor"

--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-instruments = ["anthropic >= 0.51.0, < 2"]
+instruments = ["anthropic >= 0.51.0, < 1"]
 
 [project.entry-points.opentelemetry_instrumentor]
 anthropic = "opentelemetry.instrumentation.genai.anthropic:AnthropicInstrumentor"

--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/src/opentelemetry/instrumentation/genai/anthropic/package.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/src/opentelemetry/instrumentation/genai/anthropic/package.py
@@ -1,4 +1,4 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-_instruments = ("anthropic >= 0.51.0",)
+_instruments = ("anthropic >= 0.51.0, < 2",)

--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/src/opentelemetry/instrumentation/genai/anthropic/package.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/src/opentelemetry/instrumentation/genai/anthropic/package.py
@@ -1,4 +1,4 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-_instruments = ("anthropic >= 0.51.0, < 2",)
+_instruments = ("anthropic >= 0.51.0, < 1",)

--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/requirements.latest.txt
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/requirements.latest.txt
@@ -37,7 +37,7 @@
 # This variant of the requirements aims to test the system using
 # the newest supported version of external dependencies.
 
-anthropic~=0.51.0
+anthropic~=0.125.0
 wrapt==2.2.2
 # test with the latest version of opentelemetry-api, sdk, semantic conventions, and instrumentation
 

--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/requirements.latest.txt
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/requirements.latest.txt
@@ -37,7 +37,7 @@
 # This variant of the requirements aims to test the system using
 # the newest supported version of external dependencies.
 
-anthropic
+anthropic~=0.51.0
 wrapt==2.2.2
 # test with the latest version of opentelemetry-api, sdk, semantic conventions, and instrumentation
 

--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/test_instrumentor.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/test_instrumentor.py
@@ -64,7 +64,7 @@ def test_instrumentation_dependencies():
 
     assert dependencies is not None
     assert len(dependencies) > 0
-    assert "anthropic >= 0.51.0" in dependencies
+    assert "anthropic >= 0.51.0, < 2" in dependencies
 
 
 def test_instrument_uninstrument_cycle(

--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/test_instrumentor.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/test_instrumentor.py
@@ -64,7 +64,7 @@ def test_instrumentation_dependencies():
 
     assert dependencies is not None
     assert len(dependencies) > 0
-    assert "anthropic >= 0.51.0, < 2" in dependencies
+    assert "anthropic >= 0.51.0, < 1" in dependencies
 
 
 def test_instrument_uninstrument_cycle(

--- a/instrumentation/opentelemetry-instrumentation-genai-claude-agent-sdk/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-genai-claude-agent-sdk/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-instruments = ["claude-agent-sdk >= 0.1.14"]
+instruments = ["claude-agent-sdk >= 0.1.14, < 1"]
 
 [project.entry-points.opentelemetry_instrumentor]
 claude-agent-sdk = "opentelemetry.instrumentation.genai.claude_agent_sdk:ClaudeAgentSDKInstrumentor"

--- a/instrumentation/opentelemetry-instrumentation-genai-claude-agent-sdk/src/opentelemetry/instrumentation/genai/claude_agent_sdk/package.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-claude-agent-sdk/src/opentelemetry/instrumentation/genai/claude_agent_sdk/package.py
@@ -1,4 +1,4 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-_instruments = ("claude-agent-sdk >= 0.1.14",)
+_instruments = ("claude-agent-sdk >= 0.1.14, < 1",)

--- a/instrumentation/opentelemetry-instrumentation-genai-claude-agent-sdk/tests/requirements.latest.txt
+++ b/instrumentation/opentelemetry-instrumentation-genai-claude-agent-sdk/tests/requirements.latest.txt
@@ -37,7 +37,7 @@
 # This variant of the requirements aims to test the system using
 # the newest supported version of external dependencies.
 
-claude-agent-sdk
+claude-agent-sdk~=0.2.0
 wrapt==2.2.2
 # test with the latest version of opentelemetry-api, sdk, semantic conventions, and instrumentation
 

--- a/instrumentation/opentelemetry-instrumentation-genai-claude-agent-sdk/tests/test_instrumentor.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-claude-agent-sdk/tests/test_instrumentor.py
@@ -22,7 +22,7 @@ def test_instrumentation_dependencies():
 
     assert dependencies is not None
     assert len(dependencies) > 0
-    assert "claude-agent-sdk >= 0.1.14" in dependencies
+    assert "claude-agent-sdk >= 0.1.14, < 1" in dependencies
 
 
 def test_instrument_uninstrument_cycle(

--- a/instrumentation/opentelemetry-instrumentation-genai-crewai/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-genai-crewai/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
 
 [project.optional-dependencies]
 instruments = [
-  "crewai >= 1.10.1",
+  "crewai >= 1.10.1, < 2",
 ]
 
 [project.entry-points.opentelemetry_instrumentor]

--- a/instrumentation/opentelemetry-instrumentation-genai-crewai/src/opentelemetry/instrumentation/genai/crewai/package.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-crewai/src/opentelemetry/instrumentation/genai/crewai/package.py
@@ -1,4 +1,4 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-_instruments = ("crewai >= 1.10.1",)
+_instruments = ("crewai >= 1.10.1, < 2",)

--- a/instrumentation/opentelemetry-instrumentation-genai-crewai/tests/requirements.latest.txt
+++ b/instrumentation/opentelemetry-instrumentation-genai-crewai/tests/requirements.latest.txt
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Exercise the latest supported CrewAI release with workspace instrumentation.
-crewai
+crewai~=1.15.0
 
 -e util/opentelemetry-util-genai
 -e instrumentation/opentelemetry-instrumentation-genai-crewai

--- a/instrumentation/opentelemetry-instrumentation-genai-crewai/tests/test_instrumentor.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-crewai/tests/test_instrumentor.py
@@ -11,7 +11,7 @@ from opentelemetry.sdk.trace import TracerProvider
 
 def test_instrumentation_dependencies() -> None:
     assert CrewAIInstrumentor().instrumentation_dependencies() == (
-        "crewai >= 1.10.1",
+        "crewai >= 1.10.1, < 2",
     )
 
 

--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
 
 [project.optional-dependencies]
 instruments = [
-  "langchain >= 0.3.21",
+  "langchain >= 0.3.21, < 1",
 ]
 
 [project.entry-points.opentelemetry_instrumentor]

--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
 
 [project.optional-dependencies]
 instruments = [
-  "langchain >= 0.3.21, < 1",
+  "langchain >= 0.3.21, < 2",
 ]
 
 [project.entry-points.opentelemetry_instrumentor]

--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/src/opentelemetry/instrumentation/genai/langchain/package.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/src/opentelemetry/instrumentation/genai/langchain/package.py
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-_instruments = ("langchain >= 0.3.21, < 1",)
+_instruments = ("langchain >= 0.3.21, < 2",)

--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/src/opentelemetry/instrumentation/genai/langchain/package.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/src/opentelemetry/instrumentation/genai/langchain/package.py
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-_instruments = ("langchain >= 0.3.21",)
+_instruments = ("langchain >= 0.3.21, < 1",)

--- a/instrumentation/opentelemetry-instrumentation-genai-llama-index/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-genai-llama-index/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-instruments = ["llama-index-core >= 0.14.19"]
+instruments = ["llama-index-core >= 0.14.19, < 1"]
 
 [project.entry-points.opentelemetry_instrumentor]
 llama_index = "opentelemetry.instrumentation.genai.llama_index:LlamaIndexInstrumentor"

--- a/instrumentation/opentelemetry-instrumentation-genai-llama-index/src/opentelemetry/instrumentation/genai/llama_index/package.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-llama-index/src/opentelemetry/instrumentation/genai/llama_index/package.py
@@ -1,4 +1,4 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-_instruments = ("llama-index-core >= 0.14.19",)
+_instruments = ("llama-index-core >= 0.14.19, < 1",)

--- a/instrumentation/opentelemetry-instrumentation-genai-llama-index/tests/requirements.latest.txt
+++ b/instrumentation/opentelemetry-instrumentation-genai-llama-index/tests/requirements.latest.txt
@@ -37,7 +37,7 @@
 # This variant of the requirements aims to test the system using
 # the newest supported version of external dependencies.
 
-llama-index-core
+llama-index-core~=0.14.0
 wrapt==2.2.2
 # test with the latest version of opentelemetry-api, sdk, semantic conventions, and instrumentation
 

--- a/instrumentation/opentelemetry-instrumentation-genai-openai-agents/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-genai-openai-agents/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
 
 [project.optional-dependencies]
 instruments = [
-  "openai-agents >= 0.3.3",
+  "openai-agents >= 0.3.3, < 1",
 ]
 
 [project.entry-points.opentelemetry_instrumentor]

--- a/instrumentation/opentelemetry-instrumentation-genai-openai-agents/src/opentelemetry/instrumentation/genai/openai_agents/package.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-openai-agents/src/opentelemetry/instrumentation/genai/openai_agents/package.py
@@ -1,5 +1,5 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-_instruments = ("openai-agents >= 0.3.3",)
+_instruments = ("openai-agents >= 0.3.3, < 1",)
 _supports_metrics = False

--- a/instrumentation/opentelemetry-instrumentation-genai-qwen-agent/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-genai-qwen-agent/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-instruments = ["qwen-agent >= 0.0.20"]
+instruments = ["qwen-agent >= 0.0.20, < 1"]
 
 [project.entry-points.opentelemetry_instrumentor]
 qwen-agent = "opentelemetry.instrumentation.genai.qwen_agent:QwenAgentInstrumentor"

--- a/instrumentation/opentelemetry-instrumentation-genai-qwen-agent/src/opentelemetry/instrumentation/genai/qwen_agent/package.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-qwen-agent/src/opentelemetry/instrumentation/genai/qwen_agent/package.py
@@ -1,4 +1,4 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-_instruments = ("qwen-agent >= 0.0.20",)
+_instruments = ("qwen-agent >= 0.0.20, < 1",)

--- a/instrumentation/opentelemetry-instrumentation-genai-qwen-agent/tests/test_instrumentor.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-qwen-agent/tests/test_instrumentor.py
@@ -43,7 +43,7 @@ def _run_agent_once():
 def test_instrumentation_dependencies():
     instrumentor = QwenAgentInstrumentor()
     dependencies = instrumentor.instrumentation_dependencies()
-    assert dependencies == ("qwen-agent >= 0.0.20",)
+    assert dependencies == ("qwen-agent >= 0.0.20, < 1",)
 
 
 def test_uninstrument_stops_span_creation(

--- a/instrumentation/opentelemetry-instrumentation-genai-smolagents/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-genai-smolagents/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-instruments = ["smolagents >= 1.24.0"]
+instruments = ["smolagents >= 1.24.0, < 2"]
 
 [project.entry-points.opentelemetry_instrumentor]
 smolagents = "opentelemetry.instrumentation.genai.smolagents:SmolagentsInstrumentor"

--- a/instrumentation/opentelemetry-instrumentation-genai-smolagents/src/opentelemetry/instrumentation/genai/smolagents/package.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-smolagents/src/opentelemetry/instrumentation/genai/smolagents/package.py
@@ -1,6 +1,6 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-_instruments = ("smolagents >= 1.24.0",)
+_instruments = ("smolagents >= 1.24.0, < 2",)
 
 _supports_metrics = True

--- a/instrumentation/opentelemetry-instrumentation-genai-smolagents/tests/requirements.latest.txt
+++ b/instrumentation/opentelemetry-instrumentation-genai-smolagents/tests/requirements.latest.txt
@@ -28,7 +28,7 @@
 
 # The instrumented model classes run inference in this process and the tests stub
 # their runtimes, so no model backend extra is installed.
-smolagents
+smolagents~=1.26.0
 wrapt>=2.2.2
 
 -e util/opentelemetry-util-genai

--- a/instrumentation/opentelemetry-instrumentation-genai-smolagents/tests/test_instrumentor.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-smolagents/tests/test_instrumentor.py
@@ -45,7 +45,7 @@ def test_entrypoint_loads_instrumentor() -> None:
 
 def test_instrumentation_dependencies() -> None:
     dependencies = SmolagentsInstrumentor().instrumentation_dependencies()
-    assert "smolagents >= 1.24.0" in dependencies
+    assert "smolagents >= 1.24.0, < 2" in dependencies
 
 
 def test_instrument_uninstrument_restores_originals(

--- a/scripts/check_deps.py
+++ b/scripts/check_deps.py
@@ -175,14 +175,14 @@ def check_instruments_match(pkg_dir: Path, pyproject: dict) -> list[str]:
             f"does not match pyproject.toml instruments extra ({pyproject_instruments_raw})."
         )
 
-    for req in pyproject_reqs:
+    for req in sorted(pyproject_reqs, key=lambda r: str(r)):
         if not has_lower_bound(req):
             errors.append(
                 f"{pkg_dir.name}: requirement '{req}' in pyproject.toml instruments extra is missing a lower bound (e.g. '>= x.y.z')."
             )
         if not has_upper_bound(req):
             errors.append(
-                f"{pkg_dir.name}: requirement '{req}' in pyproject.toml instruments extra is missing an upper bound (e.g. '< (x+1)')."
+                f"{pkg_dir.name}: requirement '{req}' in pyproject.toml instruments extra is missing an upper bound (e.g. '< 2')."
             )
 
     return errors

--- a/scripts/check_deps.py
+++ b/scripts/check_deps.py
@@ -4,7 +4,13 @@
 
 """Guard dependency invariants across packages.
 
-1. Oldest dependency invariant:
+1. Package runtime dependency specifier invariant:
+   Instrumentation packages declare their target library dependencies in [project.optional-dependencies]
+   `instruments` in pyproject.toml, and expose them at runtime via `_instruments` in `package.py`.
+   These two must match, and each dependency must declare both lower and upper bounds (e.g., `>= x.y.z, < (x+1)`)
+   to ensure version compatibility and prevent unbounded dependencies.
+
+2. Oldest dependency invariant:
    The oldest tox envs install the lowest versions of each package's *declared* deps straight from
    pyproject.toml via ``UV_RESOLUTION=lowest-direct`` (see AGENTS.md). pyproject.toml is therefore the
    single source of truth for those floors and running the env is what validates them. This script
@@ -14,11 +20,10 @@
    - Missing coverage: a package with an oldest tox factor (a tests/requirements.latest.txt) but no
      tests/requirements.oldest.txt at all, so its declared floors are never exercised.
 
-2. Package runtime dependency specifier invariant:
-   Instrumentation packages declare their target library dependencies in [project.optional-dependencies]
-   `instruments` in pyproject.toml, and expose them at runtime via `_instruments` in `package.py`.
-   These two must match, and each dependency must declare both lower and upper bounds (e.g., `>= x.y.z, < (x+1)`)
-   to ensure version compatibility and prevent unbounded dependencies.
+3. Latest dependency pinning invariant:
+   Target library dependencies in tests/requirements.latest.txt must have upper bounds or pins
+   (e.g., `~= major.minor` or `== major.minor.patch`) to prevent newly released major versions from
+   breaking test runs unexpectedly.
 """
 
 from __future__ import annotations
@@ -48,21 +53,28 @@ def declared_dep_names(pyproject: dict) -> set[str]:
     return names
 
 
-def pinned_names(oldest_req_path: Path) -> set[str]:
-    """Canonical names of every pinned requirement in an oldest requirements file.
-
-    Skips option lines (-e/-r/-c/--flag) and anything that isn't a parseable requirement.
-    """
-    names: set[str] = set()
-    for raw in oldest_req_path.read_text(encoding="utf-8").splitlines():
+def parse_requirements_file(path: Path) -> list[Requirement]:
+    """Extract valid Requirements from a requirements file, skipping options and comments."""
+    reqs: list[Requirement] = []
+    for raw in path.read_text(encoding="utf-8").splitlines():
         line = raw.split("#", 1)[0].strip()
         if not line or line.startswith("-"):
             continue
         try:
-            names.add(canonicalize_name(Requirement(line).name))
+            reqs.append(Requirement(line))
         except Exception:
             continue
-    return names
+    return reqs
+
+
+def has_lower_bound(req: Requirement) -> bool:
+    """Check if requirement has a lower bound (>=, >, ~=, ==)."""
+    return any(s.operator in (">=", ">", "~=", "==") for s in req.specifier)
+
+
+def has_upper_bound(req: Requirement) -> bool:
+    """Check if requirement has an upper bound (<, <=, ~=, ==)."""
+    return any(s.operator in ("<", "<=", "~=", "==") for s in req.specifier)
 
 
 def extract_instruments_from_package_py(
@@ -164,19 +176,72 @@ def check_instruments_match(pkg_dir: Path, pyproject: dict) -> list[str]:
         )
 
     for req in pyproject_reqs:
-        has_lower = any(
-            s.operator in (">=", ">", "~=", "==") for s in req.specifier
-        )
-        has_upper = any(
-            s.operator in ("<", "<=", "~=", "==") for s in req.specifier
-        )
-        if not has_lower:
+        if not has_lower_bound(req):
             errors.append(
                 f"{pkg_dir.name}: requirement '{req}' in pyproject.toml instruments extra is missing a lower bound (e.g. '>= x.y.z')."
             )
-        if not has_upper:
+        if not has_upper_bound(req):
             errors.append(
                 f"{pkg_dir.name}: requirement '{req}' in pyproject.toml instruments extra is missing an upper bound (e.g. '< (x+1)')."
+            )
+
+    return errors
+
+
+def check_oldest_requirements(pkg_dir: Path, pyproject: dict) -> list[str]:
+    """Check oldest requirements coverage and redundancy."""
+    errors: list[str] = []
+    oldest = pkg_dir / "tests" / "requirements.oldest.txt"
+    latest = pkg_dir / "tests" / "requirements.latest.txt"
+
+    if not oldest.exists():
+        if latest.exists():
+            errors.append(
+                f"{pkg_dir.name}: has tests/requirements.latest.txt but no "
+                f"tests/requirements.oldest.txt - declared floors are never tested."
+            )
+        return errors
+
+    pinned = {
+        canonicalize_name(r.name) for r in parse_requirements_file(oldest)
+    }
+    redundant = declared_dep_names(pyproject) & pinned
+    for name in sorted(redundant):
+        errors.append(
+            f"{pkg_dir.name}: '{name}' is declared in pyproject.toml and also pinned in "
+            f"tests/requirements.oldest.txt. Remove the pin - the oldest env derives it from "
+            f"the pyproject.toml floor via UV_RESOLUTION=lowest-direct."
+        )
+
+    return errors
+
+
+def check_latest_requirements(pkg_dir: Path, pyproject: dict) -> list[str]:
+    """Verify that target dependencies in tests/requirements.latest.txt have upper bounds / pins."""
+    errors: list[str] = []
+    latest_path = pkg_dir / "tests" / "requirements.latest.txt"
+    if not latest_path.exists():
+        return errors
+
+    instruments_raw = (
+        pyproject.get("project", {})
+        .get("optional-dependencies", {})
+        .get("instruments", [])
+    )
+    if not instruments_raw:
+        return errors
+
+    instrumented_names = {
+        canonicalize_name(Requirement(r).name) for r in instruments_raw
+    }
+
+    for req in parse_requirements_file(latest_path):
+        if canonicalize_name(
+            req.name
+        ) in instrumented_names and not has_upper_bound(req):
+            errors.append(
+                f"{pkg_dir.name}: target dependency '{req}' in tests/requirements.latest.txt "
+                f"is missing an upper bound or pin (use '~= major.minor' or '== major.minor.patch')."
             )
 
     return errors
@@ -192,31 +257,16 @@ def main() -> int:
 
     for pyproject_path in pyprojects:
         pkg_dir = pyproject_path.parent
-        oldest = pkg_dir / "tests" / "requirements.oldest.txt"
-        latest = pkg_dir / "tests" / "requirements.latest.txt"
-
         pyproject = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
 
         # Check 1: instruments extra in pyproject.toml matches _instruments in package.py
         errors.extend(check_instruments_match(pkg_dir, pyproject))
 
         # Check 2: oldest dependency coverage and redundancy
-        if not oldest.exists():
-            # Only a gap if the package has an oldest tox factor, signalled by a latest file.
-            if latest.exists():
-                errors.append(
-                    f"{pkg_dir.name}: has tests/requirements.latest.txt but no "
-                    f"tests/requirements.oldest.txt - declared floors are never tested."
-                )
-            continue
+        errors.extend(check_oldest_requirements(pkg_dir, pyproject))
 
-        redundant = declared_dep_names(pyproject) & pinned_names(oldest)
-        for name in sorted(redundant):
-            errors.append(
-                f"{pkg_dir.name}: '{name}' is declared in pyproject.toml and also pinned in "
-                f"tests/requirements.oldest.txt. Remove the pin - the oldest env derives it from "
-                f"the pyproject.toml floor via UV_RESOLUTION=lowest-direct."
-            )
+        # Check 3: target dependencies in requirements.latest.txt are pinned / upper-bounded
+        errors.extend(check_latest_requirements(pkg_dir, pyproject))
 
     if errors:
         print("Dependency check failed:\n", file=sys.stderr)
@@ -224,9 +274,7 @@ def main() -> int:
             print(f"  [ERROR] {err}", file=sys.stderr)
         return 1
 
-    print(
-        "Dependency checks passed: package.py matches pyproject.toml, no declared deps re-pinned, no missing coverage."
-    )
+    print("Dependency checks passed.")
     return 0
 
 

--- a/scripts/check_deps.py
+++ b/scripts/check_deps.py
@@ -17,7 +17,8 @@
 2. Package runtime dependency specifier invariant:
    Instrumentation packages declare their target library dependencies in [project.optional-dependencies]
    `instruments` in pyproject.toml, and expose them at runtime via `_instruments` in `package.py`.
-   These two must match to ensure runtime instrumentor compatibility checks and package metadata stay in sync.
+   These two must match, and each dependency must declare both lower and upper bounds (e.g., `>= x.y.z, < (x+1)`)
+   to ensure version compatibility and prevent unbounded dependencies.
 """
 
 from __future__ import annotations
@@ -161,6 +162,22 @@ def check_instruments_match(pkg_dir: Path, pyproject: dict) -> list[str]:
             f"{pkg_dir.name}: package.py _instruments ({list(pkg_instruments_raw)}) "
             f"does not match pyproject.toml instruments extra ({pyproject_instruments_raw})."
         )
+
+    for req in pyproject_reqs:
+        has_lower = any(
+            s.operator in (">=", ">", "~=", "==") for s in req.specifier
+        )
+        has_upper = any(
+            s.operator in ("<", "<=", "~=", "==") for s in req.specifier
+        )
+        if not has_lower:
+            errors.append(
+                f"{pkg_dir.name}: requirement '{req}' in pyproject.toml instruments extra is missing a lower bound (e.g. '>= x.y.z')."
+            )
+        if not has_upper:
+            errors.append(
+                f"{pkg_dir.name}: requirement '{req}' in pyproject.toml instruments extra is missing an upper bound (e.g. '< (x+1)')."
+            )
 
     return errors
 

--- a/uv.lock
+++ b/uv.lock
@@ -3274,7 +3274,7 @@ instruments = [
 
 [package.metadata]
 requires-dist = [
-    { name = "anthropic", marker = "extra == 'instruments'", specifier = ">=0.51.0,<2" },
+    { name = "anthropic", marker = "extra == 'instruments'", specifier = ">=0.51.0,<1" },
     { name = "opentelemetry-api", specifier = "~=1.43" },
     { name = "opentelemetry-instrumentation", specifier = ">=0.64b0,<1" },
     { name = "opentelemetry-semantic-conventions", specifier = ">=0.64b0,<1" },
@@ -3347,7 +3347,7 @@ instruments = [
 
 [package.metadata]
 requires-dist = [
-    { name = "langchain", marker = "extra == 'instruments'", specifier = ">=0.3.21,<1" },
+    { name = "langchain", marker = "extra == 'instruments'", specifier = ">=0.3.21,<2" },
     { name = "opentelemetry-instrumentation", specifier = ">=0.64b0,<1" },
     { name = "opentelemetry-util-genai", editable = "util/opentelemetry-util-genai" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -327,11 +327,11 @@ wheels = [
 
 [[package]]
 name = "async-timeout"
-version = "5.0.1"
+version = "4.0.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a5/ae/136395dfbfe00dfc94da3f3e136d0b13f394cba8f4841120e34226265780/async_timeout-5.0.1.tar.gz", hash = "sha256:d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3", size = 9274, upload-time = "2024-11-06T16:41:39.6Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/87/d6/21b30a550dafea84b1b8eee21b5e23fa16d010ae006011221f33dcd8d7f8/async-timeout-4.0.3.tar.gz", hash = "sha256:4640d96be84d82d02ed59ea2b7105a0f7b33abe8703703cd0ab0bf87c427522f", size = 8345, upload-time = "2023-08-10T16:35:56.907Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fe/ba/e2081de779ca30d473f21f5b30e0e737c438205440784c7dfc81efc2b029/async_timeout-5.0.1-py3-none-any.whl", hash = "sha256:39e3809566ff85354557ec2398b55e096c8364bacac9405a7a1fa429e77fe76c", size = 6233, upload-time = "2024-11-06T16:41:37.9Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/fa/e01228c2938de91d47b307831c62ab9e4001e747789d0b05baf779a6488c/async_timeout-4.0.3-py3-none-any.whl", hash = "sha256:7405140ff1230c310e51dc27b3145b9092d659ce68ff733fb0cefe3ee42be028", size = 5721, upload-time = "2023-08-10T16:35:55.203Z" },
 ]
 
 [[package]]
@@ -2142,25 +2142,29 @@ wheels = [
 
 [[package]]
 name = "langchain"
-version = "1.3.14"
+version = "0.3.30"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "async-timeout", marker = "python_full_version < '3.11'" },
     { name = "langchain-core" },
-    { name = "langgraph" },
+    { name = "langchain-text-splitters" },
+    { name = "langsmith" },
     { name = "pydantic" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "sqlalchemy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/29/68/a6dbad9c22df4087a0f9e79ddd46226c442b30128bfeee538d5889492a73/langchain-1.3.14.tar.gz", hash = "sha256:1b6696c72ba3bbbce54d745e0180742c9f6ece8bbc59ed5a46c3e20b9a435929", size = 645181, upload-time = "2026-07-16T13:28:18.29Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/14/f8/9d262e12d95ac940948847e0ed844eff430fc0660f73a704367c7c47a3ce/langchain-0.3.30.tar.gz", hash = "sha256:06599ec90fb550e0118b0ceab737667d2c0891fcc62ffce2058d21c945844448", size = 10243710, upload-time = "2026-05-07T15:48:12.796Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a9/ec/0f942e78a621f8e3162ff1ed24284f469aaf51fb4607ee5831c626f2b2bc/langchain-1.3.14-py3-none-any.whl", hash = "sha256:4d10dbe91005952cddd56d0dc77aa108964da6bae90ab20063653957e901f782", size = 139560, upload-time = "2026-07-16T13:28:16.498Z" },
+    { url = "https://files.pythonhosted.org/packages/da/54/c0775c29bf9ae27c8cbf8484ad600edd2e787a0eacf3a374cb6561613de9/langchain-0.3.30-py3-none-any.whl", hash = "sha256:37e6fcce92faf70cc7bac23739d13d6c3b9a3282da4dbcc06cb7e78330ed406a", size = 1025603, upload-time = "2026-05-07T15:48:10.607Z" },
 ]
 
 [[package]]
 name = "langchain-core"
-version = "1.5.0"
+version = "0.3.86"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonpatch" },
-    { name = "langchain-protocol" },
     { name = "langsmith" },
     { name = "packaging" },
     { name = "pydantic" },
@@ -2169,80 +2173,21 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uuid-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5c/05/986c4bb148285791eb59994e0b28947bed96cac7f24467079e4274952a37/langchain_core-1.5.0.tar.gz", hash = "sha256:e1fa09d55b354192c8f60dade06a55bd6add2318c822a684555b8d4a30a16143", size = 967401, upload-time = "2026-07-21T03:37:26.48Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/8d/d54586b8f65c6fc209db93916ff9e919e1cc14bad8fe66880ea4d7ea9d6c/langchain_core-0.3.86.tar.gz", hash = "sha256:671cbc96a325fe47f7dbab421236ada2d437bc4bfad0038102264885d0b462e2", size = 603154, upload-time = "2026-05-07T16:48:08.14Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/29/56/5ef7ba14bac95b0344da18c6e8ec108dce0baf5fc054d1117702f92af29d/langchain_core-1.5.0-py3-none-any.whl", hash = "sha256:f122efee35446632b38687119fca33711abbf3b6b555e31156762298fbe78a65", size = 558510, upload-time = "2026-07-21T03:37:24.423Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/93/ba19ca54701c6118e68f8785949b6c0eab1df3a5cfa5310508cc86877994/langchain_core-0.3.86-py3-none-any.whl", hash = "sha256:7d2a1c50d2d2a139dbc6465cd339f32d14aa43db5ac9bd232e5b567a238709e8", size = 461306, upload-time = "2026-05-07T16:48:06.283Z" },
 ]
 
 [[package]]
-name = "langchain-protocol"
-version = "0.0.18"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/d2/59/b5959aea96faa9146e2e49a7a22882b3528c62efafe9a6a95beab30c2305/langchain_protocol-0.0.18.tar.gz", hash = "sha256:ec3e11782f1ed0c9db38e5a9ed01b0e7a0d3fba406faa8aef6594b73c56a63e6", size = 6150, upload-time = "2026-06-18T17:08:26.959Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/99/2e/d82db9eec13ad0f72e7aaad5c4bc730ab111934fdc83c85523206eb9b0a0/langchain_protocol-0.0.18-py3-none-any.whl", hash = "sha256:70b53a86fbf9cedc863555effe44da192ab02d556ddbf2cf95b8873adcf41b5a", size = 7221, upload-time = "2026-06-18T17:08:25.996Z" },
-]
-
-[[package]]
-name = "langgraph"
-version = "1.2.9"
+name = "langchain-text-splitters"
+version = "0.3.11"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
-    { name = "langgraph-checkpoint" },
-    { name = "langgraph-prebuilt" },
-    { name = "langgraph-sdk" },
-    { name = "pydantic" },
-    { name = "xxhash" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/41/4b/0d1130e26b41a99dcc88353bbe7162a1f255c4db746bd94024268e6af27b/langgraph-1.2.9.tar.gz", hash = "sha256:385f87bc1802c35af7e0aa479278ecba8582d103515eb48256cb2ddcd42d0bd4", size = 722869, upload-time = "2026-07-10T01:30:14.985Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/11/43/dcda8fd25f0b19cb2835f2f6bb67f26ad58634f04ac2d8eae00526b0fa55/langchain_text_splitters-0.3.11.tar.gz", hash = "sha256:7a50a04ada9a133bbabb80731df7f6ddac51bc9f1b9cab7fa09304d71d38a6cc", size = 46458, upload-time = "2025-08-31T23:02:58.316Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/41/16/0b8dc48823f1326f3e0c8012a3c07a40da6f194299e2ec080df236287baf/langgraph-1.2.9-py3-none-any.whl", hash = "sha256:c2d98ad94333937922ba04148641c1da2bfe45b5b8e55d7b6dcb0bb2df809e76", size = 247473, upload-time = "2026-07-10T01:30:13.733Z" },
-]
-
-[[package]]
-name = "langgraph-checkpoint"
-version = "4.1.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "langchain-core" },
-    { name = "ormsgpack" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/83/47/886af6f886f0bff2273164a45f008694e48a96ff3cd25ff0228f2aa9480e/langgraph_checkpoint-4.1.1.tar.gz", hash = "sha256:6c2bdb530c91f91d7d9c1bd100925d0fc4f498d418c17f3587d1526279482a25", size = 184020, upload-time = "2026-05-22T16:57:38.503Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/bd/b4/71425e3e38be92611300b9cc5e46a5bf98ab23f5ea8a75b73d02a2f1413c/langgraph_checkpoint-4.1.1-py3-none-any.whl", hash = "sha256:25d29144b082827218e7bc3f1e9b0566a4bb007895cd6cc26f66a8428739f56e", size = 56212, upload-time = "2026-05-22T16:57:37.203Z" },
-]
-
-[[package]]
-name = "langgraph-prebuilt"
-version = "1.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "langchain-core" },
-    { name = "langgraph-checkpoint" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/29/66/ed9b93f56bc17ef22d551892f0ac2b225a97fe0fcf23a511b857f70d590b/langgraph_prebuilt-1.1.0.tar.gz", hash = "sha256:3c579cf6eed2d17f9c157c2d0fcaddcd8688524e7022d3b22b37a3bf4589d528", size = 178833, upload-time = "2026-05-12T03:37:49.332Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/43/3fe1a700b8490ed02679cdbbc8c915eb23a092faf496c9c1118abcd10be3/langgraph_prebuilt-1.1.0-py3-none-any.whl", hash = "sha256:51e311747d755b751d5c6b39b0c1446124d3a7643d2515017e6714b323508fc9", size = 41043, upload-time = "2026-05-12T03:37:48.007Z" },
-]
-
-[[package]]
-name = "langgraph-sdk"
-version = "0.4.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "httpx" },
-    { name = "langchain-core" },
-    { name = "langchain-protocol" },
-    { name = "orjson" },
-    { name = "websockets" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b4/2b/bd8ac26d4e97f6df88ef05ce5b6a38945a3903e1025d926f4752aa88aa97/langgraph_sdk-0.4.2.tar.gz", hash = "sha256:b88f0f5f6328ac0680d6790614a905b2bcfa257f2276dba4e38f0e86db0aa738", size = 348327, upload-time = "2026-06-01T17:51:19.856Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/05/aac507337cceae773c2cc9ab91eb6301963af7aeeb55b4217a00e15aff17/langgraph_sdk-0.4.2-py3-none-any.whl", hash = "sha256:75fa5096c1177ce39c847096a8fe3745ffd480ddb412995f836e9f5f884c43dd", size = 160521, upload-time = "2026-06-01T17:51:18.849Z" },
+    { url = "https://files.pythonhosted.org/packages/58/0d/41a51b40d24ff0384ec4f7ab8dd3dcea8353c05c973836b5e289f1465d4f/langchain_text_splitters-0.3.11-py3-none-any.whl", hash = "sha256:cf079131166a487f1372c8ab5d0bfaa6c0a4291733d9c43a34a16ac9bcd6a393", size = 33845, upload-time = "2025-08-31T23:02:57.195Z" },
 ]
 
 [[package]]
@@ -3304,7 +3249,7 @@ instruments = [
 
 [package.metadata]
 requires-dist = [
-    { name = "agno", marker = "extra == 'instruments'", specifier = ">=2.0.0" },
+    { name = "agno", marker = "extra == 'instruments'", specifier = ">=2.0.0,<3" },
     { name = "opentelemetry-api", specifier = "~=1.43" },
     { name = "opentelemetry-instrumentation", specifier = ">=0.64b0,<1" },
     { name = "opentelemetry-semantic-conventions", specifier = ">=0.64b0,<1" },
@@ -3329,7 +3274,7 @@ instruments = [
 
 [package.metadata]
 requires-dist = [
-    { name = "anthropic", marker = "extra == 'instruments'", specifier = ">=0.51.0" },
+    { name = "anthropic", marker = "extra == 'instruments'", specifier = ">=0.51.0,<2" },
     { name = "opentelemetry-api", specifier = "~=1.43" },
     { name = "opentelemetry-instrumentation", specifier = ">=0.64b0,<1" },
     { name = "opentelemetry-semantic-conventions", specifier = ">=0.64b0,<1" },
@@ -3354,7 +3299,7 @@ instruments = [
 
 [package.metadata]
 requires-dist = [
-    { name = "claude-agent-sdk", marker = "extra == 'instruments'", specifier = ">=0.1.14" },
+    { name = "claude-agent-sdk", marker = "extra == 'instruments'", specifier = ">=0.1.14,<1" },
     { name = "opentelemetry-api", specifier = "~=1.43" },
     { name = "opentelemetry-instrumentation", specifier = ">=0.64b0,<1" },
     { name = "opentelemetry-semantic-conventions", specifier = ">=0.64b0,<1" },
@@ -3379,7 +3324,7 @@ instruments = [
 
 [package.metadata]
 requires-dist = [
-    { name = "crewai", marker = "extra == 'instruments'", specifier = ">=1.10.1" },
+    { name = "crewai", marker = "extra == 'instruments'", specifier = ">=1.10.1,<2" },
     { name = "opentelemetry-api", specifier = "~=1.43" },
     { name = "opentelemetry-instrumentation", specifier = ">=0.64b0,<1" },
     { name = "opentelemetry-semantic-conventions", specifier = ">=0.64b0,<1" },
@@ -3402,7 +3347,7 @@ instruments = [
 
 [package.metadata]
 requires-dist = [
-    { name = "langchain", marker = "extra == 'instruments'", specifier = ">=0.3.21" },
+    { name = "langchain", marker = "extra == 'instruments'", specifier = ">=0.3.21,<1" },
     { name = "opentelemetry-instrumentation", specifier = ">=0.64b0,<1" },
     { name = "opentelemetry-util-genai", editable = "util/opentelemetry-util-genai" },
 ]
@@ -3425,7 +3370,7 @@ instruments = [
 
 [package.metadata]
 requires-dist = [
-    { name = "llama-index-core", marker = "extra == 'instruments'", specifier = ">=0.14.19" },
+    { name = "llama-index-core", marker = "extra == 'instruments'", specifier = ">=0.14.19,<1" },
     { name = "opentelemetry-api", specifier = "~=1.43" },
     { name = "opentelemetry-instrumentation", specifier = ">=0.64b0,<1" },
     { name = "opentelemetry-semantic-conventions", specifier = ">=0.64b0,<1" },
@@ -3475,7 +3420,7 @@ instruments = [
 
 [package.metadata]
 requires-dist = [
-    { name = "openai-agents", marker = "extra == 'instruments'", specifier = ">=0.3.3" },
+    { name = "openai-agents", marker = "extra == 'instruments'", specifier = ">=0.3.3,<1" },
     { name = "opentelemetry-api", specifier = "~=1.43" },
     { name = "opentelemetry-instrumentation", specifier = ">=0.64b0,<1" },
     { name = "opentelemetry-semantic-conventions", specifier = ">=0.64b0,<1" },
@@ -3504,7 +3449,7 @@ requires-dist = [
     { name = "opentelemetry-instrumentation", specifier = ">=0.64b0,<1" },
     { name = "opentelemetry-semantic-conventions", specifier = ">=0.64b0,<1" },
     { name = "opentelemetry-util-genai", editable = "util/opentelemetry-util-genai" },
-    { name = "qwen-agent", marker = "extra == 'instruments'", specifier = ">=0.0.20" },
+    { name = "qwen-agent", marker = "extra == 'instruments'", specifier = ">=0.0.20,<1" },
 ]
 provides-extras = ["instruments"]
 
@@ -3529,7 +3474,7 @@ requires-dist = [
     { name = "opentelemetry-instrumentation", specifier = ">=0.64b0,<1" },
     { name = "opentelemetry-semantic-conventions", specifier = ">=0.64b0,<1" },
     { name = "opentelemetry-util-genai", editable = "util/opentelemetry-util-genai" },
-    { name = "smolagents", marker = "extra == 'instruments'", specifier = ">=1.24.0" },
+    { name = "smolagents", marker = "extra == 'instruments'", specifier = ">=1.24.0,<2" },
 ]
 provides-extras = ["instruments"]
 
@@ -3625,10 +3570,8 @@ dependencies = [
 dev = [
     { name = "pre-commit" },
     { name = "towncrier" },
-    { name = "tox", version = "4.23.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "tox", version = "4.48.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "tox-uv", version = "1.19.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "tox-uv", version = "1.33.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "tox" },
+    { name = "tox-uv" },
 ]
 
 [package.metadata]
@@ -3842,62 +3785,6 @@ wheels = [
 ]
 
 [[package]]
-name = "ormsgpack"
-version = "1.12.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/12/0c/f1761e21486942ab9bb6feaebc610fa074f7c5e496e6962dea5873348077/ormsgpack-1.12.2.tar.gz", hash = "sha256:944a2233640273bee67521795a73cf1e959538e0dfb7ac635505010455e53b33", size = 39031, upload-time = "2026-01-18T20:55:28.023Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/93/fa/a91f70829ebccf6387c4946e0a1a109f6ba0d6a28d65f628bedfad94b890/ormsgpack-1.12.2-cp310-cp310-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:c1429217f8f4d7fcb053523bbbac6bed5e981af0b85ba616e6df7cce53c19657", size = 378262, upload-time = "2026-01-18T20:55:22.284Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/62/3698a9a0c487252b5c6a91926e5654e79e665708ea61f67a8bdeceb022bf/ormsgpack-1.12.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5f13034dc6c84a6280c6c33db7ac420253852ea233fc3ee27c8875f8dd651163", size = 203034, upload-time = "2026-01-18T20:55:53.324Z" },
-    { url = "https://files.pythonhosted.org/packages/66/3a/f716f64edc4aec2744e817660b317e2f9bb8de372338a95a96198efa1ac1/ormsgpack-1.12.2-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:59f5da97000c12bc2d50e988bdc8576b21f6ab4e608489879d35b2c07a8ab51a", size = 210538, upload-time = "2026-01-18T20:55:20.097Z" },
-    { url = "https://files.pythonhosted.org/packages/72/30/a436be9ce27d693d4e19fa94900028067133779f09fc45776db3f689c822/ormsgpack-1.12.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9e4459c3f27066beadb2b81ea48a076a417aafffff7df1d3c11c519190ed44f2", size = 212401, upload-time = "2026-01-18T20:55:46.447Z" },
-    { url = "https://files.pythonhosted.org/packages/10/c5/cde98300fd33fee84ca71de4751b19aeeca675f0cf3c0ec4b043f40f3b76/ormsgpack-1.12.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:7a1c460655d7288407ffa09065e322a7231997c0d62ce914bf3a96ad2dc6dedd", size = 387080, upload-time = "2026-01-18T20:56:00.884Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/31/30bf445ef827546747c10889dd254b3d84f92b591300efe4979d792f4c41/ormsgpack-1.12.2-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:458e4568be13d311ef7d8877275e7ccbe06c0e01b39baaac874caaa0f46d826c", size = 482346, upload-time = "2026-01-18T20:55:39.831Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/f5/e1745ddf4fa246c921b5ca253636c4c700ff768d78032f79171289159f6e/ormsgpack-1.12.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8cde5eaa6c6cbc8622db71e4a23de56828e3d876aeb6460ffbcb5b8aff91093b", size = 425178, upload-time = "2026-01-18T20:55:27.106Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/a2/e6532ed7716aed03dede8df2d0d0d4150710c2122647d94b474147ccd891/ormsgpack-1.12.2-cp310-cp310-win_amd64.whl", hash = "sha256:dc7a33be14c347893edbb1ceda89afbf14c467d593a5ee92c11de4f1666b4d4f", size = 117183, upload-time = "2026-01-18T20:55:55.52Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/08/8b68f24b18e69d92238aa8f258218e6dfeacf4381d9d07ab8df303f524a9/ormsgpack-1.12.2-cp311-cp311-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:bd5f4bf04c37888e864f08e740c5a573c4017f6fd6e99fa944c5c935fabf2dd9", size = 378266, upload-time = "2026-01-18T20:55:59.876Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/24/29fc13044ecb7c153523ae0a1972269fcd613650d1fa1a9cec1044c6b666/ormsgpack-1.12.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:34d5b28b3570e9fed9a5a76528fc7230c3c76333bc214798958e58e9b79cc18a", size = 203035, upload-time = "2026-01-18T20:55:30.59Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/c2/00169fb25dd8f9213f5e8a549dfb73e4d592009ebc85fbbcd3e1dcac575b/ormsgpack-1.12.2-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3708693412c28f3538fb5a65da93787b6bbab3484f6bc6e935bfb77a62400ae5", size = 210539, upload-time = "2026-01-18T20:55:48.569Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/33/543627f323ff3c73091f51d6a20db28a1a33531af30873ea90c5ac95a9b5/ormsgpack-1.12.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:43013a3f3e2e902e1d05e72c0f1aeb5bedbb8e09240b51e26792a3c89267e181", size = 212401, upload-time = "2026-01-18T20:56:10.101Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/5d/f70e2c3da414f46186659d24745483757bcc9adccb481a6eb93e2b729301/ormsgpack-1.12.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:7c8b1667a72cbba74f0ae7ecf3105a5e01304620ed14528b2cb4320679d2869b", size = 387082, upload-time = "2026-01-18T20:56:12.047Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/d6/06e8dc920c7903e051f30934d874d4afccc9bb1c09dcaf0bc03a7de4b343/ormsgpack-1.12.2-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:df6961442140193e517303d0b5d7bc2e20e69a879c2d774316125350c4a76b92", size = 482346, upload-time = "2026-01-18T20:56:05.152Z" },
-    { url = "https://files.pythonhosted.org/packages/66/c4/f337ac0905eed9c393ef990c54565cd33644918e0a8031fe48c098c71dbf/ormsgpack-1.12.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:c6a4c34ddef109647c769d69be65fa1de7a6022b02ad45546a69b3216573eb4a", size = 425181, upload-time = "2026-01-18T20:55:37.83Z" },
-    { url = "https://files.pythonhosted.org/packages/78/29/6d5758fabef3babdf4bbbc453738cc7de9cd3334e4c38dd5737e27b85653/ormsgpack-1.12.2-cp311-cp311-win_amd64.whl", hash = "sha256:73670ed0375ecc303858e3613f407628dd1fca18fe6ac57b7b7ce66cc7bb006c", size = 117182, upload-time = "2026-01-18T20:55:31.472Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/57/17a15549233c37e7fd054c48fe9207492e06b026dbd872b826a0b5f833b6/ormsgpack-1.12.2-cp311-cp311-win_arm64.whl", hash = "sha256:c2be829954434e33601ae5da328cccce3266b098927ca7a30246a0baec2ce7bd", size = 111464, upload-time = "2026-01-18T20:55:38.811Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/36/16c4b1921c308a92cef3bf6663226ae283395aa0ff6e154f925c32e91ff5/ormsgpack-1.12.2-cp312-cp312-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:7a29d09b64b9694b588ff2f80e9826bdceb3a2b91523c5beae1fab27d5c940e7", size = 378618, upload-time = "2026-01-18T20:55:50.835Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/68/468de634079615abf66ed13bb5c34ff71da237213f29294363beeeca5306/ormsgpack-1.12.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0b39e629fd2e1c5b2f46f99778450b59454d1f901bc507963168985e79f09c5d", size = 203186, upload-time = "2026-01-18T20:56:11.163Z" },
-    { url = "https://files.pythonhosted.org/packages/73/a9/d756e01961442688b7939bacd87ce13bfad7d26ce24f910f6028178b2cc8/ormsgpack-1.12.2-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:958dcb270d30a7cb633a45ee62b9444433fa571a752d2ca484efdac07480876e", size = 210738, upload-time = "2026-01-18T20:56:09.181Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/ba/795b1036888542c9113269a3f5690ab53dd2258c6fb17676ac4bd44fcf94/ormsgpack-1.12.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58d379d72b6c5e964851c77cfedfb386e474adee4fd39791c2c5d9efb53505cc", size = 212569, upload-time = "2026-01-18T20:56:06.135Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/aa/bff73c57497b9e0cba8837c7e4bcab584b1a6dbc91a5dd5526784a5030c8/ormsgpack-1.12.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8463a3fc5f09832e67bdb0e2fda6d518dc4281b133166146a67f54c08496442e", size = 387166, upload-time = "2026-01-18T20:55:36.738Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/cf/f8283cba44bcb7b14f97b6274d449db276b3a86589bdb363169b51bc12de/ormsgpack-1.12.2-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:eddffb77eff0bad4e67547d67a130604e7e2dfbb7b0cde0796045be4090f35c6", size = 482498, upload-time = "2026-01-18T20:55:29.626Z" },
-    { url = "https://files.pythonhosted.org/packages/05/be/71e37b852d723dfcbe952ad04178c030df60d6b78eba26bfd14c9a40575e/ormsgpack-1.12.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fcd55e5f6ba0dbce624942adf9f152062135f991a0126064889f68eb850de0dd", size = 425518, upload-time = "2026-01-18T20:55:49.556Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/0c/9803aa883d18c7ef197213cd2cbf73ba76472a11fe100fb7dab2884edf48/ormsgpack-1.12.2-cp312-cp312-win_amd64.whl", hash = "sha256:d024b40828f1dde5654faebd0d824f9cc29ad46891f626272dd5bfd7af2333a4", size = 117462, upload-time = "2026-01-18T20:55:47.726Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/9e/029e898298b2cc662f10d7a15652a53e3b525b1e7f07e21fef8536a09bb8/ormsgpack-1.12.2-cp312-cp312-win_arm64.whl", hash = "sha256:da538c542bac7d1c8f3f2a937863dba36f013108ce63e55745941dda4b75dbb6", size = 111559, upload-time = "2026-01-18T20:55:54.273Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/29/bb0eba3288c0449efbb013e9c6f58aea79cf5cb9ee1921f8865f04c1a9d7/ormsgpack-1.12.2-cp313-cp313-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:5ea60cb5f210b1cfbad8c002948d73447508e629ec375acb82910e3efa8ff355", size = 378661, upload-time = "2026-01-18T20:55:57.765Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/31/5efa31346affdac489acade2926989e019e8ca98129658a183e3add7af5e/ormsgpack-1.12.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f3601f19afdbea273ed70b06495e5794606a8b690a568d6c996a90d7255e51c1", size = 203194, upload-time = "2026-01-18T20:56:08.252Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/56/d0087278beef833187e0167f8527235ebe6f6ffc2a143e9de12a98b1ce87/ormsgpack-1.12.2-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:29a9f17a3dac6054c0dce7925e0f4995c727f7c41859adf9b5572180f640d172", size = 210778, upload-time = "2026-01-18T20:55:17.694Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/a2/072343e1413d9443e5a252a8eb591c2d5b1bffbe5e7bfc78c069361b92eb/ormsgpack-1.12.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:39c1bd2092880e413902910388be8715f70b9f15f20779d44e673033a6146f2d", size = 212592, upload-time = "2026-01-18T20:55:32.747Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/8b/a0da3b98a91d41187a63b02dda14267eefc2a74fcb43cc2701066cf1510e/ormsgpack-1.12.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:50b7249244382209877deedeee838aef1542f3d0fc28b8fe71ca9d7e1896a0d7", size = 387164, upload-time = "2026-01-18T20:55:40.853Z" },
-    { url = "https://files.pythonhosted.org/packages/19/bb/6d226bc4cf9fc20d8eb1d976d027a3f7c3491e8f08289a2e76abe96a65f3/ormsgpack-1.12.2-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:5af04800d844451cf102a59c74a841324868d3f1625c296a06cc655c542a6685", size = 482516, upload-time = "2026-01-18T20:55:42.033Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/f1/bb2c7223398543dedb3dbf8bb93aaa737b387de61c5feaad6f908841b782/ormsgpack-1.12.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:cec70477d4371cd524534cd16472d8b9cc187e0e3043a8790545a9a9b296c258", size = 425539, upload-time = "2026-01-18T20:55:24.727Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/e8/0fb45f57a2ada1fed374f7494c8cd55e2f88ccd0ab0a669aa3468716bf5f/ormsgpack-1.12.2-cp313-cp313-win_amd64.whl", hash = "sha256:21f4276caca5c03a818041d637e4019bc84f9d6ca8baa5ea03e5cc8bf56140e9", size = 117459, upload-time = "2026-01-18T20:55:56.876Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/d4/0cfeea1e960d550a131001a7f38a5132c7ae3ebde4c82af1f364ccc5d904/ormsgpack-1.12.2-cp313-cp313-win_arm64.whl", hash = "sha256:baca4b6773d20a82e36d6fd25f341064244f9f86a13dead95dd7d7f996f51709", size = 111577, upload-time = "2026-01-18T20:55:43.605Z" },
-    { url = "https://files.pythonhosted.org/packages/94/16/24d18851334be09c25e87f74307c84950f18c324a4d3c0b41dabdbf19c29/ormsgpack-1.12.2-cp314-cp314-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:bc68dd5915f4acf66ff2010ee47c8906dc1cf07399b16f4089f8c71733f6e36c", size = 378717, upload-time = "2026-01-18T20:55:26.164Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/a2/88b9b56f83adae8032ac6a6fa7f080c65b3baf9b6b64fd3d37bd202991d4/ormsgpack-1.12.2-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:46d084427b4132553940070ad95107266656cb646ea9da4975f85cb1a6676553", size = 203183, upload-time = "2026-01-18T20:55:18.815Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/80/43e4555963bf602e5bdc79cbc8debd8b6d5456c00d2504df9775e74b450b/ormsgpack-1.12.2-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c010da16235806cf1d7bc4c96bf286bfa91c686853395a299b3ddb49499a3e13", size = 210814, upload-time = "2026-01-18T20:55:33.973Z" },
-    { url = "https://files.pythonhosted.org/packages/78/e1/7cfbf28de8bca6efe7e525b329c31277d1b64ce08dcba723971c241a9d60/ormsgpack-1.12.2-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:18867233df592c997154ff942a6503df274b5ac1765215bceba7a231bea2745d", size = 212634, upload-time = "2026-01-18T20:55:28.634Z" },
-    { url = "https://files.pythonhosted.org/packages/95/f8/30ae5716e88d792a4e879debee195653c26ddd3964c968594ddef0a3cc7e/ormsgpack-1.12.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b009049086ddc6b8f80c76b3955df1aa22a5fbd7673c525cd63bf91f23122ede", size = 387139, upload-time = "2026-01-18T20:56:02.013Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/81/aee5b18a3e3a0e52f718b37ab4b8af6fae0d9d6a65103036a90c2a8ffb5d/ormsgpack-1.12.2-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:1dcc17d92b6390d4f18f937cf0b99054824a7815818012ddca925d6e01c2e49e", size = 482578, upload-time = "2026-01-18T20:55:35.117Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/17/71c9ba472d5d45f7546317f467a5fc941929cd68fb32796ca3d13dcbaec2/ormsgpack-1.12.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f04b5e896d510b07c0ad733d7fce2d44b260c5e6c402d272128f8941984e4285", size = 425539, upload-time = "2026-01-18T20:56:04.009Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/a6/ac99cd7fe77e822fed5250ff4b86fa66dd4238937dd178d2299f10b69816/ormsgpack-1.12.2-cp314-cp314-win_amd64.whl", hash = "sha256:ae3aba7eed4ca7cb79fd3436eddd29140f17ea254b91604aa1eb19bfcedb990f", size = 117493, upload-time = "2026-01-18T20:56:07.343Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/67/339872846a1ae4592535385a1c1f93614138566d7af094200c9c3b45d1e5/ormsgpack-1.12.2-cp314-cp314-win_arm64.whl", hash = "sha256:118576ea6006893aea811b17429bfc561b4778fad393f5f538c84af70b01260c", size = 111579, upload-time = "2026-01-18T20:55:21.161Z" },
-    { url = "https://files.pythonhosted.org/packages/49/c2/6feb972dc87285ad381749d3882d8aecbde9f6ecf908dd717d33d66df095/ormsgpack-1.12.2-cp314-cp314t-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:7121b3d355d3858781dc40dafe25a32ff8a8242b9d80c692fd548a4b1f7fd3c8", size = 378721, upload-time = "2026-01-18T20:55:52.12Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/9a/900a6b9b413e0f8a471cf07830f9cf65939af039a362204b36bd5b581d8b/ormsgpack-1.12.2-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4ee766d2e78251b7a63daf1cddfac36a73562d3ddef68cacfb41b2af64698033", size = 203170, upload-time = "2026-01-18T20:55:44.469Z" },
-    { url = "https://files.pythonhosted.org/packages/87/4c/27a95466354606b256f24fad464d7c97ab62bce6cc529dd4673e1179b8fb/ormsgpack-1.12.2-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:292410a7d23de9b40444636b9b8f1e4e4b814af7f1ef476e44887e52a123f09d", size = 212816, upload-time = "2026-01-18T20:55:23.501Z" },
-    { url = "https://files.pythonhosted.org/packages/73/cd/29cee6007bddf7a834e6cd6f536754c0535fcb939d384f0f37a38b1cddb8/ormsgpack-1.12.2-cp314-cp314t-win_amd64.whl", hash = "sha256:837dd316584485b72ef451d08dd3e96c4a11d12e4963aedb40e08f89685d8ec2", size = 117232, upload-time = "2026-01-18T20:55:45.448Z" },
-]
-
-[[package]]
 name = "overrides"
 version = "7.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3908,11 +3795,11 @@ wheels = [
 
 [[package]]
 name = "packaging"
-version = "26.2"
+version = "25.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
 ]
 
 [[package]]
@@ -5755,22 +5642,19 @@ wheels = [
 name = "tox"
 version = "4.23.2"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.11' and sys_platform == 'win32'",
-    "python_full_version < '3.11' and sys_platform != 'win32'",
-]
 dependencies = [
-    { name = "cachetools", marker = "python_full_version < '3.11'" },
-    { name = "chardet", marker = "python_full_version < '3.11'" },
-    { name = "colorama", marker = "python_full_version < '3.11'" },
-    { name = "filelock", marker = "python_full_version < '3.11'" },
-    { name = "packaging", marker = "python_full_version < '3.11'" },
-    { name = "platformdirs", marker = "python_full_version < '3.11'" },
-    { name = "pluggy", marker = "python_full_version < '3.11'" },
+    { name = "cachetools" },
+    { name = "chardet" },
+    { name = "colorama" },
+    { name = "filelock" },
+    { name = "packaging" },
+    { name = "platformdirs" },
+    { name = "pluggy" },
     { name = "pyproject-api", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "pyproject-api", version = "1.11.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
-    { name = "virtualenv", marker = "python_full_version < '3.11'" },
+    { name = "virtualenv" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1f/86/32b10f91b4b975a37ac402b0f9fa016775088e0565c93602ba0b3c729ce8/tox-4.23.2.tar.gz", hash = "sha256:86075e00e555df6e82e74cfc333917f91ecb47ffbc868dcafbd2672e332f4a2c", size = 189998, upload-time = "2024-10-22T14:29:04.46Z" }
 wheels = [
@@ -5778,86 +5662,17 @@ wheels = [
 ]
 
 [[package]]
-name = "tox"
-version = "4.48.1"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14' and sys_platform == 'win32'",
-    "python_full_version >= '3.14' and sys_platform != 'win32'",
-    "python_full_version == '3.13.*' and sys_platform == 'win32'",
-    "python_full_version == '3.13.*' and sys_platform != 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'win32'",
-    "python_full_version == '3.12.*' and sys_platform != 'win32'",
-    "python_full_version == '3.11.*' and sys_platform == 'win32'",
-    "python_full_version == '3.11.*' and sys_platform != 'win32'",
-]
-dependencies = [
-    { name = "cachetools", marker = "python_full_version >= '3.11'" },
-    { name = "colorama", marker = "python_full_version >= '3.11'" },
-    { name = "filelock", marker = "python_full_version >= '3.11'" },
-    { name = "packaging", marker = "python_full_version >= '3.11'" },
-    { name = "platformdirs", marker = "python_full_version >= '3.11'" },
-    { name = "pluggy", marker = "python_full_version >= '3.11'" },
-    { name = "pyproject-api", version = "1.11.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "tomli-w", marker = "python_full_version >= '3.11'" },
-    { name = "virtualenv", marker = "python_full_version >= '3.11'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ac/93/244bdd2666db5b79e02321fd24e73ccc4bf9424cf5179142937937492ba2/tox-4.48.1.tar.gz", hash = "sha256:971260ac2ea3409de8f3771612d141713d2d33446cc0d981849ebfd9b6bbd3d9", size = 257985, upload-time = "2026-03-06T01:41:17.38Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/17/9a/2b232298ad17aa07f93e3a7429070f9b9e911d9c3980dc27423931797ab3/tox-4.48.1-py3-none-any.whl", hash = "sha256:4e0369041be0d52b0dc83051f6449e4afae1764b4203a5866982fa300c8c325f", size = 205815, upload-time = "2026-03-06T01:41:15.668Z" },
-]
-
-[[package]]
 name = "tox-uv"
 version = "1.19.1"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.11' and sys_platform == 'win32'",
-    "python_full_version < '3.11' and sys_platform != 'win32'",
-]
 dependencies = [
-    { name = "packaging", marker = "python_full_version < '3.11'" },
-    { name = "tox", version = "4.23.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "uv", marker = "python_full_version < '3.11'" },
+    { name = "packaging" },
+    { name = "tox" },
+    { name = "uv" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/23/1c/464b2cc43c369afea44ceb1a9cfe66b6003b6e7263493b5cf4518b721214/tox_uv-1.19.1.tar.gz", hash = "sha256:c1f04b59a649912eb9a91a1f4f303a5c86747c978a73bdf5f99a1c956dfc5872", size = 18505, upload-time = "2025-01-20T22:33:26.592Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/e1/e57f0ee8f2098c28dc0def6cee9bfbd6a0e0117ba0b61bf375fdf970432a/tox_uv-1.19.1-py3-none-any.whl", hash = "sha256:f1d246aa1aa85393c8a1b279f0f6022cca0930dd4367c3a15d43a19da9cf4622", size = 14376, upload-time = "2025-01-20T22:33:25.367Z" },
-]
-
-[[package]]
-name = "tox-uv"
-version = "1.33.4"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14' and sys_platform == 'win32'",
-    "python_full_version >= '3.14' and sys_platform != 'win32'",
-    "python_full_version == '3.13.*' and sys_platform == 'win32'",
-    "python_full_version == '3.13.*' and sys_platform != 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'win32'",
-    "python_full_version == '3.12.*' and sys_platform != 'win32'",
-    "python_full_version == '3.11.*' and sys_platform == 'win32'",
-    "python_full_version == '3.11.*' and sys_platform != 'win32'",
-]
-dependencies = [
-    { name = "tox-uv-bare", marker = "python_full_version >= '3.11'" },
-    { name = "uv", marker = "python_full_version >= '3.11'" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/33/60/f3419045763389b7c1645753ccab1917c8758b0a95b6bad01fed479a9d5b/tox_uv-1.33.4-py3-none-any.whl", hash = "sha256:fe63d7597a0aac6116e06c0f1366b0925bc94b0b92b62a9ec5a9f3e4c17ad5b2", size = 5482, upload-time = "2026-03-12T21:20:54.221Z" },
-]
-
-[[package]]
-name = "tox-uv-bare"
-version = "1.33.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "packaging", marker = "python_full_version >= '3.11'" },
-    { name = "tox", version = "4.48.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/86/56/12f8602a3207b87825564939a4956941c6ddac2f1ac714967926ebb5c9b0/tox_uv_bare-1.33.4.tar.gz", hash = "sha256:310726bd445557f411e7b3096075378c5aac39bb9aa984651a40836f8c988703", size = 27452, upload-time = "2026-03-12T21:20:57.007Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/0d/9d47b320eec0013f7cedb3f340f965e11b8071350b01d5d6e3b301a3e558/tox_uv_bare-1.33.4-py3-none-any.whl", hash = "sha256:fab00d5b0097cdee6607ce0f79326e6c1a8828097b63ab8cb4f327cb132e5fbf", size = 19669, upload-time = "2026-03-12T21:20:55.638Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Enforces that all `[project.optional-dependencies] instruments` and `package.py` `_instruments` declare both lower and upper bounds, and that target libraries in `tests/requirements.latest.txt` are pinned/upper-bounded (`~= major.minor` or `== major.minor.patch`).

Target libraries frequently introduce breaking changes in major releases (as seen in #393 for OpenAI and #435 for Anthropic). Unbounded dependencies cause unexpected CI failures across the repo when `*-latest` matrix environments install newly released major versions.