### PR TITLE
test(openai): restore openai v2 test env

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -10,11 +10,12 @@
   "pip_requirements": {
     // Default pip_requirements fileMatch only allows [\w-]* between
     // "requirements" and ".txt", so per-instrumentation
-    // requirements.latest.txt and requirements.<lib>-v<N>.txt files are
+    // requirements.latest.txt and requirements.v<N>.txt files are
     // skipped without this.
     "managerFilePatterns": [
       "/(^|/)requirements\\.txt$/",
       "/(^|/)requirements\\.latest\\.txt$/",
+      "/(^|/)requirements\\.v\\d+\\.txt$/",
       "/(^|/)requirements\\.[\\w-]+-v\\d+\\.txt$/"
     ]
   },
@@ -71,10 +72,10 @@
       "allowedVersions": "<2.13"
     },
     {
-      // requirements.<lib>-v<N>.txt tests the newest release of an older
+      // requirements.<lib>-v<N>.txt or requirements.v<N>.txt tests the newest release of an older
       // major of <lib>, so <lib> itself must stay on that major while the
       // rest of the file keeps updating. Add one rule per such file.
-      "matchFileNames": ["**/requirements.openai-v2.txt"],
+      "matchFileNames": ["**/requirements.v2.txt"],
       "matchPackageNames": ["openai"],
       "allowedVersions": "<3"
     },

--- a/instrumentation/opentelemetry-instrumentation-genai-openai/tests/requirements.v2.txt
+++ b/instrumentation/opentelemetry-instrumentation-genai-openai/tests/requirements.v2.txt
@@ -22,7 +22,7 @@
 # file. In particular, please see:
 #
 #   openai-v2: {[testenv]test_deps}
-#   openai-v2: -r {toxinidir}/instrumentation/opentelemetry-instrumentation-genai-openai/tests/requirements.openai-v2.txt
+#   openai-v2: -r {toxinidir}/instrumentation/opentelemetry-instrumentation-genai-openai/tests/requirements.v2.txt
 #
 # This provides additional dependencies, namely:
 #

--- a/instrumentation/opentelemetry-instrumentation-genai-openai/tests/test_raw_response_httpx_interop.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-openai/tests/test_raw_response_httpx_interop.py
@@ -21,7 +21,7 @@ import json
 import pytest
 from openai import AsyncOpenAI, OpenAI
 
-# Only pinned in requirements.openai-v2.txt; other envs (openai v3+ uses
+# Only pinned in requirements.v2.txt; other envs (openai v3+ uses
 # httpx2, oldest has no httpx instrumentation) skip this module.
 httpx = pytest.importorskip("httpx")
 HTTPXClientInstrumentor = pytest.importorskip(

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ envlist =
 
     ; instrumentation-genai-openai
     py3{10,14}-test-instrumentation-genai-openai-latest
+    py3{10,14}-test-instrumentation-genai-openai-v2
     py310-test-instrumentation-genai-openai-oldest
     py314-test-instrumentation-genai-openai-conformance
 
@@ -125,6 +126,9 @@ deps =
   openai-latest: {[testenv]test_deps}
   openai-latest: {[testenv]pytest_deps}
   openai-latest: -r {toxinidir}/instrumentation/opentelemetry-instrumentation-genai-openai/tests/requirements.latest.txt
+  openai-v2: {[testenv]test_deps}
+  openai-v2: {[testenv]pytest_deps}
+  openai-v2: -r {toxinidir}/instrumentation/opentelemetry-instrumentation-genai-openai/tests/requirements.v2.txt
   openai-conformance: {[testenv]pytest_deps}
   openai-conformance: -r {toxinidir}/instrumentation/opentelemetry-instrumentation-genai-openai/tests/requirements.latest.txt
 
@@ -274,7 +278,7 @@ commands_pre =
   coverage: python {toxinidir}/scripts/eachdist.py install --editable
 
 commands =
-  test-instrumentation-genai-openai-{oldest,latest}: pytest --ignore={toxinidir}/instrumentation/opentelemetry-instrumentation-genai-openai/tests/test_conformance.py {toxinidir}/instrumentation/opentelemetry-instrumentation-genai-openai/tests {posargs}
+  test-instrumentation-genai-openai-{oldest,latest,v2}: pytest --ignore={toxinidir}/instrumentation/opentelemetry-instrumentation-genai-openai/tests/test_conformance.py {toxinidir}/instrumentation/opentelemetry-instrumentation-genai-openai/tests {posargs}
   test-instrumentation-genai-openai-conformance: pytest {toxinidir}/instrumentation/opentelemetry-instrumentation-genai-openai/tests/test_conformance.py --vcr-record=none {posargs}
   test-instrumentation-genai-openai_agents-{oldest,latest}: pytest --ignore={toxinidir}/instrumentation/opentelemetry-instrumentation-genai-openai-agents/tests/test_conformance.py {toxinidir}/instrumentation/opentelemetry-instrumentation-genai-openai-agents/tests {posargs}
   test-instrumentation-genai-openai_agents-conformance: pytest {toxinidir}/instrumentation/opentelemetry-instrumentation-genai-openai-agents/tests/test_conformance.py --vcr-record=none {posargs}


### PR DESCRIPTION
Restores the OpenAI v2 test factor in `tox.ini`.

The test environment was accidentally dropped in #411 during test matrix cleanup. Pinned test environments ensure coverage across all supported `openai` majors:
- `oldest` tests v1
- `v2` tests v2
- `latest` tests v3