### PR TITLE
[`opentelemetry-instrumentation-genai-dspy`] Instrument tool calls and `react` agent loops

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ All instrumentations use [opentelemetry-util-genai](./util/opentelemetry-util-ge
 | [opentelemetry-instrumentation-genai-bedrock](./instrumentation/opentelemetry-instrumentation-genai-bedrock) | boto3 >= 1.40.46, < 2 | 1.2b0.dev | skeleton |
 | [opentelemetry-instrumentation-genai-claude-agent-sdk](./instrumentation/opentelemetry-instrumentation-genai-claude-agent-sdk) | claude-agent-sdk >= 0.1.14, < 1 | 1.2b0.dev | skeleton |
 | [opentelemetry-instrumentation-genai-crewai](./instrumentation/opentelemetry-instrumentation-genai-crewai) | crewai >= 1.10.1, < 2 | 1.2b0.dev | skeleton |
-| [opentelemetry-instrumentation-genai-dspy](./instrumentation/opentelemetry-instrumentation-genai-dspy) | dspy >= 2.5.0, < 4 | 1.2b0.dev | skeleton |
+| [opentelemetry-instrumentation-genai-dspy](./instrumentation/opentelemetry-instrumentation-genai-dspy) | dspy >= 2.6.0, < 4 | 1.2b0.dev | skeleton |
 | [opentelemetry-instrumentation-genai-llama-index](./instrumentation/opentelemetry-instrumentation-genai-llama-index) | llama-index-core >= 0.14.19, < 1 | 1.2b0.dev | skeleton |
 | [opentelemetry-instrumentation-genai-portkey](./instrumentation/opentelemetry-instrumentation-genai-portkey) | portkey-ai >= 1.0.0, < 3 | 1.2b0.dev | to be released |
 | [opentelemetry-instrumentation-genai-weaviate-client](./instrumentation/opentelemetry-instrumentation-genai-weaviate-client) | weaviate-client >= 3.0.0, <5.0.0 | 1.2b0.dev | skeleton |

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ All instrumentations use [opentelemetry-util-genai](./util/opentelemetry-util-ge
 | [opentelemetry-instrumentation-genai-bedrock](./instrumentation/opentelemetry-instrumentation-genai-bedrock) | boto3 >= 1.40.46, < 2 | 1.2b0.dev | skeleton |
 | [opentelemetry-instrumentation-genai-claude-agent-sdk](./instrumentation/opentelemetry-instrumentation-genai-claude-agent-sdk) | claude-agent-sdk >= 0.1.14, < 1 | 1.2b0.dev | skeleton |
 | [opentelemetry-instrumentation-genai-crewai](./instrumentation/opentelemetry-instrumentation-genai-crewai) | crewai >= 1.10.1, < 2 | 1.2b0.dev | skeleton |
-| [opentelemetry-instrumentation-genai-dspy](./instrumentation/opentelemetry-instrumentation-genai-dspy) | dspy >= 2.6.0, < 4 | 1.2b0.dev | skeleton |
+| [opentelemetry-instrumentation-genai-dspy](./instrumentation/opentelemetry-instrumentation-genai-dspy) | dspy >= 3.3.0, < 4 | 1.2b0.dev | skeleton |
 | [opentelemetry-instrumentation-genai-llama-index](./instrumentation/opentelemetry-instrumentation-genai-llama-index) | llama-index-core >= 0.14.19, < 1 | 1.2b0.dev | skeleton |
 | [opentelemetry-instrumentation-genai-portkey](./instrumentation/opentelemetry-instrumentation-genai-portkey) | portkey-ai >= 1.0.0, < 3 | 1.2b0.dev | to be released |
 | [opentelemetry-instrumentation-genai-weaviate-client](./instrumentation/opentelemetry-instrumentation-genai-weaviate-client) | weaviate-client >= 3.0.0, <5.0.0 | 1.2b0.dev | skeleton |

--- a/instrumentation/opentelemetry-instrumentation-genai-dspy/.changelog/529.added
+++ b/instrumentation/opentelemetry-instrumentation-genai-dspy/.changelog/529.added
@@ -1,0 +1,1 @@
+Add instrumentation for DSPy Tool execution and ReAct agent invocations.

--- a/instrumentation/opentelemetry-instrumentation-genai-dspy/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-genai-dspy/README.rst
@@ -6,10 +6,10 @@ OpenTelemetry DSPy Instrumentation
 .. |pypi| image:: https://badge.fury.io/py/opentelemetry-instrumentation-genai-dspy.svg
    :target: https://pypi.org/project/opentelemetry-instrumentation-genai-dspy/
 
-This package provides the setup for instrumenting the
-`DSPy framework <https://pypi.org/project/dspy/>`_ with OpenTelemetry
-Generative AI semantic conventions. DSPy operation instrumentation
-will be added in follow-up changes.
+This package provides OpenTelemetry instrumentation for the
+`DSPy framework <https://pypi.org/project/dspy/>`_, emitting Generative AI
+semantic conventions for DSPy Tool executions and ReAct agent loops
+(supporting both ``dspy.ReAct`` and ``dspy.ReActV2``).
 
 Installation
 ------------

--- a/instrumentation/opentelemetry-instrumentation-genai-dspy/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-genai-dspy/pyproject.toml
@@ -28,11 +28,11 @@ dependencies = [
   "opentelemetry-api ~= 1.43",
   "opentelemetry-instrumentation >= 0.64b0, <1",
   "opentelemetry-semantic-conventions >= 0.64b0, <1",
-  "opentelemetry-util-genai >= 1.1b0.dev, <2",
+  "opentelemetry-util-genai >= 1.2b0.dev, <2",
 ]
 
 [project.optional-dependencies]
-instruments = ["dspy >= 2.5.0, < 4"]
+instruments = ["dspy >= 2.6.0, < 4"]
 
 [project.entry-points.opentelemetry_instrumentor]
 dspy = "opentelemetry.instrumentation.genai.dspy:DSPyInstrumentor"

--- a/instrumentation/opentelemetry-instrumentation-genai-dspy/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-genai-dspy/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-instruments = ["dspy >= 2.6.0, < 4"]
+instruments = ["dspy >= 3.3.0, < 4"]
 
 [project.entry-points.opentelemetry_instrumentor]
 dspy = "opentelemetry.instrumentation.genai.dspy:DSPyInstrumentor"

--- a/instrumentation/opentelemetry-instrumentation-genai-dspy/src/opentelemetry/instrumentation/genai/dspy/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-dspy/src/opentelemetry/instrumentation/genai/dspy/__init__.py
@@ -9,6 +9,10 @@ from collections.abc import Collection
 from typing import Any
 
 from opentelemetry.instrumentation.genai.dspy.package import _instruments
+from opentelemetry.instrumentation.genai.dspy.patch import (
+    patch_dspy,
+    unpatch_dspy,
+)
 from opentelemetry.instrumentation.genai.dspy.version import __version__
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 from opentelemetry.util.genai.completion_hook import load_completion_hook
@@ -28,14 +32,14 @@ class DSPyInstrumentor(BaseInstrumentor):
         completion_hook = (
             kwargs.get("completion_hook") or load_completion_hook()
         )
-        TelemetryHandler(
+        handler = TelemetryHandler(
             tracer_provider=kwargs.get("tracer_provider"),
             meter_provider=kwargs.get("meter_provider"),
             logger_provider=kwargs.get("logger_provider"),
             completion_hook=completion_hook,
         )
-        # DSPy patching will be added in a follow-up change.
+        patch_dspy(handler)
 
     def _uninstrument(self, **kwargs: Any) -> None:
         """Disable DSPy instrumentation."""
-        # DSPy unpatching will be added in a follow-up change.
+        unpatch_dspy()

--- a/instrumentation/opentelemetry-instrumentation-genai-dspy/src/opentelemetry/instrumentation/genai/dspy/package.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-dspy/src/opentelemetry/instrumentation/genai/dspy/package.py
@@ -1,4 +1,4 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-_instruments = ("dspy >= 2.6.0, < 4",)
+_instruments = ("dspy >= 3.3.0, < 4",)

--- a/instrumentation/opentelemetry-instrumentation-genai-dspy/src/opentelemetry/instrumentation/genai/dspy/package.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-dspy/src/opentelemetry/instrumentation/genai/dspy/package.py
@@ -1,4 +1,4 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-_instruments = ("dspy >= 2.5.0, < 4",)
+_instruments = ("dspy >= 2.6.0, < 4",)

--- a/instrumentation/opentelemetry-instrumentation-genai-dspy/src/opentelemetry/instrumentation/genai/dspy/patch.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-dspy/src/opentelemetry/instrumentation/genai/dspy/patch.py
@@ -1,0 +1,279 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Patching functions for DSPy instrumentation."""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING, Any
+
+from wrapt import wrap_function_wrapper
+
+from opentelemetry.instrumentation.genai.dspy.utils import (
+    extract_input_content,
+    extract_output_content,
+    prepare_tool_definitions,
+)
+from opentelemetry.instrumentation.utils import unwrap
+from opentelemetry.util.genai.handler import TelemetryHandler
+from opentelemetry.util.genai.invocation import (
+    AgentInvocation,
+    ToolInvocation,
+)
+from opentelemetry.util.genai.types import (
+    InputMessage,
+    OutputMessage,
+    TextPart,
+)
+
+if TYPE_CHECKING:
+    from dspy.adapters.types.tool import Tool
+    from dspy.primitives.module import Module
+    from dspy.primitives.prediction import Prediction
+
+_REACT_MODULE = "dspy.predict.react"
+_REACT_CLASS = "ReAct"
+
+_REACT_V2_MODULE = "dspy.predict.react_v2"
+_REACT_V2_CLASS = "ReActV2"
+
+
+def patch_dspy(handler: TelemetryHandler) -> None:
+    """Apply patches to DSPy Tool and ReAct classes."""
+    import dspy
+    import dspy.predict.react
+
+    tool_module = dspy.Tool.__module__
+    tool_name = dspy.Tool.__name__
+    wrap_function_wrapper(
+        tool_module,
+        f"{tool_name}.__call__",
+        _tool_call(handler),
+    )
+    if hasattr(dspy.Tool, "acall"):
+        wrap_function_wrapper(
+            tool_module,
+            f"{tool_name}.acall",
+            _tool_acall(handler),
+        )
+
+    wrap_function_wrapper(
+        _REACT_MODULE,
+        f"{_REACT_CLASS}.forward",
+        _react_forward(handler, "dspy.ReAct"),
+    )
+    if hasattr(dspy.predict.react.ReAct, "aforward"):
+        wrap_function_wrapper(
+            _REACT_MODULE,
+            f"{_REACT_CLASS}.aforward",
+            _react_aforward(handler, "dspy.ReAct"),
+        )
+
+    # ReActV2 was added in DSPy 3.0+; earlier supported versions (2.6.x) do not ship this module.
+    try:
+        import dspy.predict.react_v2  # pylint: disable=import-outside-toplevel
+
+        react_v2_cls = getattr(dspy.predict.react_v2, "ReActV2", None)
+        if react_v2_cls is not None:
+            if hasattr(react_v2_cls, "forward"):
+                wrap_function_wrapper(
+                    _REACT_V2_MODULE,
+                    f"{_REACT_V2_CLASS}.forward",
+                    _react_forward(handler, "dspy.ReActV2"),
+                )
+            if "aforward" in getattr(react_v2_cls, "__dict__", {}):
+                wrap_function_wrapper(
+                    _REACT_V2_MODULE,
+                    f"{_REACT_V2_CLASS}.aforward",
+                    _react_aforward(handler, "dspy.ReActV2"),
+                )
+    except (ImportError, AttributeError):
+        pass
+
+
+def unpatch_dspy() -> None:
+    """Remove patches from DSPy classes."""
+    import dspy
+    import dspy.predict.react
+
+    unwrap(dspy.Tool, "__call__")
+    if hasattr(dspy.Tool, "acall"):
+        unwrap(dspy.Tool, "acall")
+
+    unwrap(dspy.predict.react.ReAct, "forward")
+    if hasattr(dspy.predict.react.ReAct, "aforward"):
+        unwrap(dspy.predict.react.ReAct, "aforward")
+
+    # ReActV2 was added in DSPy 3.0+; earlier supported versions (2.6.x) do not ship this module.
+    try:
+        import dspy.predict.react_v2  # pylint: disable=import-outside-toplevel
+
+        react_v2_cls = getattr(dspy.predict.react_v2, "ReActV2", None)
+        if react_v2_cls is not None:
+            unwrap(react_v2_cls, "forward")
+            if "aforward" in getattr(react_v2_cls, "__dict__", {}):
+                unwrap(react_v2_cls, "aforward")
+    except (ImportError, AttributeError):
+        pass
+
+
+def _extract_tool_arguments(
+    instance: Tool,
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+) -> Any:
+    func: Any = getattr(instance, "func", None)
+    if func is not None and callable(func):
+        try:
+            sig = inspect.signature(func)
+            bound = sig.bind(*args, **kwargs)
+            bound.apply_defaults()
+            return dict(bound.arguments)
+        except (TypeError, ValueError):
+            pass
+
+    if args and kwargs:
+        return {"args": list(args), "kwargs": kwargs}
+    if kwargs:
+        return kwargs
+    if args:
+        return list(args)
+    return None
+
+
+def _start_tool_invocation(
+    handler: TelemetryHandler,
+    instance: Tool,
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+) -> ToolInvocation:
+    tool_name: Any = getattr(instance, "name", None)
+    if not tool_name:
+        func: Any = getattr(instance, "func", None)
+        tool_name = getattr(func, "__name__", None)
+    if not tool_name:
+        tool_name = "tool"
+
+    tool_desc: Any = getattr(instance, "desc", None) or getattr(
+        instance, "description", None
+    )
+
+    invocation = handler.tool(
+        name=str(tool_name),
+        tool_type="function",
+        tool_description=str(tool_desc) if tool_desc is not None else None,
+    )
+    invocation.arguments = _extract_tool_arguments(instance, args, kwargs)
+    return invocation
+
+
+def _tool_call(handler: TelemetryHandler) -> Callable[..., Any]:
+    def traced_method(
+        wrapped: Callable[..., Any],
+        instance: Tool,
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+    ) -> Any:
+        invocation = _start_tool_invocation(handler, instance, args, kwargs)
+        with invocation:
+            result = wrapped(*args, **kwargs)
+            invocation.tool_result = result
+            return result
+
+    return traced_method
+
+
+def _tool_acall(handler: TelemetryHandler) -> Callable[..., Any]:
+    async def traced_method(
+        wrapped: Callable[..., Awaitable[Any]],
+        instance: Tool,
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+    ) -> Any:
+        invocation = _start_tool_invocation(handler, instance, args, kwargs)
+        with invocation:
+            result = await wrapped(*args, **kwargs)
+            invocation.tool_result = result
+            return result
+
+    return traced_method
+
+
+def _start_agent_invocation(
+    handler: TelemetryHandler,
+    instance: Module,
+    kwargs: dict[str, Any],
+    agent_name: str,
+) -> AgentInvocation:
+    invocation = handler.invoke_local_agent(agent_name=agent_name)
+    if kwargs:
+        content_str = extract_input_content(kwargs)
+        invocation.input_messages = [
+            InputMessage(role="user", parts=[TextPart(content=content_str)])
+        ]
+
+    tools: Any = getattr(instance, "tools", None)
+    invocation.tool_definitions = prepare_tool_definitions(tools)
+    return invocation
+
+
+def _set_agent_invocation_output(
+    invocation: AgentInvocation,
+    instance: Module,
+    result: Prediction | None,
+) -> None:
+    signature: Any = getattr(instance, "signature", None)
+    output_str = extract_output_content(result, signature)
+    invocation.output_messages = [
+        OutputMessage(
+            role="assistant",
+            parts=[TextPart(content=output_str)],
+            finish_reason="stop",
+        )
+    ]
+
+
+def _react_forward(
+    handler: TelemetryHandler,
+    agent_name: str,
+) -> Callable[..., Any]:
+    def traced_method(
+        wrapped: Callable[..., Any],
+        instance: Module,
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+    ) -> Any:
+        combined_kwargs = dict(kwargs)
+        invocation = _start_agent_invocation(
+            handler, instance, combined_kwargs, agent_name
+        )
+        with invocation:
+            result = wrapped(*args, **kwargs)
+            _set_agent_invocation_output(invocation, instance, result)
+            return result
+
+    return traced_method
+
+
+def _react_aforward(
+    handler: TelemetryHandler,
+    agent_name: str,
+) -> Callable[..., Any]:
+    async def traced_method(
+        wrapped: Callable[..., Awaitable[Any]],
+        instance: Module,
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+    ) -> Any:
+        combined_kwargs = dict(kwargs)
+        invocation = _start_agent_invocation(
+            handler, instance, combined_kwargs, agent_name
+        )
+        with invocation:
+            result = await wrapped(*args, **kwargs)
+            _set_agent_invocation_output(invocation, instance, result)
+            return result
+
+    return traced_method

--- a/instrumentation/opentelemetry-instrumentation-genai-dspy/src/opentelemetry/instrumentation/genai/dspy/patch.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-dspy/src/opentelemetry/instrumentation/genai/dspy/patch.py
@@ -6,12 +6,14 @@
 from __future__ import annotations
 
 import inspect
+import sys
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Any
 
 from wrapt import wrap_function_wrapper
 
 from opentelemetry.instrumentation.genai.dspy.utils import (
+    SENTINEL_TOOL_NAMES,
     extract_input_content,
     extract_output_content,
     prepare_tool_definitions,
@@ -43,7 +45,6 @@ _REACT_V2_CLASS = "ReActV2"
 def patch_dspy(handler: TelemetryHandler) -> None:
     """Apply patches to DSPy Tool and ReAct classes."""
     import dspy
-    import dspy.predict.react
 
     tool_module = dspy.Tool.__module__
     tool_name = dspy.Tool.__name__
@@ -52,45 +53,37 @@ def patch_dspy(handler: TelemetryHandler) -> None:
         f"{tool_name}.__call__",
         _tool_call(handler),
     )
-    if hasattr(dspy.Tool, "acall"):
-        wrap_function_wrapper(
-            tool_module,
-            f"{tool_name}.acall",
-            _tool_acall(handler),
-        )
+    wrap_function_wrapper(
+        tool_module,
+        f"{tool_name}.acall",
+        _tool_acall(handler),
+    )
 
     wrap_function_wrapper(
         _REACT_MODULE,
         f"{_REACT_CLASS}.forward",
         _react_forward(handler, "dspy.ReAct"),
     )
-    if hasattr(dspy.predict.react.ReAct, "aforward"):
+    wrap_function_wrapper(
+        _REACT_MODULE,
+        f"{_REACT_CLASS}.aforward",
+        _react_aforward(handler, "dspy.ReAct"),
+    )
+
+    wrap_function_wrapper(
+        _REACT_V2_MODULE,
+        f"{_REACT_V2_CLASS}.forward",
+        _react_forward(handler, "dspy.ReActV2"),
+    )
+    react_v2_cls = getattr(
+        sys.modules.get(_REACT_V2_MODULE), _REACT_V2_CLASS, None
+    )
+    if react_v2_cls is not None and hasattr(react_v2_cls, "aforward"):
         wrap_function_wrapper(
-            _REACT_MODULE,
-            f"{_REACT_CLASS}.aforward",
-            _react_aforward(handler, "dspy.ReAct"),
+            _REACT_V2_MODULE,
+            f"{_REACT_V2_CLASS}.aforward",
+            _react_aforward(handler, "dspy.ReActV2"),
         )
-
-    # ReActV2 was added in DSPy 3.0+; earlier supported versions (2.6.x) do not ship this module.
-    try:
-        import dspy.predict.react_v2  # pylint: disable=import-outside-toplevel
-
-        react_v2_cls = getattr(dspy.predict.react_v2, "ReActV2", None)
-        if react_v2_cls is not None:
-            if hasattr(react_v2_cls, "forward"):
-                wrap_function_wrapper(
-                    _REACT_V2_MODULE,
-                    f"{_REACT_V2_CLASS}.forward",
-                    _react_forward(handler, "dspy.ReActV2"),
-                )
-            if "aforward" in getattr(react_v2_cls, "__dict__", {}):
-                wrap_function_wrapper(
-                    _REACT_V2_MODULE,
-                    f"{_REACT_V2_CLASS}.aforward",
-                    _react_aforward(handler, "dspy.ReActV2"),
-                )
-    except (ImportError, AttributeError):
-        pass
 
 
 def unpatch_dspy() -> None:
@@ -99,48 +92,41 @@ def unpatch_dspy() -> None:
     import dspy.predict.react
 
     unwrap(dspy.Tool, "__call__")
-    if hasattr(dspy.Tool, "acall"):
-        unwrap(dspy.Tool, "acall")
+    unwrap(dspy.Tool, "acall")
 
     unwrap(dspy.predict.react.ReAct, "forward")
-    if hasattr(dspy.predict.react.ReAct, "aforward"):
-        unwrap(dspy.predict.react.ReAct, "aforward")
+    unwrap(dspy.predict.react.ReAct, "aforward")
 
-    # ReActV2 was added in DSPy 3.0+; earlier supported versions (2.6.x) do not ship this module.
-    try:
-        import dspy.predict.react_v2  # pylint: disable=import-outside-toplevel
-
-        react_v2_cls = getattr(dspy.predict.react_v2, "ReActV2", None)
-        if react_v2_cls is not None:
-            unwrap(react_v2_cls, "forward")
-            if "aforward" in getattr(react_v2_cls, "__dict__", {}):
-                unwrap(react_v2_cls, "aforward")
-    except (ImportError, AttributeError):
-        pass
+    unwrap(f"{_REACT_V2_MODULE}.{_REACT_V2_CLASS}", "forward")
+    unwrap(f"{_REACT_V2_MODULE}.{_REACT_V2_CLASS}", "aforward")
 
 
 def _extract_tool_arguments(
     instance: Tool,
     args: tuple[Any, ...],
     kwargs: dict[str, Any],
-) -> Any:
+) -> dict[str, Any] | None:
     func: Any = getattr(instance, "func", None)
     if func is not None and callable(func):
         try:
             sig = inspect.signature(func)
-            bound = sig.bind(*args, **kwargs)
+            bound = sig.bind_partial(*args, **kwargs)
             bound.apply_defaults()
             return dict(bound.arguments)
         except (TypeError, ValueError):
             pass
 
-    if args and kwargs:
-        return {"args": list(args), "kwargs": dict(kwargs)}
-    if kwargs:
+    if kwargs and not args:
         return dict(kwargs)
-    if args:
-        return list(args)
     return None
+
+
+def _get_tool_name(instance: Tool) -> str:
+    tool_name: Any = getattr(instance, "name", None)
+    if not tool_name:
+        func: Any = getattr(instance, "func", None)
+        tool_name = getattr(func, "__name__", None)
+    return str(tool_name) if tool_name else "tool"
 
 
 def _start_tool_invocation(
@@ -149,23 +135,20 @@ def _start_tool_invocation(
     args: tuple[Any, ...],
     kwargs: dict[str, Any],
 ) -> ToolInvocation:
-    tool_name: Any = getattr(instance, "name", None)
-    if not tool_name:
-        func: Any = getattr(instance, "func", None)
-        tool_name = getattr(func, "__name__", None)
-    if not tool_name:
-        tool_name = "tool"
+    tool_name = _get_tool_name(instance)
 
     tool_desc: Any = getattr(instance, "desc", None) or getattr(
         instance, "description", None
     )
 
     invocation = handler.tool(
-        name=str(tool_name),
+        name=tool_name,
         tool_type="function",
-        tool_description=str(tool_desc) if tool_desc is not None else None,
     )
-    invocation.arguments = _extract_tool_arguments(instance, args, kwargs)
+    if tool_desc is not None:
+        invocation.tool_description = str(tool_desc)
+    if handler.should_capture_content():
+        invocation.arguments = _extract_tool_arguments(instance, args, kwargs)
     return invocation
 
 
@@ -176,10 +159,14 @@ def _tool_call(handler: TelemetryHandler) -> Callable[..., Any]:
         args: tuple[Any, ...],
         kwargs: dict[str, Any],
     ) -> Any:
+        if _get_tool_name(instance) in SENTINEL_TOOL_NAMES:
+            return wrapped(*args, **kwargs)
+
         invocation = _start_tool_invocation(handler, instance, args, kwargs)
         with invocation:
             result = wrapped(*args, **kwargs)
-            invocation.tool_result = result
+            if handler.should_capture_content():
+                invocation.tool_result = result
             return result
 
     return traced_method
@@ -192,10 +179,14 @@ def _tool_acall(handler: TelemetryHandler) -> Callable[..., Any]:
         args: tuple[Any, ...],
         kwargs: dict[str, Any],
     ) -> Any:
+        if _get_tool_name(instance) in SENTINEL_TOOL_NAMES:
+            return await wrapped(*args, **kwargs)
+
         invocation = _start_tool_invocation(handler, instance, args, kwargs)
         with invocation:
             result = await wrapped(*args, **kwargs)
-            invocation.tool_result = result
+            if handler.should_capture_content():
+                invocation.tool_result = result
             return result
 
     return traced_method
@@ -208,7 +199,7 @@ def _start_agent_invocation(
     agent_name: str,
 ) -> AgentInvocation:
     invocation = handler.invoke_local_agent(agent_name=agent_name)
-    if kwargs:
+    if handler.should_capture_content() and kwargs:
         content_str = extract_input_content(kwargs)
         invocation.input_messages = [
             InputMessage(role="user", parts=[TextPart(content=content_str)])
@@ -250,7 +241,8 @@ def _react_forward(
         )
         with invocation:
             result = wrapped(*args, **kwargs)
-            _set_agent_invocation_output(invocation, instance, result)
+            if handler.should_capture_content():
+                _set_agent_invocation_output(invocation, instance, result)
             return result
 
     return traced_method
@@ -271,7 +263,8 @@ def _react_aforward(
         )
         with invocation:
             result = await wrapped(*args, **kwargs)
-            _set_agent_invocation_output(invocation, instance, result)
+            if handler.should_capture_content():
+                _set_agent_invocation_output(invocation, instance, result)
             return result
 
     return traced_method

--- a/instrumentation/opentelemetry-instrumentation-genai-dspy/src/opentelemetry/instrumentation/genai/dspy/patch.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-dspy/src/opentelemetry/instrumentation/genai/dspy/patch.py
@@ -135,9 +135,9 @@ def _extract_tool_arguments(
             pass
 
     if args and kwargs:
-        return {"args": list(args), "kwargs": kwargs}
+        return {"args": list(args), "kwargs": dict(kwargs)}
     if kwargs:
-        return kwargs
+        return dict(kwargs)
     if args:
         return list(args)
     return None
@@ -245,9 +245,8 @@ def _react_forward(
         args: tuple[Any, ...],
         kwargs: dict[str, Any],
     ) -> Any:
-        combined_kwargs = dict(kwargs)
         invocation = _start_agent_invocation(
-            handler, instance, combined_kwargs, agent_name
+            handler, instance, dict(kwargs), agent_name
         )
         with invocation:
             result = wrapped(*args, **kwargs)
@@ -267,9 +266,8 @@ def _react_aforward(
         args: tuple[Any, ...],
         kwargs: dict[str, Any],
     ) -> Any:
-        combined_kwargs = dict(kwargs)
         invocation = _start_agent_invocation(
-            handler, instance, combined_kwargs, agent_name
+            handler, instance, dict(kwargs), agent_name
         )
         with invocation:
             result = await wrapped(*args, **kwargs)

--- a/instrumentation/opentelemetry-instrumentation-genai-dspy/src/opentelemetry/instrumentation/genai/dspy/patch.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-dspy/src/opentelemetry/instrumentation/genai/dspy/patch.py
@@ -70,20 +70,21 @@ def patch_dspy(handler: TelemetryHandler) -> None:
         _react_aforward(handler, "dspy.ReAct"),
     )
 
-    wrap_function_wrapper(
-        _REACT_V2_MODULE,
-        f"{_REACT_V2_CLASS}.forward",
-        _react_forward(handler, "dspy.ReActV2"),
-    )
     react_v2_cls = getattr(
         sys.modules.get(_REACT_V2_MODULE), _REACT_V2_CLASS, None
     )
-    if react_v2_cls is not None and hasattr(react_v2_cls, "aforward"):
+    if react_v2_cls is not None:
         wrap_function_wrapper(
             _REACT_V2_MODULE,
-            f"{_REACT_V2_CLASS}.aforward",
-            _react_aforward(handler, "dspy.ReActV2"),
+            f"{_REACT_V2_CLASS}.forward",
+            _react_forward(handler, "dspy.ReActV2"),
         )
+        if hasattr(react_v2_cls, "aforward"):
+            wrap_function_wrapper(
+                _REACT_V2_MODULE,
+                f"{_REACT_V2_CLASS}.aforward",
+                _react_aforward(handler, "dspy.ReActV2"),
+            )
 
 
 def unpatch_dspy() -> None:
@@ -97,8 +98,12 @@ def unpatch_dspy() -> None:
     unwrap(dspy.predict.react.ReAct, "forward")
     unwrap(dspy.predict.react.ReAct, "aforward")
 
-    unwrap(f"{_REACT_V2_MODULE}.{_REACT_V2_CLASS}", "forward")
-    unwrap(f"{_REACT_V2_MODULE}.{_REACT_V2_CLASS}", "aforward")
+    react_v2_cls = getattr(
+        sys.modules.get(_REACT_V2_MODULE), _REACT_V2_CLASS, None
+    )
+    if react_v2_cls is not None:
+        unwrap(react_v2_cls, "forward")
+        unwrap(react_v2_cls, "aforward")
 
 
 def _extract_tool_arguments(

--- a/instrumentation/opentelemetry-instrumentation-genai-dspy/src/opentelemetry/instrumentation/genai/dspy/utils.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-dspy/src/opentelemetry/instrumentation/genai/dspy/utils.py
@@ -68,7 +68,11 @@ def extract_output_content(
                     filtered_dict[key_str] = output_dict[key_str]
         if not filtered_dict:
             for k_str, v_val in output_dict.items():
-                if k_str not in ("trajectory", "history", "termination_reason"):
+                if k_str not in (
+                    "trajectory",
+                    "history",
+                    "termination_reason",
+                ):
                     filtered_dict[k_str] = v_val
 
         if filtered_dict:

--- a/instrumentation/opentelemetry-instrumentation-genai-dspy/src/opentelemetry/instrumentation/genai/dspy/utils.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-dspy/src/opentelemetry/instrumentation/genai/dspy/utils.py
@@ -1,0 +1,141 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Utility functions for DSPy instrumentation."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from typing import TYPE_CHECKING, Any, cast
+
+from opentelemetry.util.genai.types import (
+    FunctionToolDefinition,
+    ToolDefinition,
+)
+
+if TYPE_CHECKING:
+    from dspy.adapters.types.tool import Tool
+    from dspy.primitives.prediction import Prediction
+
+
+def extract_input_content(input_args: dict[str, Any]) -> str:
+    """Extract input content string from agent invocation arguments."""
+    if not input_args:
+        return ""
+    if len(input_args) == 1:
+        val: Any = next(iter(input_args.values()))
+        if isinstance(val, str):
+            return val
+        if isinstance(val, (int, float, bool)):
+            return str(val)
+        try:
+            return json.dumps(val, ensure_ascii=False)
+        except Exception:
+            return str(val)
+    try:
+        return json.dumps(input_args, ensure_ascii=False)
+    except Exception:
+        return str(input_args)
+
+
+def extract_output_content(
+    result: Prediction | None,
+    signature: Any = None,
+) -> str:
+    """Extract output content string from a DSPy prediction result."""
+    if result is None:
+        return ""
+
+    output_dict: dict[str, Any] = {}
+    if hasattr(result, "items") and callable(getattr(result, "items")):
+        try:
+            items_func: Callable[[], Any] = getattr(result, "items")
+            for k, v in cast(Iterable[tuple[Any, Any]], items_func()):
+                output_dict[str(k)] = v
+        except Exception:
+            pass
+
+    if output_dict:
+        filtered_dict: dict[str, Any] = {}
+        output_fields: Any = (
+            getattr(signature, "output_fields", None) if signature else None
+        )
+        if isinstance(output_fields, (dict, list, set, tuple)):
+            for key in cast(Iterable[Any], output_fields):
+                key_str = str(key)
+                if key_str in output_dict:
+                    filtered_dict[key_str] = output_dict[key_str]
+        if not filtered_dict:
+            for k_str, v_val in output_dict.items():
+                if k_str not in ("trajectory", "history", "termination_reason"):
+                    filtered_dict[k_str] = v_val
+
+        if filtered_dict:
+            if len(filtered_dict) == 1:
+                val: Any = next(iter(filtered_dict.values()))
+                if isinstance(val, str):
+                    return val
+                if isinstance(val, (int, float, bool)):
+                    return str(val)
+                try:
+                    return json.dumps(val, ensure_ascii=False)
+                except Exception:
+                    return str(val)
+            try:
+                return json.dumps(filtered_dict, ensure_ascii=False)
+            except Exception:
+                return str(filtered_dict)
+
+    return str(result)
+
+
+def prepare_tool_definitions(
+    tools: Sequence[Tool | Callable[..., Any]]
+    | Mapping[str, Tool | Callable[..., Any]]
+    | None,
+) -> list[ToolDefinition] | None:
+    """Prepare FunctionToolDefinition instances from a tools collection."""
+    if not tools:
+        return None
+
+    if isinstance(tools, Mapping):
+        tool_items = list(tools.values())
+    elif isinstance(tools, (list, tuple, set)):
+        tool_items = list(tools)
+    else:
+        return None
+
+    definitions: list[ToolDefinition] = []
+    for tool in tool_items:
+        tool_name = getattr(tool, "name", None)
+        if not tool_name:
+            func = getattr(tool, "func", None)
+            tool_name = (
+                getattr(func, "__name__", None)
+                if func
+                else getattr(tool, "__name__", None)
+            )
+        if not tool_name:
+            tool_name = "tool"
+
+        name_str = str(tool_name)
+        if name_str in ("finish", "submit"):
+            continue
+
+        desc = (
+            getattr(tool, "desc", None)
+            or getattr(tool, "description", None)
+            or getattr(tool, "__doc__", None)
+        )
+        args_schema = getattr(tool, "args", None)
+
+        definitions.append(
+            FunctionToolDefinition(
+                name=name_str,
+                description=str(desc).strip() if desc is not None else None,
+                parameters=args_schema,
+            )
+        )
+
+    return definitions or None

--- a/instrumentation/opentelemetry-instrumentation-genai-dspy/src/opentelemetry/instrumentation/genai/dspy/utils.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-dspy/src/opentelemetry/instrumentation/genai/dspy/utils.py
@@ -18,6 +18,8 @@ if TYPE_CHECKING:
     from dspy.adapters.types.tool import Tool
     from dspy.primitives.prediction import Prediction
 
+SENTINEL_TOOL_NAMES: frozenset[str] = frozenset({"finish", "submit"})
+
 
 def extract_input_content(input_args: dict[str, Any]) -> str:
     """Extract input content string from agent invocation arguments."""
@@ -124,7 +126,7 @@ def prepare_tool_definitions(
             tool_name = "tool"
 
         name_str = str(tool_name)
-        if name_str in ("finish", "submit"):
+        if name_str in SENTINEL_TOOL_NAMES:
             continue
 
         desc = (

--- a/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/conformance/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/conformance/__init__.py
@@ -1,0 +1,2 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0

--- a/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/conformance/react.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/conformance/react.py
@@ -1,0 +1,83 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Conformance scenario: basic ReAct agent run with tool execution for DSPy."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import dspy
+
+from opentelemetry.instrumentation.genai.dspy import DSPyInstrumentor
+from opentelemetry.sdk._logs import LoggerProvider
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.test_util_genai.conformance import (
+    ExpectedViolation,
+    Scenario,
+)
+from opentelemetry.test_util_genai.instrumentor import instrument
+
+
+def add(x: int, y: int) -> int:
+    """Add two numbers."""
+    return x + y
+
+
+class MockSyncPredict:
+    def __init__(self) -> None:
+        self.count = 0
+
+    def __call__(self, **kwargs: object) -> object:
+        self.count += 1
+
+        class Pred:
+            next_thought = "Need to calculate 2 + 2"
+            next_tool_name = "add"
+            next_tool_args = {"x": 2, "y": 2}
+
+        class FinishPred:
+            next_thought = "Done calculation"
+            next_tool_name = "finish"
+            next_tool_args = {}
+
+        return Pred() if self.count == 1 else FinishPred()
+
+
+class MockExtract:
+    def __call__(self, **kwargs: object) -> dict[str, str]:
+        return {"answer": "4"}
+
+
+class ReActScenario(Scenario):
+    expected_spans = {"invoke_agent": 1, "execute_tool": 2}
+    expected_metrics = ("gen_ai.client.operation.duration",)
+    expected_violations = (
+        ExpectedViolation(
+            advice_id="genai_expected_attribute_missing",
+            message_substring="gen_ai.tool.call.id",
+        ),
+    )
+
+    def run(
+        self,
+        *,
+        tracer_provider: TracerProvider,
+        meter_provider: MeterProvider,
+        logger_provider: LoggerProvider,
+        vcr: Any,
+    ) -> None:
+        with instrument(
+            DSPyInstrumentor(),
+            tracer_provider=tracer_provider,
+            logger_provider=logger_provider,
+            meter_provider=meter_provider,
+            content_capture="SPAN_ONLY",
+        ):
+            tool = dspy.Tool(add, name="add", desc="Add two numbers.")
+            react = dspy.ReAct("question -> answer", tools=[tool])
+            react.react = MockSyncPredict()
+            react.extract = MockExtract()
+
+            react(question="What is 2 + 2?")

--- a/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/conformance/react_v2.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/conformance/react_v2.py
@@ -1,14 +1,14 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Conformance scenario: basic ReAct agent run with tool execution for DSPy."""
+"""Conformance scenario: basic ReActV2 agent run with tool execution for DSPy."""
 
 from __future__ import annotations
 
 from typing import Any
 
 import dspy
-
+from dspy.adapters.types.tool import ToolCalls
 from opentelemetry.instrumentation.genai.dspy import DSPyInstrumentor
 from opentelemetry.sdk._logs import LoggerProvider
 from opentelemetry.sdk.metrics import MeterProvider
@@ -25,32 +25,37 @@ def add(x: int, y: int) -> int:
     return x + y
 
 
-class MockSyncPredict:
+class MockSyncPredictV2:
     def __init__(self) -> None:
         self.count = 0
 
     def __call__(self, **kwargs: object) -> object:
         self.count += 1
 
-        class Pred:
-            next_thought = "Need to calculate 2 + 2"
-            next_tool_name = "add"
-            next_tool_args = {"x": 2, "y": 2}
+        class CallPred:
+            next_thought = "Add 2 and 2"
+            tool_calls = ToolCalls(
+                tool_calls=[
+                    ToolCalls.ToolCall(
+                        id="call_1", name="add", args={"x": 2, "y": 2}
+                    )
+                ]
+            )
 
-        class FinishPred:
-            next_thought = "Done calculation"
-            next_tool_name = "finish"
-            next_tool_args = {}
+        class SubmitPred:
+            next_thought = "Submit answer"
+            tool_calls = ToolCalls(
+                tool_calls=[
+                    ToolCalls.ToolCall(
+                        id="call_2", name="submit", args={"answer": "4"}
+                    )
+                ]
+            )
 
-        return Pred() if self.count == 1 else FinishPred()
+        return CallPred() if self.count == 1 else SubmitPred()
 
 
-class MockExtract:
-    def __call__(self, **kwargs: object) -> dict[str, str]:
-        return {"answer": "4"}
-
-
-class ReActScenario(Scenario):
+class ReActV2Scenario(Scenario):
     expected_spans = {"invoke_agent": 1, "execute_tool": 1}
     expected_metrics = ("gen_ai.client.operation.duration",)
     expected_violations = (
@@ -75,9 +80,6 @@ class ReActScenario(Scenario):
             meter_provider=meter_provider,
             content_capture="SPAN_ONLY",
         ):
-            tool = dspy.Tool(add, name="add", desc="Add two numbers.")
-            react = dspy.ReAct("question -> answer", tools=[tool])
-            react.react = MockSyncPredict()
-            react.extract = MockExtract()
-
-            react(question="What is 2 + 2?")
+            react_v2 = dspy.ReActV2("question -> answer", tools=[add])
+            react_v2.react = MockSyncPredictV2()
+            react_v2(question="What is 2 + 2?")

--- a/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/conformance/react_v2.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/conformance/react_v2.py
@@ -9,6 +9,7 @@ from typing import Any
 
 import dspy
 from dspy.adapters.types.tool import ToolCalls
+
 from opentelemetry.instrumentation.genai.dspy import DSPyInstrumentor
 from opentelemetry.sdk._logs import LoggerProvider
 from opentelemetry.sdk.metrics import MeterProvider

--- a/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/conformance/tool.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/conformance/tool.py
@@ -1,0 +1,56 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Conformance scenario: standalone tool execution for DSPy."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import dspy
+
+from opentelemetry.instrumentation.genai.dspy import DSPyInstrumentor
+from opentelemetry.sdk._logs import LoggerProvider
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.test_util_genai.conformance import (
+    ExpectedViolation,
+    Scenario,
+)
+from opentelemetry.test_util_genai.instrumentor import instrument
+
+
+def multiply(a: int, b: int) -> int:
+    """Multiply two numbers."""
+    return a * b
+
+
+class ToolScenario(Scenario):
+    expected_spans = {"execute_tool": 1}
+    expected_metrics = ("gen_ai.client.operation.duration",)
+    expected_violations = (
+        ExpectedViolation(
+            advice_id="genai_expected_attribute_missing",
+            message_substring="gen_ai.tool.call.id",
+        ),
+    )
+
+    def run(
+        self,
+        *,
+        tracer_provider: TracerProvider,
+        meter_provider: MeterProvider,
+        logger_provider: LoggerProvider,
+        vcr: Any,
+    ) -> None:
+        with instrument(
+            DSPyInstrumentor(),
+            tracer_provider=tracer_provider,
+            logger_provider=logger_provider,
+            meter_provider=meter_provider,
+            content_capture="SPAN_ONLY",
+        ):
+            tool = dspy.Tool(
+                multiply, name="multiply", desc="Multiply two numbers."
+            )
+            tool(a=3, b=4)

--- a/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/requirements.oldest.txt
+++ b/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/requirements.oldest.txt
@@ -3,3 +3,6 @@
 
 # The oldest tox factor resolves declared dependencies from pyproject.toml
 # with UV_RESOLUTION=lowest-direct. There are no additional test-only pins.
+
+# Drop this once opentelemetry-util-genai 1.2b0 is published.
+-e util/opentelemetry-util-genai

--- a/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/test_conformance.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/test_conformance.py
@@ -21,12 +21,14 @@ from opentelemetry.test_util_genai.conformance import (
 )
 
 from .conformance.react import ReActScenario
+from .conformance.tool import ToolScenario
 
 
 @pytest.mark.parametrize(
     "scenario",
     [
         pytest.param(ReActScenario()),
+        pytest.param(ToolScenario()),
     ],
     ids=lambda s: type(s).__name__,
 )

--- a/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/test_conformance.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/test_conformance.py
@@ -1,0 +1,36 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Per-scenario conformance tests for DSPy."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+# Skip collection when weaver_live_check or OTLP exporters aren't installed
+# (non-conformance envs).
+pytest.importorskip("opentelemetry.test.weaver_live_check")
+pytest.importorskip("opentelemetry.exporter.otlp.proto.grpc")
+
+from opentelemetry.test.weaver_live_check import WeaverLiveCheck
+from opentelemetry.test_util_genai.conformance import (
+    Scenario,
+    run_conformance,
+)
+
+from .conformance.react import ReActScenario
+
+
+@pytest.mark.parametrize(
+    "scenario",
+    [
+        pytest.param(ReActScenario()),
+    ],
+    ids=lambda s: type(s).__name__,
+)
+def test_conformance(
+    scenario: Scenario, vcr: Any, weaver_live_check: WeaverLiveCheck
+) -> None:
+    run_conformance(scenario, vcr=vcr, weaver=weaver_live_check)

--- a/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/test_conformance.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/test_conformance.py
@@ -21,6 +21,7 @@ from opentelemetry.test_util_genai.conformance import (
 )
 
 from .conformance.react import ReActScenario
+from .conformance.react_v2 import ReActV2Scenario
 from .conformance.tool import ToolScenario
 
 
@@ -28,6 +29,7 @@ from .conformance.tool import ToolScenario
     "scenario",
     [
         pytest.param(ReActScenario()),
+        pytest.param(ReActV2Scenario()),
         pytest.param(ToolScenario()),
     ],
     ids=lambda s: type(s).__name__,

--- a/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/test_instrumentor.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/test_instrumentor.py
@@ -11,7 +11,7 @@ from opentelemetry.sdk.trace import TracerProvider
 
 def test_instrumentation_dependencies() -> None:
     assert DSPyInstrumentor().instrumentation_dependencies() == (
-        "dspy >= 2.6.0, < 4",
+        "dspy >= 3.3.0, < 4",
     )
 
 

--- a/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/test_instrumentor.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/test_instrumentor.py
@@ -11,7 +11,7 @@ from opentelemetry.sdk.trace import TracerProvider
 
 def test_instrumentation_dependencies() -> None:
     assert DSPyInstrumentor().instrumentation_dependencies() == (
-        "dspy >= 2.5.0, < 4",
+        "dspy >= 2.6.0, < 4",
     )
 
 

--- a/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/test_react.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/test_react.py
@@ -6,8 +6,9 @@
 from __future__ import annotations
 
 import json
-import pytest
+
 import dspy
+import pytest
 
 from opentelemetry.instrumentation.genai.dspy import DSPyInstrumentor
 from opentelemetry.sdk._logs import LoggerProvider
@@ -161,7 +162,9 @@ async def test_react_async_execution(
         meter_provider=meter_provider,
         content_capture="SPAN_ONLY",
     ):
-        tool = dspy.Tool(async_multiply, name="multiply", desc="Multiply numbers.")
+        tool = dspy.Tool(
+            async_multiply, name="multiply", desc="Multiply numbers."
+        )
         react = dspy.ReAct("question -> answer", tools=[tool])
         async_predict = MockAsyncPredict()
         react.react = async_predict

--- a/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/test_react.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/test_react.py
@@ -1,0 +1,250 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for DSPy ReAct (v1) agent instrumentation."""
+
+from __future__ import annotations
+
+import json
+import pytest
+import dspy
+
+from opentelemetry.instrumentation.genai.dspy import DSPyInstrumentor
+from opentelemetry.sdk._logs import LoggerProvider
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
+from opentelemetry.semconv._incubating.attributes import (
+    gen_ai_attributes as GenAI,
+)
+from opentelemetry.semconv.attributes import error_attributes
+from opentelemetry.test_util_genai.instrumentor import instrument
+from opentelemetry.trace import StatusCode
+
+
+def add(x: int, y: int) -> int:
+    """Add two numbers."""
+    return x + y
+
+
+async def async_multiply(a: int, b: int) -> int:
+    """Multiply two numbers."""
+    return a * b
+
+
+class MockSyncPredict:
+    def __init__(self) -> None:
+        self.count = 0
+
+    def __call__(self, **kwargs: object) -> object:
+        self.count += 1
+
+        class Pred:
+            next_thought = "Need to calculate 2 + 2"
+            next_tool_name = "add"
+            next_tool_args = {"x": 2, "y": 2}
+
+        class FinishPred:
+            next_thought = "Done calculation"
+            next_tool_name = "finish"
+            next_tool_args = {}
+
+        return Pred() if self.count == 1 else FinishPred()
+
+
+class MockAsyncPredict:
+    def __init__(self) -> None:
+        self.count = 0
+
+    async def acall(self, **kwargs: object) -> object:
+        self.count += 1
+
+        class Pred:
+            next_thought = "Need to multiply 3 and 5"
+            next_tool_name = "multiply"
+            next_tool_args = {"a": 3, "b": 5}
+
+        class FinishPred:
+            next_thought = "Done calculation"
+            next_tool_name = "finish"
+            next_tool_args = {}
+
+        return Pred() if self.count == 1 else FinishPred()
+
+
+class MockExtract:
+    def __call__(self, **kwargs: object) -> dict[str, str]:
+        return {"answer": "4"}
+
+    async def acall(self, **kwargs: object) -> dict[str, str]:
+        return {"answer": "15"}
+
+
+def test_react_sync_execution(
+    tracer_provider: TracerProvider,
+    logger_provider: LoggerProvider,
+    meter_provider: MeterProvider,
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    with instrument(
+        DSPyInstrumentor(),
+        tracer_provider=tracer_provider,
+        logger_provider=logger_provider,
+        meter_provider=meter_provider,
+        content_capture="SPAN_ONLY",
+    ):
+        tool = dspy.Tool(add, name="add", desc="Add two numbers.")
+        react = dspy.ReAct("question -> answer", tools=[tool])
+        react.react = MockSyncPredict()
+        react.extract = MockExtract()
+
+        res = react(question="What is 2 + 2?")
+        assert res.answer == "4"
+
+    spans = span_exporter.get_finished_spans()
+    # Expect 1 execute_tool add, 1 execute_tool finish, 1 invoke_agent dspy.ReAct
+    assert len(spans) == 3
+
+    agent_spans = [s for s in spans if s.name == "invoke_agent dspy.ReAct"]
+    tool_spans = [s for s in spans if s.name.startswith("execute_tool")]
+
+    assert len(agent_spans) == 1
+    agent_span = agent_spans[0]
+    assert agent_span.status.status_code == StatusCode.UNSET
+
+    agent_attrs = agent_span.attributes or {}
+    assert agent_attrs.get(GenAI.GEN_AI_OPERATION_NAME) == "invoke_agent"
+    assert agent_attrs.get(GenAI.GEN_AI_AGENT_NAME) == "dspy.ReAct"
+
+    # Verify input messages
+    input_msgs_raw = agent_attrs.get(GenAI.GEN_AI_INPUT_MESSAGES)
+    assert input_msgs_raw is not None
+    input_msgs = json.loads(str(input_msgs_raw))
+    assert input_msgs[0]["parts"][0]["content"] == "What is 2 + 2?"
+
+    # Verify output messages
+    output_msgs_raw = agent_attrs.get(GenAI.GEN_AI_OUTPUT_MESSAGES)
+    assert output_msgs_raw is not None
+    output_msgs = json.loads(str(output_msgs_raw))
+    assert output_msgs[0]["parts"][0]["content"] == "4"
+
+    # Verify tool definitions
+    tool_defs_raw = agent_attrs.get(GenAI.GEN_AI_TOOL_DEFINITIONS)
+    assert tool_defs_raw is not None
+    tool_defs = json.loads(str(tool_defs_raw))
+    assert any(t["name"] == "add" for t in tool_defs)
+
+    # Verify child tool spans reference agent span
+    assert len(tool_spans) == 2
+    for t_span in tool_spans:
+        assert t_span.parent is not None
+        assert t_span.parent.span_id == agent_span.context.span_id
+
+
+@pytest.mark.skipif(
+    not hasattr(dspy.ReAct, "aforward"),
+    reason="dspy.ReAct.aforward not available in this DSPy version",
+)
+@pytest.mark.anyio
+async def test_react_async_execution(
+    tracer_provider: TracerProvider,
+    logger_provider: LoggerProvider,
+    meter_provider: MeterProvider,
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    with instrument(
+        DSPyInstrumentor(),
+        tracer_provider=tracer_provider,
+        logger_provider=logger_provider,
+        meter_provider=meter_provider,
+        content_capture="SPAN_ONLY",
+    ):
+        tool = dspy.Tool(async_multiply, name="multiply", desc="Multiply numbers.")
+        react = dspy.ReAct("question -> answer", tools=[tool])
+        async_predict = MockAsyncPredict()
+        react.react = async_predict
+        react.react.acall = async_predict.acall
+        react.extract = MockExtract()
+        react.extract.acall = react.extract.acall
+
+        res = await react.aforward(question="What is 3 * 5?")
+        assert res.answer == "15"
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 3
+
+    agent_spans = [s for s in spans if s.name == "invoke_agent dspy.ReAct"]
+    assert len(agent_spans) == 1
+    agent_span = agent_spans[0]
+
+    agent_attrs = agent_span.attributes or {}
+    assert agent_attrs.get(GenAI.GEN_AI_OPERATION_NAME) == "invoke_agent"
+    assert agent_attrs.get(GenAI.GEN_AI_AGENT_NAME) == "dspy.ReAct"
+
+
+def test_react_no_content_capture(
+    tracer_provider: TracerProvider,
+    logger_provider: LoggerProvider,
+    meter_provider: MeterProvider,
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    with instrument(
+        DSPyInstrumentor(),
+        tracer_provider=tracer_provider,
+        logger_provider=logger_provider,
+        meter_provider=meter_provider,
+        content_capture="NO_CONTENT",
+    ):
+        tool = dspy.Tool(add, name="add", desc="Add two numbers.")
+        react = dspy.ReAct("question -> answer", tools=[tool])
+        react.react = MockSyncPredict()
+        react.extract = MockExtract()
+
+        res = react(question="What is 2 + 2?")
+        assert res.answer == "4"
+
+    spans = span_exporter.get_finished_spans()
+    agent_spans = [s for s in spans if s.name == "invoke_agent dspy.ReAct"]
+    assert len(agent_spans) == 1
+    agent_span = agent_spans[0]
+
+    attrs = agent_span.attributes or {}
+    assert GenAI.GEN_AI_INPUT_MESSAGES not in attrs
+    assert GenAI.GEN_AI_OUTPUT_MESSAGES not in attrs
+    assert attrs.get(GenAI.GEN_AI_AGENT_NAME) == "dspy.ReAct"
+
+
+def test_react_error_handling(
+    tracer_provider: TracerProvider,
+    logger_provider: LoggerProvider,
+    meter_provider: MeterProvider,
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    with instrument(
+        DSPyInstrumentor(),
+        tracer_provider=tracer_provider,
+        logger_provider=logger_provider,
+        meter_provider=meter_provider,
+        content_capture="SPAN_ONLY",
+    ):
+        tool = dspy.Tool(add, name="add", desc="Add two numbers.")
+        react = dspy.ReAct("question -> answer", tools=[tool])
+
+        class FailingPredict:
+            def __call__(self, **kwargs: object) -> object:
+                raise RuntimeError("Predict model failure")
+
+        react.react = FailingPredict()
+
+        with pytest.raises(RuntimeError, match="Predict model failure"):
+            react(question="What is 2 + 2?")
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.name == "invoke_agent dspy.ReAct"
+    assert span.status.status_code == StatusCode.ERROR
+    attrs = span.attributes or {}
+    assert attrs.get(error_attributes.ERROR_TYPE) == "RuntimeError"

--- a/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/test_react.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/test_react.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import json
+from unittest import mock
 
 import dspy
 import pytest
@@ -105,8 +106,8 @@ def test_react_sync_execution(
         assert res.answer == "4"
 
     spans = span_exporter.get_finished_spans()
-    # Expect 1 execute_tool add, 1 execute_tool finish, 1 invoke_agent dspy.ReAct
-    assert len(spans) == 3
+    # Expect 1 execute_tool add, 1 invoke_agent dspy.ReAct (finish sentinel skipped)
+    assert len(spans) == 2
 
     agent_spans = [s for s in spans if s.name == "invoke_agent dspy.ReAct"]
     tool_spans = [s for s in spans if s.name.startswith("execute_tool")]
@@ -137,17 +138,14 @@ def test_react_sync_execution(
     tool_defs = json.loads(str(tool_defs_raw))
     assert any(t["name"] == "add" for t in tool_defs)
 
-    # Verify child tool spans reference agent span
-    assert len(tool_spans) == 2
-    for t_span in tool_spans:
-        assert t_span.parent is not None
-        assert t_span.parent.span_id == agent_span.context.span_id
+    # Verify child tool spans reference agent span and finish is skipped
+    assert len(tool_spans) == 1
+    assert tool_spans[0].name == "execute_tool add"
+    assert not any(s.name == "execute_tool finish" for s in spans)
+    assert tool_spans[0].parent is not None
+    assert tool_spans[0].parent.span_id == agent_span.context.span_id
 
 
-@pytest.mark.skipif(
-    not hasattr(dspy.ReAct, "aforward"),
-    reason="dspy.ReAct.aforward not available in this DSPy version",
-)
 @pytest.mark.anyio
 async def test_react_async_execution(
     tracer_provider: TracerProvider,
@@ -174,11 +172,16 @@ async def test_react_async_execution(
         assert res.answer == "15"
 
     spans = span_exporter.get_finished_spans()
-    assert len(spans) == 3
+    assert len(spans) == 2
 
     agent_spans = [s for s in spans if s.name == "invoke_agent dspy.ReAct"]
     assert len(agent_spans) == 1
     agent_span = agent_spans[0]
+
+    tool_spans = [s for s in spans if s.name.startswith("execute_tool")]
+    assert len(tool_spans) == 1
+    assert tool_spans[0].name == "execute_tool multiply"
+    assert not any(s.name == "execute_tool finish" for s in spans)
 
     agent_attrs = agent_span.attributes or {}
     assert agent_attrs.get(GenAI.GEN_AI_OPERATION_NAME) == "invoke_agent"
@@ -191,20 +194,30 @@ def test_react_no_content_capture(
     meter_provider: MeterProvider,
     span_exporter: InMemorySpanExporter,
 ) -> None:
-    with instrument(
-        DSPyInstrumentor(),
-        tracer_provider=tracer_provider,
-        logger_provider=logger_provider,
-        meter_provider=meter_provider,
-        content_capture="NO_CONTENT",
+    with (
+        mock.patch(
+            "opentelemetry.instrumentation.genai.dspy.patch.extract_input_content"
+        ) as mock_input_extract,
+        mock.patch(
+            "opentelemetry.instrumentation.genai.dspy.patch.extract_output_content"
+        ) as mock_output_extract,
     ):
-        tool = dspy.Tool(add, name="add", desc="Add two numbers.")
-        react = dspy.ReAct("question -> answer", tools=[tool])
-        react.react = MockSyncPredict()
-        react.extract = MockExtract()
+        with instrument(
+            DSPyInstrumentor(),
+            tracer_provider=tracer_provider,
+            logger_provider=logger_provider,
+            meter_provider=meter_provider,
+            content_capture="NO_CONTENT",
+        ):
+            tool = dspy.Tool(add, name="add", desc="Add two numbers.")
+            react = dspy.ReAct("question -> answer", tools=[tool])
+            react.react = MockSyncPredict()
+            react.extract = MockExtract()
 
-        res = react(question="What is 2 + 2?")
-        assert res.answer == "4"
+            res = react(question="What is 2 + 2?")
+            assert res.answer == "4"
+        mock_input_extract.assert_not_called()
+        mock_output_extract.assert_not_called()
 
     spans = span_exporter.get_finished_spans()
     agent_spans = [s for s in spans if s.name == "invoke_agent dspy.ReAct"]

--- a/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/test_react.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/test_react.py
@@ -168,9 +168,7 @@ async def test_react_async_execution(
         react = dspy.ReAct("question -> answer", tools=[tool])
         async_predict = MockAsyncPredict()
         react.react = async_predict
-        react.react.acall = async_predict.acall
         react.extract = MockExtract()
-        react.extract.acall = react.extract.acall
 
         res = await react.aforward(question="What is 3 * 5?")
         assert res.answer == "15"

--- a/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/test_react.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/test_react.py
@@ -262,3 +262,40 @@ def test_react_error_handling(
     assert span.status.status_code == StatusCode.ERROR
     attrs = span.attributes or {}
     assert attrs.get(error_attributes.ERROR_TYPE) == "RuntimeError"
+
+
+@pytest.mark.anyio
+async def test_react_async_error_handling(
+    tracer_provider: TracerProvider,
+    logger_provider: LoggerProvider,
+    meter_provider: MeterProvider,
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    with instrument(
+        DSPyInstrumentor(),
+        tracer_provider=tracer_provider,
+        logger_provider=logger_provider,
+        meter_provider=meter_provider,
+        content_capture="SPAN_ONLY",
+    ):
+        tool = dspy.Tool(
+            async_multiply, name="multiply", desc="Multiply numbers."
+        )
+        react = dspy.ReAct("question -> answer", tools=[tool])
+
+        class FailingAsyncPredict:
+            async def acall(self, **kwargs: object) -> object:
+                raise RuntimeError("Async predict model failure")
+
+        react.react = FailingAsyncPredict()
+
+        with pytest.raises(RuntimeError, match="Async predict model failure"):
+            await react.aforward(question="What is 3 * 5?")
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.name == "invoke_agent dspy.ReAct"
+    assert span.status.status_code == StatusCode.ERROR
+    attrs = span.attributes or {}
+    assert attrs.get(error_attributes.ERROR_TYPE) == "RuntimeError"

--- a/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/test_react_v2.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/test_react_v2.py
@@ -6,8 +6,9 @@
 from __future__ import annotations
 
 import json
-import pytest
+
 import dspy
+import pytest
 
 try:
     from dspy.adapters.types.tool import ToolCalls

--- a/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/test_react_v2.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/test_react_v2.py
@@ -1,0 +1,193 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for DSPy ReActV2 agent instrumentation."""
+
+from __future__ import annotations
+
+import json
+import pytest
+import dspy
+
+try:
+    from dspy.adapters.types.tool import ToolCalls
+except ImportError:
+    ToolCalls = None  # type: ignore[assignment,misc]
+
+from opentelemetry.instrumentation.genai.dspy import DSPyInstrumentor
+from opentelemetry.sdk._logs import LoggerProvider
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
+from opentelemetry.semconv._incubating.attributes import (
+    gen_ai_attributes as GenAI,
+)
+from opentelemetry.semconv.attributes import error_attributes
+from opentelemetry.test_util_genai.instrumentor import instrument
+from opentelemetry.trace import StatusCode
+
+pytestmark = pytest.mark.skipif(
+    not hasattr(dspy, "ReActV2") or ToolCalls is None,
+    reason="dspy.ReActV2 not available in this DSPy version",
+)
+
+
+def add(x: int, y: int) -> int:
+    """Add two numbers."""
+    return x + y
+
+
+class MockSyncPredictV2:
+    def __init__(self) -> None:
+        self.count = 0
+
+    def __call__(self, **kwargs: object) -> object:
+        self.count += 1
+
+        class Pred:
+            pass
+
+        p = Pred()
+        if self.count == 1:
+            p.next_thought = "Add 2 and 2"  # type: ignore[attr-defined]
+            p.tool_calls = ToolCalls(  # type: ignore[misc]
+                tool_calls=[
+                    ToolCalls.ToolCall(  # type: ignore[misc]
+                        id="call_1", name="add", args={"x": 2, "y": 2}
+                    )
+                ]
+            )
+        else:
+            p.next_thought = "Submit answer"  # type: ignore[attr-defined]
+            p.tool_calls = ToolCalls(  # type: ignore[misc]
+                tool_calls=[
+                    ToolCalls.ToolCall(  # type: ignore[misc]
+                        id="call_2", name="submit", args={"answer": "4"}
+                    )
+                ]
+            )
+        return p
+
+
+def test_react_v2_sync_execution(
+    tracer_provider: TracerProvider,
+    logger_provider: LoggerProvider,
+    meter_provider: MeterProvider,
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    with instrument(
+        DSPyInstrumentor(),
+        tracer_provider=tracer_provider,
+        logger_provider=logger_provider,
+        meter_provider=meter_provider,
+        content_capture="SPAN_ONLY",
+    ):
+        react_v2 = dspy.ReActV2("question -> answer", tools=[add])
+        react_v2.react = MockSyncPredictV2()
+
+        res = react_v2(question="What is 2 + 2?")
+        assert res.answer == "4"
+
+    spans = span_exporter.get_finished_spans()
+    # Expect 1 execute_tool add, 1 execute_tool submit, 1 invoke_agent dspy.ReActV2
+    assert len(spans) == 3
+
+    agent_spans = [s for s in spans if s.name == "invoke_agent dspy.ReActV2"]
+    tool_spans = [s for s in spans if s.name.startswith("execute_tool")]
+
+    assert len(agent_spans) == 1
+    agent_span = agent_spans[0]
+    assert agent_span.status.status_code == StatusCode.UNSET
+
+    agent_attrs = agent_span.attributes or {}
+    assert agent_attrs.get(GenAI.GEN_AI_OPERATION_NAME) == "invoke_agent"
+    assert agent_attrs.get(GenAI.GEN_AI_AGENT_NAME) == "dspy.ReActV2"
+
+    # Verify input messages
+    input_msgs_raw = agent_attrs.get(GenAI.GEN_AI_INPUT_MESSAGES)
+    assert input_msgs_raw is not None
+    input_msgs = json.loads(str(input_msgs_raw))
+    assert input_msgs[0]["parts"][0]["content"] == "What is 2 + 2?"
+
+    # Verify output messages
+    output_msgs_raw = agent_attrs.get(GenAI.GEN_AI_OUTPUT_MESSAGES)
+    assert output_msgs_raw is not None
+    output_msgs = json.loads(str(output_msgs_raw))
+    assert output_msgs[0]["parts"][0]["content"] == "4"
+
+    # Verify tool definitions
+    tool_defs_raw = agent_attrs.get(GenAI.GEN_AI_TOOL_DEFINITIONS)
+    assert tool_defs_raw is not None
+    tool_defs = json.loads(str(tool_defs_raw))
+    assert any(t["name"] == "add" for t in tool_defs)
+
+    # Verify child tool spans reference agent span
+    assert len(tool_spans) == 2
+    for t_span in tool_spans:
+        assert t_span.parent is not None
+        assert t_span.parent.span_id == agent_span.context.span_id
+
+
+def test_react_v2_no_content_capture(
+    tracer_provider: TracerProvider,
+    logger_provider: LoggerProvider,
+    meter_provider: MeterProvider,
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    with instrument(
+        DSPyInstrumentor(),
+        tracer_provider=tracer_provider,
+        logger_provider=logger_provider,
+        meter_provider=meter_provider,
+        content_capture="NO_CONTENT",
+    ):
+        react_v2 = dspy.ReActV2("question -> answer", tools=[add])
+        react_v2.react = MockSyncPredictV2()
+
+        res = react_v2(question="What is 2 + 2?")
+        assert res.answer == "4"
+
+    spans = span_exporter.get_finished_spans()
+    agent_spans = [s for s in spans if s.name == "invoke_agent dspy.ReActV2"]
+    assert len(agent_spans) == 1
+    agent_span = agent_spans[0]
+
+    attrs = agent_span.attributes or {}
+    assert GenAI.GEN_AI_INPUT_MESSAGES not in attrs
+    assert GenAI.GEN_AI_OUTPUT_MESSAGES not in attrs
+    assert attrs.get(GenAI.GEN_AI_AGENT_NAME) == "dspy.ReActV2"
+
+
+def test_react_v2_error_handling(
+    tracer_provider: TracerProvider,
+    logger_provider: LoggerProvider,
+    meter_provider: MeterProvider,
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    with instrument(
+        DSPyInstrumentor(),
+        tracer_provider=tracer_provider,
+        logger_provider=logger_provider,
+        meter_provider=meter_provider,
+        content_capture="SPAN_ONLY",
+    ):
+        react_v2 = dspy.ReActV2("question -> answer", tools=[add])
+
+        class FailingPredictV2:
+            def __call__(self, **kwargs: object) -> object:
+                raise RuntimeError("ReActV2 model error")
+
+        react_v2.react = FailingPredictV2()
+
+        with pytest.raises(RuntimeError, match="ReActV2 model error"):
+            react_v2(question="What is 2 + 2?")
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.name == "invoke_agent dspy.ReActV2"
+    assert span.status.status_code == StatusCode.ERROR
+    attrs = span.attributes or {}
+    assert attrs.get(error_attributes.ERROR_TYPE) == "RuntimeError"

--- a/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/test_react_v2.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/test_react_v2.py
@@ -9,11 +9,7 @@ import json
 
 import dspy
 import pytest
-
-try:
-    from dspy.adapters.types.tool import ToolCalls
-except ImportError:
-    ToolCalls = None  # type: ignore[assignment,misc]
+from dspy.adapters.types.tool import ToolCalls
 
 from opentelemetry.instrumentation.genai.dspy import DSPyInstrumentor
 from opentelemetry.sdk._logs import LoggerProvider
@@ -29,11 +25,6 @@ from opentelemetry.semconv.attributes import error_attributes
 from opentelemetry.test_util_genai.instrumentor import instrument
 from opentelemetry.trace import StatusCode
 
-pytestmark = pytest.mark.skipif(
-    not hasattr(dspy, "ReActV2") or ToolCalls is None,
-    reason="dspy.ReActV2 not available in this DSPy version",
-)
-
 
 def add(x: int, y: int) -> int:
     """Add two numbers."""
@@ -47,29 +38,27 @@ class MockSyncPredictV2:
     def __call__(self, **kwargs: object) -> object:
         self.count += 1
 
-        class Pred:
-            pass
-
-        p = Pred()
-        if self.count == 1:
-            p.next_thought = "Add 2 and 2"  # type: ignore[attr-defined]
-            p.tool_calls = ToolCalls(  # type: ignore[misc]
+        class CallPred:
+            next_thought = "Add 2 and 2"
+            tool_calls = ToolCalls(
                 tool_calls=[
-                    ToolCalls.ToolCall(  # type: ignore[misc]
+                    ToolCalls.ToolCall(
                         id="call_1", name="add", args={"x": 2, "y": 2}
                     )
                 ]
             )
-        else:
-            p.next_thought = "Submit answer"  # type: ignore[attr-defined]
-            p.tool_calls = ToolCalls(  # type: ignore[misc]
+
+        class SubmitPred:
+            next_thought = "Submit answer"
+            tool_calls = ToolCalls(
                 tool_calls=[
-                    ToolCalls.ToolCall(  # type: ignore[misc]
+                    ToolCalls.ToolCall(
                         id="call_2", name="submit", args={"answer": "4"}
                     )
                 ]
             )
-        return p
+
+        return CallPred() if self.count == 1 else SubmitPred()
 
 
 def test_react_v2_sync_execution(
@@ -92,8 +81,8 @@ def test_react_v2_sync_execution(
         assert res.answer == "4"
 
     spans = span_exporter.get_finished_spans()
-    # Expect 1 execute_tool add, 1 execute_tool submit, 1 invoke_agent dspy.ReActV2
-    assert len(spans) == 3
+    # Expect 1 execute_tool add, 1 invoke_agent dspy.ReActV2 (submit sentinel skipped)
+    assert len(spans) == 2
 
     agent_spans = [s for s in spans if s.name == "invoke_agent dspy.ReActV2"]
     tool_spans = [s for s in spans if s.name.startswith("execute_tool")]
@@ -124,11 +113,12 @@ def test_react_v2_sync_execution(
     tool_defs = json.loads(str(tool_defs_raw))
     assert any(t["name"] == "add" for t in tool_defs)
 
-    # Verify child tool spans reference agent span
-    assert len(tool_spans) == 2
-    for t_span in tool_spans:
-        assert t_span.parent is not None
-        assert t_span.parent.span_id == agent_span.context.span_id
+    # Verify child tool spans reference agent span and submit is skipped
+    assert len(tool_spans) == 1
+    assert tool_spans[0].name == "execute_tool add"
+    assert not any(s.name == "execute_tool submit" for s in spans)
+    assert tool_spans[0].parent is not None
+    assert tool_spans[0].parent.span_id == agent_span.context.span_id
 
 
 def test_react_v2_no_content_capture(

--- a/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/test_react_v2.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/test_react_v2.py
@@ -182,3 +182,58 @@ def test_react_v2_error_handling(
     assert span.status.status_code == StatusCode.ERROR
     attrs = span.attributes or {}
     assert attrs.get(error_attributes.ERROR_TYPE) == "RuntimeError"
+
+
+def test_react_v2_missing_tolerated(
+    monkeypatch: pytest.MonkeyPatch,
+    tracer_provider: TracerProvider,
+    logger_provider: LoggerProvider,
+    meter_provider: MeterProvider,
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    import dspy.predict.react_v2
+
+    monkeypatch.delattr(dspy.predict.react_v2, "ReActV2", raising=False)
+
+    class MockSyncPredict:
+        def __init__(self) -> None:
+            self.count = 0
+
+        def __call__(self, **kwargs: object) -> object:
+            self.count += 1
+
+            class Pred:
+                next_thought = "Need to add 2 and 2"
+                next_tool_name = "add"
+                next_tool_args = {"x": 2, "y": 2}
+
+            class FinishPred:
+                next_thought = "Done calculation"
+                next_tool_name = "finish"
+                next_tool_args = {}
+
+            return Pred() if self.count == 1 else FinishPred()
+
+    class MockExtract:
+        def __call__(self, **kwargs: object) -> dict[str, str]:
+            return {"answer": "4"}
+
+    with instrument(
+        DSPyInstrumentor(),
+        tracer_provider=tracer_provider,
+        logger_provider=logger_provider,
+        meter_provider=meter_provider,
+        content_capture="SPAN_ONLY",
+    ):
+        tool = dspy.Tool(add, name="add", desc="Add two numbers.")
+        react = dspy.ReAct("question -> answer", tools=[tool])
+        react.react = MockSyncPredict()
+        react.extract = MockExtract()
+
+        res = react(question="What is 2 + 2?")
+        assert res.answer == "4"
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 2
+    assert any(s.name == "invoke_agent dspy.ReAct" for s in spans)
+    assert any(s.name == "execute_tool add" for s in spans)

--- a/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/test_tools.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/test_tools.py
@@ -1,0 +1,224 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for DSPy Tool instrumentation."""
+
+from __future__ import annotations
+
+import json
+import pytest
+import dspy
+
+from opentelemetry.instrumentation.genai.dspy import DSPyInstrumentor
+from opentelemetry.sdk._logs import LoggerProvider
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
+from opentelemetry.semconv._incubating.attributes import (
+    gen_ai_attributes as GenAI,
+)
+from opentelemetry.semconv.attributes import error_attributes
+from opentelemetry.test_util_genai.instrumentor import instrument
+from opentelemetry.trace import StatusCode
+
+
+def add(x: int, y: int) -> int:
+    """Add two numbers."""
+    return x + y
+
+
+async def async_multiply(a: int, b: int) -> int:
+    """Multiply two numbers."""
+    return a * b
+
+
+def failing_tool(x: int) -> int:
+    """Always fails."""
+    raise ValueError("Calculation error")
+
+
+async def async_failing_tool(x: int) -> int:
+    """Always fails asynchronously."""
+    raise RuntimeError("Async calculation error")
+
+
+def test_sync_tool_execution(
+    tracer_provider: TracerProvider,
+    logger_provider: LoggerProvider,
+    meter_provider: MeterProvider,
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    with instrument(
+        DSPyInstrumentor(),
+        tracer_provider=tracer_provider,
+        logger_provider=logger_provider,
+        meter_provider=meter_provider,
+        content_capture="SPAN_ONLY",
+    ):
+        tool = dspy.Tool(add, name="add", desc="Add two numbers.")
+        res = tool(x=3, y=4)
+        assert res == 7
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+
+    assert span.name == "execute_tool add"
+    assert span.status.status_code == StatusCode.UNSET
+    attrs = span.attributes or {}
+    assert attrs.get(GenAI.GEN_AI_OPERATION_NAME) == "execute_tool"
+    assert attrs.get(GenAI.GEN_AI_TOOL_NAME) == "add"
+    assert attrs.get(GenAI.GEN_AI_TOOL_TYPE) == "function"
+    assert attrs.get(GenAI.GEN_AI_TOOL_DESCRIPTION) == "Add two numbers."
+
+    args_attr = attrs.get(GenAI.GEN_AI_TOOL_CALL_ARGUMENTS)
+    assert args_attr is not None
+    assert json.loads(str(args_attr)) == {"x": 3, "y": 4}
+    assert attrs.get(GenAI.GEN_AI_TOOL_CALL_RESULT) == 7
+
+
+def test_sync_tool_positional_and_mixed_args_extraction(
+    tracer_provider: TracerProvider,
+    logger_provider: LoggerProvider,
+    meter_provider: MeterProvider,
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    from opentelemetry.instrumentation.genai.dspy.patch import (
+        _extract_tool_arguments,
+    )
+
+    tool = dspy.Tool(add, name="add", desc="Add two numbers.")
+    extracted = _extract_tool_arguments(tool, (5,), {"y": 10})
+    assert extracted == {"x": 5, "y": 10}
+
+    extracted_pos = _extract_tool_arguments(tool, (5, 10), {})
+    assert extracted_pos == {"x": 5, "y": 10}
+
+
+@pytest.mark.skipif(
+    not hasattr(dspy.Tool, "acall"),
+    reason="dspy.Tool.acall not available in this DSPy version",
+)
+@pytest.mark.anyio
+async def test_async_tool_execution(
+    tracer_provider: TracerProvider,
+    logger_provider: LoggerProvider,
+    meter_provider: MeterProvider,
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    with instrument(
+        DSPyInstrumentor(),
+        tracer_provider=tracer_provider,
+        logger_provider=logger_provider,
+        meter_provider=meter_provider,
+        content_capture="SPAN_ONLY",
+    ):
+        tool = dspy.Tool(async_multiply, name="multiply", desc="Multiply numbers.")
+        res = await tool.acall(a=5, b=6)
+        assert res == 30
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+
+    assert span.name == "execute_tool multiply"
+    assert span.status.status_code == StatusCode.UNSET
+    attrs = span.attributes or {}
+    assert attrs.get(GenAI.GEN_AI_OPERATION_NAME) == "execute_tool"
+    assert attrs.get(GenAI.GEN_AI_TOOL_NAME) == "multiply"
+    assert attrs.get(GenAI.GEN_AI_TOOL_TYPE) == "function"
+    assert attrs.get(GenAI.GEN_AI_TOOL_DESCRIPTION) == "Multiply numbers."
+
+    args_attr = attrs.get(GenAI.GEN_AI_TOOL_CALL_ARGUMENTS)
+    assert args_attr is not None
+    assert json.loads(str(args_attr)) == {"a": 5, "b": 6}
+    assert attrs.get(GenAI.GEN_AI_TOOL_CALL_RESULT) == 30
+
+
+def test_sync_tool_error(
+    tracer_provider: TracerProvider,
+    logger_provider: LoggerProvider,
+    meter_provider: MeterProvider,
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    with instrument(
+        DSPyInstrumentor(),
+        tracer_provider=tracer_provider,
+        logger_provider=logger_provider,
+        meter_provider=meter_provider,
+        content_capture="SPAN_ONLY",
+    ):
+        tool = dspy.Tool(failing_tool, name="failing_tool")
+        with pytest.raises(ValueError, match="Calculation error"):
+            tool(x=10)
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+
+    assert span.status.status_code == StatusCode.ERROR
+    attrs = span.attributes or {}
+    assert attrs.get(error_attributes.ERROR_TYPE) == "ValueError"
+    assert attrs.get(GenAI.GEN_AI_OPERATION_NAME) == "execute_tool"
+    assert attrs.get(GenAI.GEN_AI_TOOL_NAME) == "failing_tool"
+
+
+@pytest.mark.skipif(
+    not hasattr(dspy.Tool, "acall"),
+    reason="dspy.Tool.acall not available in this DSPy version",
+)
+@pytest.mark.anyio
+async def test_async_tool_error(
+    tracer_provider: TracerProvider,
+    logger_provider: LoggerProvider,
+    meter_provider: MeterProvider,
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    with instrument(
+        DSPyInstrumentor(),
+        tracer_provider=tracer_provider,
+        logger_provider=logger_provider,
+        meter_provider=meter_provider,
+        content_capture="SPAN_ONLY",
+    ):
+        tool = dspy.Tool(async_failing_tool, name="async_failing_tool")
+        with pytest.raises(RuntimeError, match="Async calculation error"):
+            await tool.acall(x=10)
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+
+    assert span.status.status_code == StatusCode.ERROR
+    attrs = span.attributes or {}
+    assert attrs.get(error_attributes.ERROR_TYPE) == "RuntimeError"
+    assert attrs.get(GenAI.GEN_AI_OPERATION_NAME) == "execute_tool"
+
+
+def test_tool_content_capture_disabled(
+    tracer_provider: TracerProvider,
+    logger_provider: LoggerProvider,
+    meter_provider: MeterProvider,
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    with instrument(
+        DSPyInstrumentor(),
+        tracer_provider=tracer_provider,
+        logger_provider=logger_provider,
+        meter_provider=meter_provider,
+        content_capture="NO_CONTENT",
+    ):
+        tool = dspy.Tool(add, name="add")
+        res = tool(x=1, y=2)
+        assert res == 3
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+
+    attrs = span.attributes or {}
+    assert GenAI.GEN_AI_TOOL_CALL_ARGUMENTS not in attrs
+    assert GenAI.GEN_AI_TOOL_CALL_RESULT not in attrs
+    assert attrs.get(GenAI.GEN_AI_TOOL_NAME) == "add"

--- a/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/test_tools.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/test_tools.py
@@ -6,8 +6,9 @@
 from __future__ import annotations
 
 import json
-import pytest
+
 import dspy
+import pytest
 
 from opentelemetry.instrumentation.genai.dspy import DSPyInstrumentor
 from opentelemetry.sdk._logs import LoggerProvider
@@ -115,7 +116,9 @@ async def test_async_tool_execution(
         meter_provider=meter_provider,
         content_capture="SPAN_ONLY",
     ):
-        tool = dspy.Tool(async_multiply, name="multiply", desc="Multiply numbers.")
+        tool = dspy.Tool(
+            async_multiply, name="multiply", desc="Multiply numbers."
+        )
         res = await tool.acall(a=5, b=6)
         assert res == 30
 

--- a/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/test_tools.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/test_tools.py
@@ -6,6 +6,8 @@
 from __future__ import annotations
 
 import json
+from typing import Any
+from unittest import mock
 
 import dspy
 import pytest
@@ -97,11 +99,28 @@ def test_sync_tool_positional_and_mixed_args_extraction(
     extracted_pos = _extract_tool_arguments(tool, (5, 10), {})
     assert extracted_pos == {"x": 5, "y": 10}
 
+    extracted_partial = _extract_tool_arguments(tool, (5,), {})
+    assert extracted_partial == {"x": 5}
 
-@pytest.mark.skipif(
-    not hasattr(dspy.Tool, "acall"),
-    reason="dspy.Tool.acall not available in this DSPy version",
-)
+
+def test_tool_arguments_fallback_when_signature_unavailable() -> None:
+    from opentelemetry.instrumentation.genai.dspy.patch import (
+        _extract_tool_arguments,
+    )
+
+    class DummyTool:
+        func = None
+
+    tool: Any = DummyTool()
+
+    # Keyword-only arguments map parameter names to argument values
+    assert _extract_tool_arguments(tool, (), {"foo": "bar"}) == {"foo": "bar"}
+
+    # Positional arguments cannot be mapped to parameter names; skip
+    assert _extract_tool_arguments(tool, ("bar",), {}) is None
+    assert _extract_tool_arguments(tool, ("bar",), {"foo": "baz"}) is None
+
+
 @pytest.mark.anyio
 async def test_async_tool_execution(
     tracer_provider: TracerProvider,
@@ -168,10 +187,6 @@ def test_sync_tool_error(
     assert attrs.get(GenAI.GEN_AI_TOOL_NAME) == "failing_tool"
 
 
-@pytest.mark.skipif(
-    not hasattr(dspy.Tool, "acall"),
-    reason="dspy.Tool.acall not available in this DSPy version",
-)
 @pytest.mark.anyio
 async def test_async_tool_error(
     tracer_provider: TracerProvider,
@@ -206,16 +221,20 @@ def test_tool_content_capture_disabled(
     meter_provider: MeterProvider,
     span_exporter: InMemorySpanExporter,
 ) -> None:
-    with instrument(
-        DSPyInstrumentor(),
-        tracer_provider=tracer_provider,
-        logger_provider=logger_provider,
-        meter_provider=meter_provider,
-        content_capture="NO_CONTENT",
-    ):
-        tool = dspy.Tool(add, name="add")
-        res = tool(x=1, y=2)
-        assert res == 3
+    with mock.patch(
+        "opentelemetry.instrumentation.genai.dspy.patch._extract_tool_arguments"
+    ) as mock_extract:
+        with instrument(
+            DSPyInstrumentor(),
+            tracer_provider=tracer_provider,
+            logger_provider=logger_provider,
+            meter_provider=meter_provider,
+            content_capture="NO_CONTENT",
+        ):
+            tool = dspy.Tool(add, name="add")
+            res = tool(x=1, y=2)
+            assert res == 3
+        mock_extract.assert_not_called()
 
     spans = span_exporter.get_finished_spans()
     assert len(spans) == 1
@@ -255,3 +274,54 @@ def test_tool_kwargs_not_mutated_by_caller(
     assert args_raw is not None
     args_dict = json.loads(str(args_raw))
     assert args_dict.get("msg") == "world"
+
+
+@pytest.mark.parametrize("sentinel_name", ["finish", "submit"])
+def test_sentinel_tool_skips_span_creation_sync(
+    sentinel_name: str,
+    tracer_provider: TracerProvider,
+    logger_provider: LoggerProvider,
+    meter_provider: MeterProvider,
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    def sentinel_fn() -> str:
+        return "done"
+
+    with instrument(
+        DSPyInstrumentor(),
+        tracer_provider=tracer_provider,
+        logger_provider=logger_provider,
+        meter_provider=meter_provider,
+    ):
+        tool = dspy.Tool(sentinel_fn, name=sentinel_name)
+        result = tool()
+        assert result == "done"
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 0
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("sentinel_name", ["finish", "submit"])
+async def test_sentinel_tool_skips_span_creation_async(
+    sentinel_name: str,
+    tracer_provider: TracerProvider,
+    logger_provider: LoggerProvider,
+    meter_provider: MeterProvider,
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    async def async_sentinel_fn() -> str:
+        return "done"
+
+    with instrument(
+        DSPyInstrumentor(),
+        tracer_provider=tracer_provider,
+        logger_provider=logger_provider,
+        meter_provider=meter_provider,
+    ):
+        tool = dspy.Tool(async_sentinel_fn, name=sentinel_name)
+        result = await tool.acall()
+        assert result == "done"
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 0

--- a/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/test_tools.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/test_tools.py
@@ -225,3 +225,33 @@ def test_tool_content_capture_disabled(
     assert GenAI.GEN_AI_TOOL_CALL_ARGUMENTS not in attrs
     assert GenAI.GEN_AI_TOOL_CALL_RESULT not in attrs
     assert attrs.get(GenAI.GEN_AI_TOOL_NAME) == "add"
+
+
+def test_tool_kwargs_not_mutated_by_caller(
+    tracer_provider: TracerProvider,
+    logger_provider: LoggerProvider,
+    meter_provider: MeterProvider,
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    def greet(msg: str) -> str:
+        return f"Hello, {msg}"
+
+    with instrument(
+        DSPyInstrumentor(),
+        tracer_provider=tracer_provider,
+        logger_provider=logger_provider,
+        meter_provider=meter_provider,
+        content_capture="SPAN_ONLY",
+    ):
+        tool = dspy.Tool(greet, name="greet")
+        kwargs = {"msg": "world"}
+        tool(**kwargs)
+        kwargs["msg"] = "mutated"
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    attrs = spans[0].attributes or {}
+    args_raw = attrs.get(GenAI.GEN_AI_TOOL_CALL_ARGUMENTS)
+    assert args_raw is not None
+    args_dict = json.loads(str(args_raw))
+    assert args_dict.get("msg") == "world"

--- a/tox.ini
+++ b/tox.ini
@@ -211,6 +211,7 @@ deps =
   dspy-latest: {[testenv]test_deps}
   dspy-latest: {[testenv]pytest_deps}
   dspy-latest: -r {toxinidir}/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/requirements.latest.txt
+  dspy-conformance: {[testenv]test_deps}
   dspy-conformance: {[testenv]pytest_deps}
   dspy-conformance: -r {toxinidir}/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/requirements.latest.txt
 

--- a/tox.ini
+++ b/tox.ini
@@ -56,6 +56,7 @@ envlist =
     ; instrumentation-genai-dspy
     py3{10,14}-test-instrumentation-genai-dspy-latest
     py310-test-instrumentation-genai-dspy-oldest
+    py314-test-instrumentation-genai-dspy-conformance
 
     ; instrumentation-genai-langchain
     py3{10,14}-test-instrumentation-genai-langchain-latest
@@ -210,6 +211,8 @@ deps =
   dspy-latest: {[testenv]test_deps}
   dspy-latest: {[testenv]pytest_deps}
   dspy-latest: -r {toxinidir}/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/requirements.latest.txt
+  dspy-conformance: {[testenv]pytest_deps}
+  dspy-conformance: -r {toxinidir}/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/requirements.latest.txt
 
   qwen-agent-oldest: {[testenv]pytest_deps}
   qwen-agent-oldest: -e {toxinidir}/instrumentation/opentelemetry-instrumentation-genai-qwen-agent[instruments]
@@ -306,6 +309,7 @@ commands =
   test-instrumentation-genai-claude-agent-sdk: pytest {toxinidir}/instrumentation/opentelemetry-instrumentation-genai-claude-agent-sdk/tests --vcr-record=none {posargs}
   test-instrumentation-genai-crewai-{oldest,latest}: pytest {toxinidir}/instrumentation/opentelemetry-instrumentation-genai-crewai/tests --vcr-record=none {posargs}
   test-instrumentation-genai-dspy-{oldest,latest}: pytest --ignore={toxinidir}/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/test_conformance.py {toxinidir}/instrumentation/opentelemetry-instrumentation-genai-dspy/tests --vcr-record=none {posargs}
+  test-instrumentation-genai-dspy-conformance: pytest {toxinidir}/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/test_conformance.py --vcr-record=none {posargs}
 
   test-instrumentation-genai-langchain-{oldest,latest}: pytest --ignore={toxinidir}/instrumentation/opentelemetry-instrumentation-genai-langchain/tests/test_conformance.py {toxinidir}/instrumentation/opentelemetry-instrumentation-genai-langchain/tests --vcr-record=none {posargs}
   test-instrumentation-genai-langchain-conformance: pytest {toxinidir}/instrumentation/opentelemetry-instrumentation-genai-langchain/tests/test_conformance.py --vcr-record=none {posargs}

--- a/uv.lock
+++ b/uv.lock
@@ -3652,7 +3652,7 @@ instruments = [
 
 [package.metadata]
 requires-dist = [
-    { name = "dspy", marker = "extra == 'instruments'", specifier = ">=2.5.0,<4" },
+    { name = "dspy", marker = "extra == 'instruments'", specifier = ">=2.6.0,<4" },
     { name = "opentelemetry-api", specifier = "~=1.43" },
     { name = "opentelemetry-instrumentation", specifier = ">=0.64b0,<1" },
     { name = "opentelemetry-semantic-conventions", specifier = ">=0.64b0,<1" },

--- a/uv.lock
+++ b/uv.lock
@@ -3652,7 +3652,7 @@ instruments = [
 
 [package.metadata]
 requires-dist = [
-    { name = "dspy", marker = "extra == 'instruments'", specifier = ">=2.6.0,<4" },
+    { name = "dspy", marker = "extra == 'instruments'", specifier = ">=3.3.0,<4" },
     { name = "opentelemetry-api", specifier = "~=1.43" },
     { name = "opentelemetry-instrumentation", specifier = ">=0.64b0,<1" },
     { name = "opentelemetry-semantic-conventions", specifier = ">=0.64b0,<1" },


### PR DESCRIPTION
# Description

Monkey patches `dspy.Tool.__call__` and `dspy.Tool.acall` methods so that an execute tool span is emitted (https://dspy.ai/api/primitives/Tool/)

Monkey patches `dspy.predict.react.ReAct.forward` (and `aforward`) and `dspy.predict.react_v2.ReActV2.forward` so that an invoke agent span is emitted (https://dspy.ai/diving-deeper/react/).

Also, I'm going to require `DsPy` v3.3+ -- this gets us `litellm` v1.84 which fixed a bad vulnerability in all previous versions. Also it simplifies the implementation a little bit, we don't need to wrap certain imports in try/except blocks because they are guaranteed to exist in 3.3+..

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How has this been tested?

Unit tests, live weaver tests..

# Checklist

- [x] Followed the style guidelines of this project
- [x] Changelog updated if the change requires an entry
- [x] Unit tests added
- [x] Documentation updated
