### PR TITLE
Adopt shared `Role` enum across instrumentations

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-genai-agno/src/opentelemetry/instrumentation/genai/agno/patch.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-agno/src/opentelemetry/instrumentation/genai/agno/patch.py
@@ -32,6 +32,7 @@ from opentelemetry.util.genai.invocation import (
 from opentelemetry.util.genai.types import (
     InputMessage,
     OutputMessage,
+    Role,
     TextPart,
 )
 
@@ -201,7 +202,7 @@ def _set_invocation_input(
             content_str = _extract_input_content(input_val)
             invocation.input_messages = [
                 InputMessage(
-                    role="user", parts=[TextPart(content=content_str)]
+                    role=Role.USER.value, parts=[TextPart(content=content_str)]
                 )
             ]
 
@@ -221,7 +222,7 @@ def _set_invocation_output(
         output_str = _extract_output_content(result)
         invocation.output_messages = [
             OutputMessage(
-                role="assistant",
+                role=Role.ASSISTANT.value,
                 parts=[TextPart(content=output_str)],
                 finish_reason=_extract_finish_reason(result),
             )

--- a/instrumentation/opentelemetry-instrumentation-genai-bedrock/src/opentelemetry/instrumentation/genai/bedrock/extractors.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-bedrock/src/opentelemetry/instrumentation/genai/bedrock/extractors.py
@@ -16,6 +16,7 @@ from opentelemetry.util.genai.types import (
     MessagePart,
     OutputMessage,
     ReasoningPart,
+    Role,
     TextPart,
     ToolCallRequestPart,
     ToolCallResponsePart,
@@ -193,7 +194,7 @@ def extract_converse_request(
         for msg in raw_messages:
             if not _is_dict(msg):
                 continue
-            role = msg.get("role", "user")
+            role = msg.get("role", Role.USER.value)
             parts: list[MessagePart] = []
             content = msg.get("content")
             if _is_list(content):
@@ -256,7 +257,7 @@ def extract_converse_response(
     if capture_content and _is_dict(output):
         msg = output.get("message")
         if _is_dict(msg):
-            role = msg.get("role", "assistant")
+            role = msg.get("role", Role.ASSISTANT.value)
             parts: list[MessagePart] = []
             content = msg.get("content")
             if _is_list(content):

--- a/instrumentation/opentelemetry-instrumentation-genai-bedrock/src/opentelemetry/instrumentation/genai/bedrock/stream.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-bedrock/src/opentelemetry/instrumentation/genai/bedrock/stream.py
@@ -14,6 +14,7 @@ from opentelemetry.util.genai.types import (
     MessagePart,
     OutputMessage,
     ReasoningPart,
+    Role,
     TextPart,
     ToolCallRequestPart,
 )
@@ -34,7 +35,7 @@ class BedrockConverseStreamWrapper(SyncStreamWrapper[dict[str, Any]]):
         super().__init__(stream, invocation=invocation)
         self._self_invocation = invocation
         self._self_capture_content = capture_content
-        self._self_role = "assistant"
+        self._self_role = Role.ASSISTANT.value
         self._self_stop_reason: str | None = None
         self._self_input_tokens: int | None = None
         self._self_output_tokens: int | None = None

--- a/instrumentation/opentelemetry-instrumentation-genai-llama-index/src/opentelemetry/instrumentation/genai/llama_index/_handler.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-llama-index/src/opentelemetry/instrumentation/genai/llama_index/_handler.py
@@ -44,6 +44,7 @@ from opentelemetry.util.genai.types import (
     MessagePart,
     OutputMessage,
     ReasoningPart,
+    Role,
     TextPart,
     ToolCallRequestPart,
     ToolDefinition,
@@ -207,7 +208,9 @@ def _agent_input(bound_args: inspect.BoundArguments) -> list[InputMessage]:
         messages.append(_input_message(user_message))
     elif isinstance(user_message, str) and user_message:
         messages.append(
-            InputMessage(role="user", parts=[TextPart(content=user_message)])
+            InputMessage(
+                role=Role.USER.value, parts=[TextPart(content=user_message)]
+            )
         )
     return messages
 

--- a/instrumentation/opentelemetry-instrumentation-genai-openai/src/opentelemetry/instrumentation/genai/openai/chat_wrappers.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-openai/src/opentelemetry/instrumentation/genai/openai/chat_wrappers.py
@@ -19,6 +19,7 @@ from opentelemetry.util.genai.stream import (
 )
 from opentelemetry.util.genai.types import (
     OutputMessage,
+    Role,
     TextPart,
     ToolCallRequestPart,
 )
@@ -117,7 +118,7 @@ class _ChatStreamMixin:
         output_messages = []
         for choice in self._self_choice_buffers:
             message = OutputMessage(
-                role="assistant",
+                role=Role.ASSISTANT.value,
                 finish_reason=choice.finish_reason or "error",
                 parts=[],
             )

--- a/instrumentation/opentelemetry-instrumentation-genai-openai/src/opentelemetry/instrumentation/genai/openai/response_extractors.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-openai/src/opentelemetry/instrumentation/genai/openai/response_extractors.py
@@ -68,6 +68,7 @@ try:
         InputMessage,
         OutputMessage,
         ReasoningPart,
+        Role,
         TextPart,
     )
     from opentelemetry.util.genai.types import (
@@ -80,6 +81,7 @@ except ImportError:
     InputMessage = None
     OutputMessage = None
     ReasoningPart = None
+    Role = None
     TextPart = None
     ToolCall = None
 
@@ -194,7 +196,9 @@ def get_input_messages(
 
     if isinstance(input_value, str):
         return [
-            InputMessage(role="user", parts=[TextPart(content=input_value)])
+            InputMessage(
+                role=Role.USER.value, parts=[TextPart(content=input_value)]
+            )
         ]
 
     messages: list[InputMessage] = []
@@ -383,7 +387,7 @@ def get_output_messages_from_response(
 
             messages.append(
                 OutputMessage(
-                    role="assistant",
+                    role=Role.ASSISTANT.value,
                     parts=[
                         ToolCall(
                             id=item.call_id if item.call_id else item.id,
@@ -407,7 +411,7 @@ def get_output_messages_from_response(
             if parts:
                 messages.append(
                     OutputMessage(
-                        role="assistant",
+                        role=Role.ASSISTANT.value,
                         parts=parts,
                         finish_reason=finish_reason,
                     )

--- a/instrumentation/opentelemetry-instrumentation-genai-portkey/.changelog/+util-genai-role-enum.changed
+++ b/instrumentation/opentelemetry-instrumentation-genai-portkey/.changelog/+util-genai-role-enum.changed
@@ -1,0 +1,1 @@
+Bump the minimum `opentelemetry-util-genai` version to 1.2b0.

--- a/instrumentation/opentelemetry-instrumentation-genai-portkey/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-genai-portkey/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
   "opentelemetry-api ~= 1.43",
   "opentelemetry-instrumentation >= 0.64b0, <1",
   "opentelemetry-semantic-conventions >= 0.64b0, <1",
-  "opentelemetry-util-genai >= 1.1b0.dev, <2",
+  "opentelemetry-util-genai >= 1.2b0.dev, <2",
   "wrapt >= 1.14.0, < 3.0.0",
 ]
 

--- a/instrumentation/opentelemetry-instrumentation-genai-portkey/src/opentelemetry/instrumentation/genai/portkey/utils.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-portkey/src/opentelemetry/instrumentation/genai/portkey/utils.py
@@ -20,6 +20,7 @@ from opentelemetry.util.genai.types import (
     InputMessage,
     MessagePart,
     OutputMessage,
+    Role,
     Text,
     ToolCallRequest,
     ToolCallResponse,
@@ -210,7 +211,7 @@ def _prepare_output_messages(
         finish_reason = get_property_value(choice, "finish_reason") or "stop"
         parts: list[MessagePart] = []
         message = get_property_value(choice, "message")
-        role = "assistant"
+        role = Role.ASSISTANT.value
         if message is not None:
             msg_role = get_property_value(message, "role")
             if msg_role:

--- a/instrumentation/opentelemetry-instrumentation-genai-portkey/src/opentelemetry/instrumentation/genai/portkey/wrappers.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-portkey/src/opentelemetry/instrumentation/genai/portkey/wrappers.py
@@ -20,6 +20,7 @@ from opentelemetry.util.genai.stream import (
 from opentelemetry.util.genai.types import (
     MessagePart,
     OutputMessage,
+    Role,
     Text,
     ToolCallRequest,
 )
@@ -175,7 +176,7 @@ class _PortkeyStreamMixin:
                 parts.extend(tool_calls)
             output_messages.append(
                 OutputMessage(
-                    role="assistant",
+                    role=Role.ASSISTANT.value,
                     finish_reason=choice.finish_reason or "stop",
                     parts=parts,
                 )

--- a/instrumentation/opentelemetry-instrumentation-genai-portkey/tests/requirements.oldest.txt
+++ b/instrumentation/opentelemetry-instrumentation-genai-portkey/tests/requirements.oldest.txt
@@ -23,3 +23,6 @@
 #
 # There is currently nothing to pin: portkey-ai has no test-only dependency that isn't already
 # provided by a declared bound or by the shared test fixtures.
+
+# Drop this once opentelemetry-util-genai 1.2b0 is published.
+-e util/opentelemetry-util-genai

--- a/instrumentation/opentelemetry-instrumentation-genai-qwen-agent/src/opentelemetry/instrumentation/genai/qwen_agent/utils.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-qwen-agent/src/opentelemetry/instrumentation/genai/qwen_agent/utils.py
@@ -16,6 +16,7 @@ from opentelemetry.util.genai.types import (
     InputMessage,
     MessagePart,
     OutputMessage,
+    Role,
     TextPart,
     ToolCallRequestPart,
     ToolCallResponsePart,
@@ -152,7 +153,7 @@ def convert_to_input_messages(
     input_messages: list[InputMessage] = []
     for msg in messages:
         try:
-            role = _field_value(msg, "role") or "user"
+            role = _field_value(msg, "role") or Role.USER.value
             content = _field_value(msg, "content") or ""
             function_call = _field_value(msg, "function_call")
 
@@ -217,7 +218,7 @@ def convert_to_output_messages(
 
             output_messages.append(
                 OutputMessage(
-                    role="assistant",
+                    role=Role.ASSISTANT.value,
                     parts=parts,
                     finish_reason=finish_reason,
                 )

--- a/instrumentation/opentelemetry-instrumentation-genai-smolagents/src/opentelemetry/instrumentation/genai/smolagents/_messages.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-smolagents/src/opentelemetry/instrumentation/genai/smolagents/_messages.py
@@ -28,6 +28,7 @@ from opentelemetry.util.genai.types import (
     InputMessage,
     MessagePart,
     OutputMessage,
+    Role,
     TextPart,
     ToolDefinition,
     UriPart,
@@ -57,8 +58,8 @@ _DATA_URL_PREFIX = "data:"
 # overrides the mapping and can send different roles. Roles that are already
 # spec values pass through unchanged.
 _ROLE_MAP: dict[str, str] = {
-    "tool-call": "assistant",
-    "tool-response": "user",
+    "tool-call": Role.ASSISTANT.value,
+    "tool-response": Role.USER.value,
 }
 
 
@@ -199,7 +200,7 @@ def to_output_message(output_message: ChatMessage) -> OutputMessage:
     would make a generation cut short by ``max_new_tokens`` look like a natural
     stop.
     """
-    role = _unwrap_role(output_message.role) or "assistant"
+    role = _unwrap_role(output_message.role) or Role.ASSISTANT.value
     parts = _parts_from_content(output_message.content)
     return OutputMessage(role=role, parts=parts, finish_reason="")
 

--- a/instrumentation/opentelemetry-instrumentation-genai-smolagents/src/opentelemetry/instrumentation/genai/smolagents/patch.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-smolagents/src/opentelemetry/instrumentation/genai/smolagents/patch.py
@@ -30,7 +30,7 @@ from opentelemetry.semconv._incubating.attributes import (
 from opentelemetry.util.genai.handler import TelemetryHandler
 from opentelemetry.util.genai.invocation import InferenceInvocation
 from opentelemetry.util.genai.stream import SyncStreamWrapper
-from opentelemetry.util.genai.types import OutputMessage, TextPart
+from opentelemetry.util.genai.types import OutputMessage, Role, TextPart
 
 from ._messages import (
     to_input_messages,
@@ -349,7 +349,7 @@ class _ModelStreamWrapper(SyncStreamWrapper["ChatMessageStreamDelta"]):
         # Deltas carry no finish reason, and defaulting to "stop" would hide a
         # generation cut short by a token limit.
         return OutputMessage(
-            role="assistant",
+            role=Role.ASSISTANT.value,
             parts=[TextPart(content=content)],
             finish_reason="",
         )

--- a/instrumentation/opentelemetry-instrumentation-google-genai/src/opentelemetry/instrumentation/google_genai/interactions.py
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/src/opentelemetry/instrumentation/google_genai/interactions.py
@@ -99,6 +99,7 @@ from opentelemetry.util.genai.types import (
     GenericToolDefinition,
     InputMessage,
     OutputMessage,
+    Role,
     TextPart,
     ToolCallRequestPart,
     ToolCallResponsePart,
@@ -175,7 +176,9 @@ def _interactions_input_to_messages(
         return []
     if isinstance(input_data, str):
         return [
-            InputMessage(role="user", parts=[TextPart(content=input_data)])
+            InputMessage(
+                role=Role.USER.value, parts=[TextPart(content=input_data)]
+            )
         ]
 
     if not isinstance(input_data, Sequence):
@@ -213,7 +216,7 @@ def _interactions_input_to_messages(
             part = GenericPart(type=item_type, value=type(item).__name__)
             parts.append(part)
 
-    return [InputMessage(role="user", parts=parts)]
+    return [InputMessage(role=Role.USER.value, parts=parts)]
 
 
 def _get_interaction_output_text(interaction: Interaction) -> str:
@@ -245,7 +248,7 @@ def _interactions_response_to_messages(
     output_text = _get_interaction_output_text(interaction)
     return [
         OutputMessage(
-            role="assistant",
+            role=Role.ASSISTANT.value,
             parts=[TextPart(content=output_text)],
             finish_reason="stop",
         )

--- a/instrumentation/opentelemetry-instrumentation-google-genai/src/opentelemetry/instrumentation/google_genai/message.py
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/src/opentelemetry/instrumentation/google_genai/message.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import logging
-from enum import Enum
 
 from google.genai import types as genai_types
 
@@ -14,19 +13,12 @@ from opentelemetry.util.genai.types import (
     InputMessage,
     MessagePart,
     OutputMessage,
+    Role,
     TextPart,
     ToolCallRequestPart,
     ToolCallResponsePart,
     UriPart,
 )
-
-
-class Role(str, Enum):
-    SYSTEM = "system"
-    USER = "user"
-    ASSISTANT = "assistant"
-    TOOL = "tool"
-
 
 _logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Closes #534.

Replaces hardcoded role literals and google-genai's private `Role` enum with `opentelemetry.util.genai.types.Role` across all instrumentations that emit a role they control: google-genai, smolagents, openai, agno, qwen-agent, bedrock, portkey, and llama-index. Anthropic is passthrough-only and is unchanged. Portkey's `opentelemetry-util-genai` floor is bumped to `1.2b0.dev` where `Role` was introduced, matching every other package; its `oldest` tox env gains the same `-e util/opentelemetry-util-genai` workaround the other packages already carry.

No behaviour change — the enum values are identical to the literals they replace.

Made with [Cursor](https://cursor.com)