### PR TITLE
Remove obsolete Scorecard runner input

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -17,5 +17,3 @@ jobs:
       id-token: write # for Scorecard to publish results
       security-events: write # for the SARIF upload to code scanning
     uses: open-telemetry/shared-workflows/.github/workflows/scorecard.yml@dde3047a8f219c296772c17936b9d02bb7447af5 # v0.12.0
-    with:
-      use-cncf-hosted-runner: true


### PR DESCRIPTION
Removes the obsolete `use-cncf-hosted-runner` input while keeping the shared Scorecard workflow pinned to v0.12.0.

(switching to use `ubuntu-slim` instead for these workflows: https://github.com/open-telemetry/shared-workflows/pull/337)