### PR TITLE
fix(anthropic): capture sampling params from extra_body

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/.changelog/480.fixed
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/.changelog/480.fixed
@@ -1,0 +1,1 @@
+Capture Anthropic sampling parameters passed through ``extra_body``.

--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/src/opentelemetry/instrumentation/genai/anthropic/messages_extractors.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/src/opentelemetry/instrumentation/genai/anthropic/messages_extractors.py
@@ -5,9 +5,9 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 from urllib.parse import urlparse
 
 try:
@@ -36,7 +36,7 @@ from .utils import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Mapping
+    from collections.abc import Iterable
 
     from anthropic.resources.messages import AsyncMessages, Messages
     from anthropic.types import (
@@ -201,6 +201,32 @@ def extract_params(  # pylint: disable=too-many-locals
     timeout: float | _http_lib.Timeout | None = None,
     **_kwargs: object,
 ) -> MessageRequestParams:
+    if isinstance(extra_body, Mapping):
+        body = cast(Mapping[object, object], extra_body)
+        body_temperature = body.get("temperature")
+        if (
+            temperature is None
+            and isinstance(body_temperature, (int, float))
+            and not isinstance(body_temperature, bool)
+        ):
+            temperature = float(body_temperature)
+
+        body_top_p = body.get("top_p")
+        if (
+            top_p is None
+            and isinstance(body_top_p, (int, float))
+            and not isinstance(body_top_p, bool)
+        ):
+            top_p = float(body_top_p)
+
+        body_top_k = body.get("top_k")
+        if (
+            top_k is None
+            and isinstance(body_top_k, int)
+            and not isinstance(body_top_k, bool)
+        ):
+            top_k = body_top_k
+
     return MessageRequestParams(
         model=model,
         max_tokens=max_tokens,

--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/test_async_messages.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/test_async_messages.py
@@ -237,8 +237,11 @@ async def test_async_messages_create_with_all_params(
         "messages": messages,
         "stop_sequences": ["STOP"],
     }
+    sampling_params = {"temperature": 0.7, "top_p": 0.9, "top_k": 40}
     if "temperature" in _create_params:
-        kwargs.update(temperature=0.7, top_p=0.9, top_k=40)
+        kwargs.update(sampling_params)
+    else:
+        kwargs["extra_body"] = sampling_params
 
     await async_anthropic_client.messages.create(**kwargs)
 
@@ -246,12 +249,9 @@ async def test_async_messages_create_with_all_params(
     assert len(spans) == 1
     span = spans[0]
     assert span.attributes[GenAIAttributes.GEN_AI_REQUEST_MAX_TOKENS] == 50
-    if "temperature" in kwargs:
-        assert (
-            span.attributes[GenAIAttributes.GEN_AI_REQUEST_TEMPERATURE] == 0.7
-        )
-        assert span.attributes[GenAIAttributes.GEN_AI_REQUEST_TOP_P] == 0.9
-        assert span.attributes[GenAIAttributes.GEN_AI_REQUEST_TOP_K] == 40
+    assert span.attributes[GenAIAttributes.GEN_AI_REQUEST_TEMPERATURE] == 0.7
+    assert span.attributes[GenAIAttributes.GEN_AI_REQUEST_TOP_P] == 0.9
+    assert span.attributes[GenAIAttributes.GEN_AI_REQUEST_TOP_K] == 40
     assert span.attributes[GenAIAttributes.GEN_AI_REQUEST_STOP_SEQUENCES] == (
         "STOP",
     )

--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/test_messages_extractors.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/test_messages_extractors.py
@@ -1,0 +1,49 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for Anthropic message parameter extraction."""
+
+from opentelemetry.instrumentation.genai.anthropic.messages_extractors import (
+    extract_params,
+)
+
+
+def test_extract_params_reads_sampling_params_from_extra_body():
+    params = extract_params(
+        extra_body={"temperature": 0.7, "top_p": 0.9, "top_k": 40}
+    )
+
+    assert params.temperature == 0.7
+    assert params.top_p == 0.9
+    assert params.top_k == 40
+
+
+def test_extract_params_prefers_named_sampling_params():
+    params = extract_params(
+        temperature=0.2,
+        top_p=0.3,
+        top_k=10,
+        extra_body={"temperature": 0.7, "top_p": 0.9, "top_k": 40},
+    )
+
+    assert params.temperature == 0.2
+    assert params.top_p == 0.3
+    assert params.top_k == 10
+
+
+def test_extract_params_ignores_non_numeric_extra_body_sampling_params():
+    params = extract_params(
+        extra_body={"temperature": "high", "top_p": True, "top_k": 2.5}
+    )
+
+    assert params.temperature is None
+    assert params.top_p is None
+    assert params.top_k is None
+
+
+def test_extract_params_ignores_non_mapping_extra_body():
+    params = extract_params(extra_body="temperature=0.7")
+
+    assert params.temperature is None
+    assert params.top_p is None
+    assert params.top_k is None

--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/test_sync_messages.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/test_sync_messages.py
@@ -439,8 +439,11 @@ def test_sync_messages_create_with_all_params(
         "messages": messages,
         "stop_sequences": ["STOP"],
     }
+    sampling_params = {"temperature": 0.7, "top_p": 0.9, "top_k": 40}
     if "temperature" in _create_params:
-        kwargs.update(temperature=0.7, top_p=0.9, top_k=40)
+        kwargs.update(sampling_params)
+    else:
+        kwargs["extra_body"] = sampling_params
 
     anthropic_client.messages.create(**kwargs)
 
@@ -448,12 +451,9 @@ def test_sync_messages_create_with_all_params(
     assert len(spans) == 1
     span = spans[0]
     assert span.attributes[GenAIAttributes.GEN_AI_REQUEST_MAX_TOKENS] == 50
-    if "temperature" in kwargs:
-        assert (
-            span.attributes[GenAIAttributes.GEN_AI_REQUEST_TEMPERATURE] == 0.7
-        )
-        assert span.attributes[GenAIAttributes.GEN_AI_REQUEST_TOP_P] == 0.9
-        assert span.attributes[GenAIAttributes.GEN_AI_REQUEST_TOP_K] == 40
+    assert span.attributes[GenAIAttributes.GEN_AI_REQUEST_TEMPERATURE] == 0.7
+    assert span.attributes[GenAIAttributes.GEN_AI_REQUEST_TOP_P] == 0.9
+    assert span.attributes[GenAIAttributes.GEN_AI_REQUEST_TOP_K] == 40
     # OpenTelemetry converts lists to tuples when storing as attributes
     assert span.attributes[GenAIAttributes.GEN_AI_REQUEST_STOP_SEQUENCES] == (
         "STOP",


### PR DESCRIPTION
## Why

Anthropic SDK 1.x removed `temperature`, `top_p`, and `top_k` from its typed method signatures while retaining them through `extra_body`. The instrumentation ignored that mapping, so these request attributes disappeared from telemetry. Fixes #471.

## What

Fall back to numeric sampling values from `extra_body` when their named arguments are absent. Add extractor unit tests and make the existing sync/async coverage assert sampling attributes on both supported SDK generations.

## Why the approach

For backward compatibility reasons, when conflicting values are supplied in both locations, the code ensures that the original named values win.

## Validation

- [x] Anthropic latest: 166 passed, 2 skipped
- [x] Anthropic oldest: 159 passed, 9 skipped
- [x] Anthropic conformance: 5 skipped (`weaver` binary unavailable locally; CI installs it)
- [x] `tox -e typecheck`
- [x] `tox -e precommit`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Followed the style guidelines of this project
- [x] Changelog updated if the change requires an entry
- [x] Unit tests added
- [ ] Documentation updated
