### PR TITLE
fix(anthropic): capture sampling params from extra_body

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/.changelog/484.fixed
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/.changelog/484.fixed
@@ -1,0 +1,1 @@
+capture Anthropic sampling parameters passed through extra_body

--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/src/opentelemetry/instrumentation/genai/anthropic/messages_extractors.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/src/opentelemetry/instrumentation/genai/anthropic/messages_extractors.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 from urllib.parse import urlparse
@@ -36,7 +36,7 @@ from .utils import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Mapping
+    from collections.abc import Iterable
 
     from anthropic.resources.messages import AsyncMessages, Messages
     from anthropic.types import (
@@ -201,12 +201,15 @@ def extract_params(  # pylint: disable=too-many-locals
     timeout: float | _http_lib.Timeout | None = None,
     **_kwargs: object,
 ) -> MessageRequestParams:
+    body = extra_body if isinstance(extra_body, Mapping) else {}
     return MessageRequestParams(
         model=model,
         max_tokens=max_tokens,
-        temperature=temperature,
-        top_p=top_p,
-        top_k=top_k,
+        temperature=(
+            temperature if temperature is not None else body.get("temperature")
+        ),
+        top_p=top_p if top_p is not None else body.get("top_p"),
+        top_k=top_k if top_k is not None else body.get("top_k"),
         stop_sequences=stop_sequences,
         stream=stream,
         messages=messages,

--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/test_sync_messages.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/test_sync_messages.py
@@ -42,6 +42,7 @@ from opentelemetry.instrumentation.genai.anthropic._raw_response import (
 from opentelemetry.instrumentation.genai.anthropic.messages_extractors import (
     GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS,
     GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS,
+    extract_params,
     get_server_address_and_port,
 )
 from opentelemetry.semconv._incubating.attributes import (
@@ -458,6 +459,23 @@ def test_sync_messages_create_with_all_params(
     assert span.attributes[GenAIAttributes.GEN_AI_REQUEST_STOP_SEQUENCES] == (
         "STOP",
     )
+
+
+def test_extract_params_captures_sampling_params_from_extra_body():
+    params = extract_params(
+        model="claude-sonnet-4-20250514",
+        max_tokens=50,
+        messages=[{"role": "user", "content": "Say hello."}],
+        extra_body={
+            "temperature": 0.7,
+            "top_p": 0.9,
+            "top_k": 40,
+        },
+    )
+
+    assert params.temperature == 0.7
+    assert params.top_p == 0.9
+    assert params.top_k == 40
 
 
 @pytest.mark.vcr()


### PR DESCRIPTION
Fixes #471

## Summary
- fall back to `extra_body` for `temperature`, `top_p`, and `top_k` when the named parameters are absent
- preserve named-parameter precedence when both forms are present
- add a regression test for sampling parameters passed through `extra_body`

## Testing
- `python -m uv run pytest instrumentation\opentelemetry-instrumentation-genai-anthropic\tests\test_sync_messages.py -k "extract_params_captures_sampling_params_from_extra_body" -q`
- `python -m uv run pre-commit run ruff --files instrumentation\opentelemetry-instrumentation-genai-anthropic\src\opentelemetry\instrumentation\genai\anthropic\messages_extractors.py instrumentation\opentelemetry-instrumentation-genai-anthropic\tests\test_sync_messages.py`

Note: workspace typecheck did not run to completion locally because tox dependency setup hit a Windows `Access is denied` error while replacing `uv.exe`; no Pyright diagnostics were produced.