### PR TITLE
util-genai: end streamed invocations abandoned before draining

### DIFF
--- a/util/opentelemetry-util-genai/.changelog/492.fixed
+++ b/util/opentelemetry-util-genai/.changelog/492.fixed
@@ -1,0 +1,1 @@
+End streamed invocations abandoned before the stream is drained, so the span and OTel context no longer leak.

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/stream.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/stream.py
@@ -126,6 +126,28 @@ class SyncStreamWrapper(
             invocation._request_stream = True
         self._bind_stream(stream)
 
+    def __del__(self) -> None:
+        """End a streamed invocation abandoned without draining.
+
+        The wrapper going out of scope before the stream was fully consumed is
+        the only signal for "the caller walked away". A properly drained,
+        closed, or failed stream has already finalized, so this is a no-op for
+        it. Interpreter shutdown tears down modules before instances, so
+        attribute access and finalization are wrapped defensively.
+        """
+        try:
+            finalized = self._self_finalized
+            invocation = self._self_invocation
+        except Exception:  # pragma: no cover - interpreter-shutdown only
+            return
+        if finalized or invocation is None:
+            return
+        if getattr(invocation, "_context_token", None) is not None:
+            try:
+                invocation.stop()
+            except Exception:  # pragma: no cover - interpreter-shutdown only
+                pass
+
     # The SDK stream, held loosely typed: subclasses re-expose it through a
     # ``stream`` property carrying the SDK's own type.
     _self_stream: Any

--- a/util/opentelemetry-util-genai/tests/test_handler_agent.py
+++ b/util/opentelemetry-util-genai/tests/test_handler_agent.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import gc
 import unittest
 from unittest.mock import patch
 
@@ -19,6 +20,7 @@ from opentelemetry.semconv.attributes import server_attributes
 from opentelemetry.test.test_base import TestBase
 from opentelemetry.trace import INVALID_SPAN, SpanKind
 from opentelemetry.util.genai.handler import TelemetryHandler
+from opentelemetry.util.genai.stream import SyncStreamWrapper
 from opentelemetry.util.genai.types import (
     ContentCapturingMode,
     Error,
@@ -624,3 +626,75 @@ class TestAgentInvocationMetrics(TestBase):
             points = metric.data.data_points or []
             metrics_by_name.setdefault(metric.name, []).extend(points)
         return metrics_by_name
+
+
+class _AbandonableStreamWrapper(SyncStreamWrapper):
+    """Minimal wrapper whose invocation is finalized only on a GC finalizer."""
+
+    def _process_chunk(self, chunk):  # pylint: disable=unused-argument
+        pass
+
+    def _on_stream_end(self):
+        self._self_invocation.stop()
+
+    def _on_stream_error(self, error):
+        self._self_invocation.fail(error)
+
+
+class TestAbandonedStreamInvocation(unittest.TestCase):
+    """Caller walking away before consuming the stream leaks the span/context.
+
+    Regression coverage for the open-telemetry/opentelemetry-python-genai
+    abandoned-stream investigation.
+    """
+
+    def setUp(self):
+        self._span_exporter = InMemorySpanExporter()
+        self._tracer_provider = TracerProvider()
+        self._tracer_provider.add_span_processor(
+            SimpleSpanProcessor(self._span_exporter)
+        )
+        self._tracer = self._tracer_provider.get_tracer(__name__)
+        self._handler = TelemetryHandler(tracer_provider=self._tracer_provider)
+
+    def _abandoned_spans(self, agent_name):
+        invocation = self._handler.invoke_local_agent(
+            agent_name=agent_name, request_model="gpt-4"
+        )
+        wrapper = _AbandonableStreamWrapper(self._chunks(), invocation)
+        for _ in wrapper:
+            break
+        del wrapper
+        gc.collect()
+
+    @staticmethod
+    def _chunks():
+        yield "a"
+        yield "b"
+
+    def test_abandoned_stream_ends_span_and_detaches_context(self):
+        self._abandoned_spans("Math Tutor")
+
+        with self._tracer.start_as_current_span("later"):
+            pass
+
+        spans = {
+            span.name: span
+            for span in self._span_exporter.get_finished_spans()
+        }
+        assert "invoke_agent Math Tutor" in spans
+        assert spans["later"].parent is None
+
+    def test_consumed_stream_still_ends_span(self):
+        invocation = self._handler.invoke_local_agent(
+            agent_name="Reading", request_model="gpt-4"
+        )
+        wrapper = _AbandonableStreamWrapper(self._chunks(), invocation)
+        list(wrapper)
+        del wrapper
+        gc.collect()
+
+        spans = {
+            span.name for span in self._span_exporter.get_finished_spans()
+        }
+        assert "invoke_agent Reading" in spans

--- a/util/opentelemetry-util-genai/tests/test_stream.py
+++ b/util/opentelemetry-util-genai/tests/test_stream.py
@@ -4,6 +4,7 @@
 # pylint: disable=abstract-class-instantiated
 
 import asyncio
+import gc
 import inspect
 import timeit
 from unittest.mock import patch
@@ -399,9 +400,13 @@ class _FakeTimingInvocation:
     def __init__(self):
         self.chunk_times = []
         self._request_stream = None
+        self.stop_count = 0
 
     def _on_stream_chunk(self, chunk_at):
         self.chunk_times.append(chunk_at)
+
+    def stop(self):
+        self.stop_count += 1
 
 
 class _TimingSyncWrapper(SyncStreamWrapper):
@@ -488,6 +493,81 @@ def test_sync_wrapper_error_before_first_chunk_no_report():
         next(wrapper)
 
     assert invocation.chunk_times == []
+
+
+class _FakeFinalizeInvocation:
+    """Stand-in for a started-but-unfinalized invocation: has a live context
+    token until stopped, mirroring GenAIInvocation's finalized-once signal."""
+
+    def __init__(self):
+        self.stop_count = 0
+        self._context_token = object()
+        self._request_stream = None
+
+    def _on_stream_chunk(self, chunk_at):
+        pass
+
+    def stop(self):
+        if self._context_token is not None:
+            self._context_token = None
+            self.stop_count += 1
+
+    def fail(self, error):
+        pass
+
+
+def test_sync_wrapper_abandoned_before_drain_ends_invocation():
+    """Issue repro: a stream abandoned before draining now ends the span via
+    the wrapper's GC finalizer instead of leaking it."""
+    invocation = _FakeFinalizeInvocation()
+
+    wrapper = _TestSyncStreamWrapper(
+        _FakeSyncStream(chunks=["a", "b"]), invocation=invocation
+    )
+    del wrapper
+    gc.collect()
+
+    assert invocation.stop_count == 1
+
+
+def test_sync_wrapper_abandoned_pattern_b_ends_invocation():
+    """Subclasses that set ``_self_invocation`` after ``super().__init__``
+    still get the abandonment finalizer."""
+    invocation = _FakeFinalizeInvocation()
+    wrapper = _TestSyncStreamWrapper(_FakeSyncStream(chunks=["a"]))
+    wrapper._self_invocation = invocation
+
+    del wrapper
+    gc.collect()
+
+    assert invocation.stop_count == 1
+
+
+def test_sync_wrapper_drained_then_collected_no_double_stop():
+    """A fully drained stream finalizes exactly once; the abandonment
+    finalizer firing on collection afterwards does not stop it again."""
+    invocation = _FakeFinalizeInvocation()
+    wrapper = _TestSyncStreamWrapper(
+        _FakeSyncStream(chunks=["a"]), invocation=invocation
+    )
+
+    list(wrapper)
+    assert invocation.stop_count == 1
+
+    del wrapper
+    gc.collect()
+
+    assert invocation.stop_count == 1
+
+
+def test_sync_wrapper_without_invocation_collected_untouched():
+    stream = _FakeSyncStream(chunks=["a"])
+    wrapper = _TestSyncStreamWrapper(stream)
+    assert wrapper._self_invocation is None
+
+    # Collection of a wrapper with no invocation must not raise.
+    del wrapper
+    gc.collect()
 
 
 def test_sync_wrapper_captures_arrival_before_processing():


### PR DESCRIPTION
Fixes #491: a streamed invocation whose wrapper the caller abandoned before draining leaked both the span and the OTel context, so every abandoned stream left a dangling span and a permanently-attached context token.

SyncStreamWrapper now ends the invocation on collection via the GC finalizer, using the same detach/stop path as normal finalization. The `_context_token` guard makes finalization idempotent, so drained/closed/failed streams are untouched.

Known gaps: sync only (async abandonment deferred until the async lease problem is settled); covers wrappers following the `_self_invocation` convention; span end time reflects collection, not drain; a cross-thread collection may swallow the context detach. This is a draft so the maintainers can steer the design for the explicitly "needs investigation" path.