### PR TITLE
Temporary EasyCLA check for workflow formatting

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-genai-llama-index/tests/conformance/workflow.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-llama-index/tests/conformance/workflow.py
@@ -95,6 +95,7 @@ class WorkflowScenario(Scenario):
             meter_provider=meter_provider,
             content_capture="SPAN_ONLY",
         ):
+
             async def run_workflow() -> None:
                 await workflow.run(user_msg="Complete the request")
 


### PR DESCRIPTION
Temporary draft to run the required EasyCLA status on the workflow formatter commit. It will be closed automatically once the native stack branch is synchronized.