### PR TITLE
[backport 1.1bx] chore(langchain): raise opentelemetry-util-genai dependency floor to 1.1b0 (#433)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,22 +13,22 @@ All instrumentations use [opentelemetry-util-genai](./util/opentelemetry-util-ge
 
 | Instrumentation | Supported Package | Version |
 | --------------- | ----------------- | ------- |
-| [opentelemetry-instrumentation-genai-anthropic](./instrumentation/opentelemetry-instrumentation-genai-anthropic) | anthropic >= 0.51.0 | [1.0b0](https://pypi.org/project/opentelemetry-instrumentation-genai-anthropic/) |
-| [opentelemetry-instrumentation-genai-langchain](./instrumentation/opentelemetry-instrumentation-genai-langchain) | langchain >= 0.3.21 | [1.0b0](https://pypi.org/project/opentelemetry-instrumentation-genai-langchain/) |
-| [opentelemetry-instrumentation-genai-openai](./instrumentation/opentelemetry-instrumentation-genai-openai) | openai >= 1.26.0, < 4 | [1.0b0](https://pypi.org/project/opentelemetry-instrumentation-genai-openai/) |
-| [opentelemetry-instrumentation-genai-openai-agents](./instrumentation/opentelemetry-instrumentation-genai-openai-agents) | openai-agents >= 0.3.3 | [1.0b0](https://pypi.org/project/opentelemetry-instrumentation-genai-openai-agents/) |
-| [opentelemetry-instrumentation-google-genai](./instrumentation/opentelemetry-instrumentation-google-genai) | google-genai >= 1.32.0, <3 | [1.0b1](https://pypi.org/project/opentelemetry-instrumentation-google-genai/) |
+| [opentelemetry-instrumentation-genai-agno](./instrumentation/opentelemetry-instrumentation-genai-agno) | agno >= 2.0.0 | [1.1b0](https://pypi.org/project/opentelemetry-instrumentation-genai-agno/) |
+| [opentelemetry-instrumentation-genai-anthropic](./instrumentation/opentelemetry-instrumentation-genai-anthropic) | anthropic >= 0.51.0, < 2 | [1.1b0](https://pypi.org/project/opentelemetry-instrumentation-genai-anthropic/) |
+| [opentelemetry-instrumentation-genai-langchain](./instrumentation/opentelemetry-instrumentation-genai-langchain) | langchain >= 0.3.21 | [1.1b0](https://pypi.org/project/opentelemetry-instrumentation-genai-langchain/) |
+| [opentelemetry-instrumentation-genai-openai](./instrumentation/opentelemetry-instrumentation-genai-openai) | openai >= 1.26.0, < 4 | [1.1b0](https://pypi.org/project/opentelemetry-instrumentation-genai-openai/) |
+| [opentelemetry-instrumentation-genai-openai-agents](./instrumentation/opentelemetry-instrumentation-genai-openai-agents) | openai-agents >= 0.3.3 | [1.1b0](https://pypi.org/project/opentelemetry-instrumentation-genai-openai-agents/) |
+| [opentelemetry-instrumentation-genai-qwen-agent](./instrumentation/opentelemetry-instrumentation-genai-qwen-agent) | qwen-agent >= 0.0.20 | [1.1b0](https://pypi.org/project/opentelemetry-instrumentation-genai-qwen-agent/) |
+| [opentelemetry-instrumentation-genai-smolagents](./instrumentation/opentelemetry-instrumentation-genai-smolagents) | smolagents >= 1.24.0 | [1.1b0](https://pypi.org/project/opentelemetry-instrumentation-genai-smolagents/) |
+| [opentelemetry-instrumentation-google-genai](./instrumentation/opentelemetry-instrumentation-google-genai) | google-genai >= 1.32.0, <3 | [1.1b0](https://pypi.org/project/opentelemetry-instrumentation-google-genai/) |
 
 ## Unreleased Instrumentations
 
 | Instrumentation | Supported Package | Version | Status |
 | --------------- | ----------------- | ------- | ------ |
-| [opentelemetry-instrumentation-genai-agno](./instrumentation/opentelemetry-instrumentation-genai-agno) | agno >= 2.0.0 | 1.1b0 | to be released |
 | [opentelemetry-instrumentation-genai-claude-agent-sdk](./instrumentation/opentelemetry-instrumentation-genai-claude-agent-sdk) | claude-agent-sdk >= 0.1.14 | 1.1b0.dev | skeleton |
 | [opentelemetry-instrumentation-genai-crewai](./instrumentation/opentelemetry-instrumentation-genai-crewai) | crewai >= 1.10.1 | 1.1b0.dev | skeleton |
 | [opentelemetry-instrumentation-genai-llama-index](./instrumentation/opentelemetry-instrumentation-genai-llama-index) | llama-index-core >= 0.14.19 | 1.1b0.dev | skeleton |
-| [opentelemetry-instrumentation-genai-qwen-agent](./instrumentation/opentelemetry-instrumentation-genai-qwen-agent) | qwen-agent >= 0.0.20 | 1.1b0 | to be released |
-| [opentelemetry-instrumentation-genai-smolagents](./instrumentation/opentelemetry-instrumentation-genai-smolagents) | smolagents >= 1.24.0 | 1.1b0 | to be released |
 | [opentelemetry-instrumentation-genai-weaviate-client](./instrumentation/opentelemetry-instrumentation-genai-weaviate-client) | weaviate-client >= 3.0.0, <5.0.0 | 1.1b0.dev | skeleton |
 <!-- end -->
 

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -8,7 +8,7 @@ wrapt>=2.2.2,<3.0.0
 
 # Required by instrumentation packages
 agno>=2.9.0
-anthropic>=0.122.0
+anthropic>=1.0.0
 claude-agent-sdk>=0.2.142
 google-genai>=2.18.1
 langchain>=1.3.15

--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/.changelog/435.changed
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/.changelog/435.changed
@@ -1,0 +1,1 @@
+Support Anthropic 1.x, which uses ``httpx2`` as its HTTP client.

--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/examples/manual/requirements.txt
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/examples/manual/requirements.txt
@@ -1,5 +1,4 @@
-anthropic>=0.122.0
+anthropic>=1.0.0
 opentelemetry-sdk~=1.43.0
 opentelemetry-instrumentation-genai-anthropic~=1.0b0
 opentelemetry-exporter-otlp-proto-grpc~=1.43.0
-

--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/examples/zero-code/requirements.txt
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/examples/zero-code/requirements.txt
@@ -1,6 +1,5 @@
-anthropic>=0.122.0
+anthropic>=1.0.0
 opentelemetry-sdk~=1.43.0
 opentelemetry-distro~=0.64b0
 opentelemetry-instrumentation-genai-anthropic~=1.0b0
 opentelemetry-exporter-otlp-proto-grpc~=1.43.0
-

--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-instruments = ["anthropic >= 0.51.0"]
+instruments = ["anthropic >= 0.51.0, < 2"]
 
 [project.entry-points.opentelemetry_instrumentor]
 anthropic = "opentelemetry.instrumentation.genai.anthropic:AnthropicInstrumentor"

--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/src/opentelemetry/instrumentation/genai/anthropic/_raw_response.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/src/opentelemetry/instrumentation/genai/anthropic/_raw_response.py
@@ -11,7 +11,10 @@ import logging
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Any, cast
 
-import httpx
+try:
+    import httpx2 as _http_lib
+except ImportError:
+    import httpx as _http_lib
 from anthropic._models import construct_type
 from anthropic.types import Message as AnthropicMessage
 
@@ -429,7 +432,7 @@ def _body_was_read(http_response: Any) -> bool:
         return False
     try:
         http_response.content  # pylint: disable=pointless-statement
-    except httpx.ResponseNotRead:
+    except _http_lib.ResponseNotRead:
         return False
     return True
 

--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/src/opentelemetry/instrumentation/genai/anthropic/messages_extractors.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/src/opentelemetry/instrumentation/genai/anthropic/messages_extractors.py
@@ -8,7 +8,12 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
+from urllib.parse import urlparse
 
+try:
+    import httpx2 as _http_lib
+except ImportError:
+    import httpx as _http_lib
 from anthropic.types import MessageDeltaUsage
 
 from opentelemetry.semconv._incubating.attributes import (
@@ -33,7 +38,6 @@ from .utils import (
 if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping
 
-    import httpx
     from anthropic.resources.messages import AsyncMessages, Messages
     from anthropic.types import (
         Message,
@@ -194,7 +198,7 @@ def extract_params(  # pylint: disable=too-many-locals
     extra_headers: Mapping[str, str] | None = None,
     extra_query: Mapping[str, object] | None = None,
     extra_body: object | None = None,
-    timeout: float | httpx.Timeout | None = None,
+    timeout: float | _http_lib.Timeout | None = None,
     **_kwargs: object,
 ) -> MessageRequestParams:
     return MessageRequestParams(
@@ -213,12 +217,23 @@ def extract_params(  # pylint: disable=too-many-locals
 def get_server_address_and_port(
     client_instance: Messages | AsyncMessages,
 ) -> tuple[str | None, int | None]:
-    base_url = client_instance._client.base_url
-    port = base_url.port
-    return (
-        base_url.host or None,
-        port if port and port != 443 and port > 0 else None,
-    )
+    base_client = getattr(client_instance, "_client", None)
+    base_url = getattr(base_client, "base_url", None)
+    if not base_url:
+        return None, None
+
+    server_address = getattr(base_url, "host", None)
+    server_port = getattr(base_url, "port", None)
+
+    if server_address is None:
+        parsed = urlparse(str(base_url))
+        server_address = parsed.hostname
+        server_port = parsed.port
+
+    if server_port in (80, 443):
+        server_port = None
+
+    return server_address, server_port
 
 
 def get_llm_request_attributes(

--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/src/opentelemetry/instrumentation/genai/anthropic/package.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/src/opentelemetry/instrumentation/genai/anthropic/package.py
@@ -1,4 +1,4 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-_instruments = ("anthropic >= 0.51.0",)
+_instruments = ("anthropic >= 0.51.0, < 2",)

--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/src/opentelemetry/instrumentation/genai/anthropic/wrappers.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/src/opentelemetry/instrumentation/genai/anthropic/wrappers.py
@@ -12,6 +12,11 @@ from typing import (
     cast,
 )
 
+try:
+    import httpx2 as _http_lib
+except ImportError:
+    import httpx as _http_lib
+
 from opentelemetry.util.genai.stream import (
     AsyncStreamManagerWrapper,
     AsyncStreamWrapper,
@@ -31,7 +36,6 @@ except ImportError:
     _sdk_accumulate_event = None
 
 if TYPE_CHECKING:
-    import httpx
     from anthropic._streaming import AsyncStream, Stream
     from anthropic.lib.streaming._messages import (  # pylint: disable=no-name-in-module
         AsyncMessageStream,
@@ -162,7 +166,7 @@ class MessagesStreamWrapper(
         self._self_message_telemetry_finalized = False
 
     @property
-    def response(self) -> httpx.Response:
+    def response(self) -> _http_lib.Response:
         return finalize_on_close(self.stream.response, self._stop)
 
     @property
@@ -202,7 +206,7 @@ class AsyncMessagesStreamWrapper(
         self._self_message_telemetry_finalized = False
 
     @property
-    def response(self) -> httpx.Response:
+    def response(self) -> _http_lib.Response:
         return finalize_on_aclose(self.stream.response, self._stop)
 
     @property

--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/requirements.latest.txt
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/requirements.latest.txt
@@ -37,7 +37,7 @@
 # This variant of the requirements aims to test the system using
 # the newest supported version of external dependencies.
 
-anthropic
+anthropic < 2
 wrapt==2.2.2
 # test with the latest version of opentelemetry-api, sdk, semantic conventions, and instrumentation
 

--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/test_async_messages.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/test_async_messages.py
@@ -6,11 +6,19 @@
 import inspect
 import json
 
-import httpx
 import pytest
+
+try:
+    import httpx2 as _http_lib
+except ImportError:
+    import httpx as _http_lib
 from anthropic import APIConnectionError, AsyncAnthropic, NotFoundError
-from anthropic._legacy_response import LegacyAPIResponse
 from anthropic._response import AsyncAPIResponse
+
+try:
+    from anthropic._legacy_response import LegacyAPIResponse
+except ImportError:
+    from anthropic._response import AsyncAPIResponse as LegacyAPIResponse
 from anthropic._streaming import AsyncStream as AnthropicAsyncStream
 from anthropic.resources.messages import AsyncMessages as _AsyncMessages
 from anthropic.types import Message
@@ -40,6 +48,13 @@ from opentelemetry.semconv._incubating.metrics import gen_ai_metrics
 _create_params = set(inspect.signature(_AsyncMessages.create).parameters)
 _has_tools_param = "tools" in _create_params
 _has_thinking_param = "thinking" in _create_params
+
+
+async def _parse_raw_response(raw_response, **kwargs):
+    result = raw_response.parse(**kwargs)
+    if inspect.isawaitable(result):
+        return await result
+    return result
 
 
 def normalize_stop_reason(stop_reason):
@@ -156,7 +171,7 @@ async def test_async_messages_create_with_raw_response(
     )
 
     assert hasattr(raw_response, "headers")
-    message = raw_response.parse()
+    message = await _parse_raw_response(raw_response)
 
     spans = span_exporter.get_finished_spans()
     assert len(spans) == 1
@@ -216,23 +231,27 @@ async def test_async_messages_create_with_all_params(
     model = "claude-sonnet-4-20250514"
     messages = [{"role": "user", "content": "Say hello."}]
 
-    await async_anthropic_client.messages.create(
-        model=model,
-        max_tokens=50,
-        messages=messages,
-        temperature=0.7,
-        top_p=0.9,
-        top_k=40,
-        stop_sequences=["STOP"],
-    )
+    kwargs = {
+        "model": model,
+        "max_tokens": 50,
+        "messages": messages,
+        "stop_sequences": ["STOP"],
+    }
+    if "temperature" in _create_params:
+        kwargs.update(temperature=0.7, top_p=0.9, top_k=40)
+
+    await async_anthropic_client.messages.create(**kwargs)
 
     spans = span_exporter.get_finished_spans()
     assert len(spans) == 1
     span = spans[0]
     assert span.attributes[GenAIAttributes.GEN_AI_REQUEST_MAX_TOKENS] == 50
-    assert span.attributes[GenAIAttributes.GEN_AI_REQUEST_TEMPERATURE] == 0.7
-    assert span.attributes[GenAIAttributes.GEN_AI_REQUEST_TOP_P] == 0.9
-    assert span.attributes[GenAIAttributes.GEN_AI_REQUEST_TOP_K] == 40
+    if "temperature" in kwargs:
+        assert (
+            span.attributes[GenAIAttributes.GEN_AI_REQUEST_TEMPERATURE] == 0.7
+        )
+        assert span.attributes[GenAIAttributes.GEN_AI_REQUEST_TOP_P] == 0.9
+        assert span.attributes[GenAIAttributes.GEN_AI_REQUEST_TOP_K] == 40
     assert span.attributes[GenAIAttributes.GEN_AI_REQUEST_STOP_SEQUENCES] == (
         "STOP",
     )
@@ -1106,7 +1125,7 @@ async def test_async_messages_create_streaming_with_raw_response(
     # Deferred: the span must not be finalized before the caller parses/drains.
     assert span_exporter.get_finished_spans() == ()
 
-    stream = raw_response.parse()
+    stream = await _parse_raw_response(raw_response)
     response_text = ""
     async for chunk in stream:
         if chunk.type == "content_block_delta":
@@ -1488,9 +1507,9 @@ async def test_async_messages_raw_response_parse_to_honors_cast_target(
         messages=[{"role": "user", "content": "Say hello in one word."}],
     ) as raw_response:
         await raw_response.parse()
-        as_httpx = await raw_response.parse(to=httpx.Response)
+        as_httpx = await raw_response.parse(to=_http_lib.Response)
 
-    assert isinstance(as_httpx, httpx.Response)
+    assert isinstance(as_httpx, _http_lib.Response)
 
 
 @pytest.mark.cassette("test_async_messages_create_with_raw_response")
@@ -1686,7 +1705,7 @@ async def test_async_messages_with_raw_response_does_not_parse_early(
     assert spans[0].attributes[GenAIAttributes.GEN_AI_RESPONSE_MODEL] == model
     assert not parse_calls
 
-    assert raw_response.parse().model == model
+    assert (await _parse_raw_response(raw_response)).model == model
     assert len(parse_calls) == 1
 
 
@@ -1731,7 +1750,7 @@ async def test_async_messages_with_raw_response_captures_content(
             messages=[{"role": "user", "content": "Say hello in one word."}],
         )
     )
-    message = raw_response.parse()
+    message = await _parse_raw_response(raw_response)
 
     span = span_exporter.get_finished_spans()[0]
     input_messages = _load_span_messages(

--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/test_instrumentor.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/test_instrumentor.py
@@ -64,7 +64,7 @@ def test_instrumentation_dependencies():
 
     assert dependencies is not None
     assert len(dependencies) > 0
-    assert "anthropic >= 0.51.0" in dependencies
+    assert "anthropic >= 0.51.0, < 2" in dependencies
 
 
 def test_instrument_uninstrument_cycle(

--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/test_sync_messages.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/test_sync_messages.py
@@ -8,12 +8,21 @@ import inspect
 import json
 import os
 from pathlib import Path
+from types import SimpleNamespace
 
-import httpx
 import pytest
+
+try:
+    import httpx
+except ImportError:
+    import httpx2 as httpx
 from anthropic import Anthropic, APIConnectionError, NotFoundError
-from anthropic._legacy_response import LegacyAPIResponse
 from anthropic._response import APIResponse
+
+try:
+    from anthropic._legacy_response import LegacyAPIResponse
+except ImportError:
+    from anthropic._response import APIResponse as LegacyAPIResponse
 from anthropic._streaming import Stream as AnthropicStream
 from anthropic.resources.messages import Messages as _Messages
 from anthropic.types import (
@@ -33,6 +42,7 @@ from opentelemetry.instrumentation.genai.anthropic._raw_response import (
 from opentelemetry.instrumentation.genai.anthropic.messages_extractors import (
     GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS,
     GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS,
+    get_server_address_and_port,
 )
 from opentelemetry.semconv._incubating.attributes import (
     error_attributes as ErrorAttributes,
@@ -50,6 +60,25 @@ from opentelemetry.semconv._incubating.metrics import gen_ai_metrics
 _create_params = set(inspect.signature(_Messages.create).parameters)
 _has_tools_param = "tools" in _create_params
 _has_thinking_param = "thinking" in _create_params
+
+
+@pytest.mark.parametrize(
+    ("base_url", "expected"),
+    [
+        (None, (None, None)),
+        ("https://api.anthropic.com:443", ("api.anthropic.com", None)),
+        ("http://localhost:80", ("localhost", None)),
+        ("https://collector.example:4318", ("collector.example", 4318)),
+        (
+            SimpleNamespace(host="custom.anthropic.test", port=8443),
+            ("custom.anthropic.test", 8443),
+        ),
+    ],
+)
+def test_get_server_address_and_port(base_url, expected):
+    client = SimpleNamespace(_client=SimpleNamespace(base_url=base_url))
+
+    assert get_server_address_and_port(client) == expected
 
 
 def normalize_stop_reason(stop_reason):
@@ -404,23 +433,27 @@ def test_sync_messages_create_with_all_params(
     model = "claude-sonnet-4-20250514"
     messages = [{"role": "user", "content": "Say hello."}]
 
-    anthropic_client.messages.create(
-        model=model,
-        max_tokens=50,
-        messages=messages,
-        temperature=0.7,
-        top_p=0.9,
-        top_k=40,
-        stop_sequences=["STOP"],
-    )
+    kwargs = {
+        "model": model,
+        "max_tokens": 50,
+        "messages": messages,
+        "stop_sequences": ["STOP"],
+    }
+    if "temperature" in _create_params:
+        kwargs.update(temperature=0.7, top_p=0.9, top_k=40)
+
+    anthropic_client.messages.create(**kwargs)
 
     spans = span_exporter.get_finished_spans()
     assert len(spans) == 1
     span = spans[0]
     assert span.attributes[GenAIAttributes.GEN_AI_REQUEST_MAX_TOKENS] == 50
-    assert span.attributes[GenAIAttributes.GEN_AI_REQUEST_TEMPERATURE] == 0.7
-    assert span.attributes[GenAIAttributes.GEN_AI_REQUEST_TOP_P] == 0.9
-    assert span.attributes[GenAIAttributes.GEN_AI_REQUEST_TOP_K] == 40
+    if "temperature" in kwargs:
+        assert (
+            span.attributes[GenAIAttributes.GEN_AI_REQUEST_TEMPERATURE] == 0.7
+        )
+        assert span.attributes[GenAIAttributes.GEN_AI_REQUEST_TOP_P] == 0.9
+        assert span.attributes[GenAIAttributes.GEN_AI_REQUEST_TOP_K] == 40
     # OpenTelemetry converts lists to tuples when storing as attributes
     assert span.attributes[GenAIAttributes.GEN_AI_REQUEST_STOP_SEQUENCES] == (
         "STOP",

--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/.changelog/433.changed
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/.changelog/433.changed
@@ -1,0 +1,1 @@
+Raised `opentelemetry-util-genai` dependency floor to 1.1b0.

--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 dependencies = [
   "opentelemetry-instrumentation >= 0.64b0, <1",
-  "opentelemetry-util-genai >= 1.0b0, <2",
+  "opentelemetry-util-genai >= 1.1b0, <2",
 ]
 
 [project.optional-dependencies]

--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/tests/requirements.oldest.txt
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/tests/requirements.oldest.txt
@@ -20,11 +20,7 @@
 # pyproject floors by UV_RESOLUTION=lowest-direct on the oldest tox factor, so they are NOT pinned
 # here to avoid drift between the declared bound and the tested version.
 
-# Exception: this change depends on the fully-qualified error.type behavior added in
-# opentelemetry-util-genai 1.1b0, which is not on PyPI yet. Install it from the workspace so the
-# oldest env exercises the required behavior. Remove this once 1.1b0 is released and bump the
-# pyproject floor to >= 1.1b0.
--e ./util/opentelemetry-util-genai
+
 
 langchain-openai==0.2.0
 langchain-aws==0.2.2

--- a/uv.lock
+++ b/uv.lock
@@ -273,21 +273,20 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "0.118.0"
+version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "distro" },
     { name = "docstring-parser" },
-    { name = "httpx" },
+    { name = "httpx2" },
     { name = "jiter" },
     { name = "pydantic" },
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/07/ff/bbad57650babf07ae9761f1d974fcee73430387b5d3aa0ddb395234906e8/anthropic-0.118.0.tar.gz", hash = "sha256:acb3c43b7e7592cf635fa21930e67a99d32641d68ccd53f625b52f71d7870d55", size = 994705, upload-time = "2026-07-22T16:43:57.019Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/aa/4978e58035bd6c638c7b483450a68b7ef2d732ab78885e27bb9db0cff1a2/anthropic-1.0.0.tar.gz", hash = "sha256:42be3c97604af7252c5898413aee076ace6c46e9bca0d0d90ceb77c7d3719027", size = 1077769, upload-time = "2026-08-20T19:59:00.565Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/91/9f/d46e77054d7efb61c85ef5e8c7e95927cc89988b6491b46d22af60d63bda/anthropic-0.118.0-py3-none-any.whl", hash = "sha256:524d835869b8e374510b3bcc552e28dbdafc035a61d63fc0088c4035286ef8fe", size = 1010922, upload-time = "2026-07-22T16:43:55.461Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/5b/db4a854aebf5d33a5ab714c46af6eb85ee44f390ed29b7b325c00b9f11ed/anthropic-1.0.0-py3-none-any.whl", hash = "sha256:32dd52e9e1d774393b27182f451398ba4262287a4d0eab30887f89f1481b3ae4", size = 1171725, upload-time = "2026-08-20T19:58:58.725Z" },
 ]
 
 [[package]]
@@ -1657,6 +1656,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/be/ad/f4f0e57345f1870f3e8cb624e058d7eca6e5a27d33bcc3311d9b618734cd/httpcore2-2.12.0.tar.gz", hash = "sha256:9293522bba0aa7c4c8e9e3f040c16575bd8868e155a77fa30c7a9085a5eae648", size = 67548, upload-time = "2026-08-18T13:22:08.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/74/d370e55600d9bcfa0d9794b0166126d49291a3d2b20c268fc98c453a4948/httpcore2-2.12.0-py3-none-any.whl", hash = "sha256:7e04258ce01013d7d615e5b910a3b27fac937d7a95038227e79652b4ba3b4ceb", size = 83074, upload-time = "2026-08-18T13:22:05.854Z" },
+]
+
+[[package]]
 name = "httptools"
 version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1733,6 +1745,32 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
+name = "httpx2"
+version = "2.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio", marker = "sys_platform != 'emscripten'" },
+    { name = "httpcore2", marker = "sys_platform != 'emscripten'" },
+    { name = "httpx2-jsfetch", marker = "python_full_version >= '3.12' and sys_platform == 'emscripten'" },
+    { name = "idna" },
+    { name = "truststore", marker = "sys_platform != 'emscripten'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7f/f8/579a8b51e42e38ee32647df9f08aa25643ae788e275cc625b199829c4671/httpx2-2.12.0.tar.gz", hash = "sha256:7631fe9887a8a2275f4a2540e053aa670fcc50742864a9ae7c66e609fdcf12cf", size = 100040, upload-time = "2026-08-18T13:22:09.086Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/95/411ba65569158e862368917aaf56597f3e5fa3b91b0502919638465a08f3/httpx2-2.12.0-py3-none-any.whl", hash = "sha256:cc8b6eecb8661c146b8f89a60e97456ee086e91a784ed31ac450c3a9e613dd36", size = 95427, upload-time = "2026-08-18T13:22:06.834Z" },
+]
+
+[[package]]
+name = "httpx2-jsfetch"
+version = "1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/0e5636363151a2a1795e0a77617168b9ca438e1748ec05fc9b5687f93d64/httpx2_jsfetch-1.0.tar.gz", hash = "sha256:70a0e3eabfef7cce5ad9c629f7d01ca05e418f586646f4ddf14782e4c1454c60", size = 6872, upload-time = "2026-08-07T00:13:07.492Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/43/832f631d32e4f1211caa2ba368317739fe71f0b8530e4c9d15dc454bac2a/httpx2_jsfetch-1.0-py3-none-any.whl", hash = "sha256:cb916b707601e69a07721aabc8f3f6659be3a6893bc1ff5c6f9e02241df2da32", size = 6382, upload-time = "2026-08-07T00:13:06.567Z" },
 ]
 
 [[package]]
@@ -3329,7 +3367,7 @@ instruments = [
 
 [package.metadata]
 requires-dist = [
-    { name = "anthropic", marker = "extra == 'instruments'", specifier = ">=0.51.0" },
+    { name = "anthropic", marker = "extra == 'instruments'", specifier = ">=0.51.0,<2" },
     { name = "opentelemetry-api", specifier = "~=1.43" },
     { name = "opentelemetry-instrumentation", specifier = ">=0.64b0,<1" },
     { name = "opentelemetry-semantic-conventions", specifier = ">=0.64b0,<1" },
@@ -5870,6 +5908,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8c/69/40407dfc835517f058b603dbf37a6df094d8582b015a51eddc988febbcb7/tqdm-4.69.0.tar.gz", hash = "sha256:700c5e85dcd5f009dd6222588a29180a193a748247a5d855b4d67db93d79a53b", size = 792569, upload-time = "2026-07-17T18:09:06.2Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fe/21/99a0cdaf54eb35e77623c41b5a2c9472ee4404bba687052791fe2aba6773/tqdm-4.69.0-py3-none-any.whl", hash = "sha256:9979978912be667a6ef21fd5d8abf54e324e63d82f7f43c360792ebc2bc4e622", size = 676680, upload-time = "2026-07-17T18:09:04.172Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Backports #433 to `package-release/opentelemetry-instrumentation-genai-langchain/v1.1bx` for patch release 1.1b1.