### PR TITLE
[opentelemetry-util-genai] Keep tool_call_id and tool_description off start attributes

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-genai-agno/src/opentelemetry/instrumentation/genai/agno/patch.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-agno/src/opentelemetry/instrumentation/genai/agno/patch.py
@@ -258,10 +258,12 @@ def _start_tool_invocation(
 
     invocation = handler.tool(
         name=str(tool_name),
-        tool_call_id=str(tool_call_id) if tool_call_id else None,
         tool_type="function",
-        tool_description=str(tool_desc) if tool_desc else None,
     )
+    if tool_call_id:
+        invocation.tool_call_id = str(tool_call_id)
+    if tool_desc:
+        invocation.tool_description = str(tool_desc)
     _set_tool_invocation_input(invocation, instance, capture_content)
     return invocation
 

--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/src/opentelemetry/instrumentation/genai/langchain/callback_handler.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/src/opentelemetry/instrumentation/genai/langchain/callback_handler.py
@@ -586,10 +586,10 @@ class OpenTelemetryLangChainCallbackHandler(BaseCallbackHandler):
 
         tool_invocation = self._telemetry_handler.tool(
             name=name,
-            tool_description=description,
             tool_type="function",
             agent_name=agent_name,
         )
+        tool_invocation.tool_description = description
         tool_invocation.arguments = arguments
         tool_call_id = kwargs.get("tool_call_id")
         if tool_call_id:

--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/tests/conformance/tool_calling.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/tests/conformance/tool_calling.py
@@ -126,9 +126,9 @@ class ToolCallingScenario(Scenario):
                     for tool_call in first_response.tool_calls:
                         with tool_handler.tool(
                             tool_call["name"],
-                            tool_call_id=tool_call["id"],
                             tool_type="function",
                         ) as invocation:
+                            invocation.tool_call_id = tool_call["id"]
                             result = _execute_weather_tool(
                                 json.dumps(tool_call["args"])
                             )

--- a/instrumentation/opentelemetry-instrumentation-genai-llama-index/src/opentelemetry/instrumentation/genai/llama_index/_handler.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-llama-index/src/opentelemetry/instrumentation/genai/llama_index/_handler.py
@@ -451,10 +451,10 @@ class LlamaIndexSpanHandler(BaseSpanHandler[_LlamaIndexInvocation]):
             )
             tool_invocation = self._handler.tool(
                 tool_call.tool_name,
-                tool_call_id=tool_call.tool_id,
                 tool_type=tool_type,
-                tool_description=tool_description,
             )
+            tool_invocation.tool_call_id = tool_call.tool_id
+            tool_invocation.tool_description = tool_description
             if tool_invocation.should_capture_content_on_span:
                 tool_invocation.arguments = cast(
                     dict[str, Any], cast(Any, tool_call).tool_kwargs
@@ -475,8 +475,8 @@ class LlamaIndexSpanHandler(BaseSpanHandler[_LlamaIndexInvocation]):
             tool_invocation = self._handler.tool(
                 metadata.get_name(),
                 tool_type="function",
-                tool_description=metadata.description or None,
             )
+            tool_invocation.tool_description = metadata.description or None
             if tool_invocation.should_capture_content_on_span:
                 tool_invocation.arguments = _tool_arguments(
                     instance, bound_args

--- a/instrumentation/opentelemetry-instrumentation-genai-qwen-agent/src/opentelemetry/instrumentation/genai/qwen_agent/patch.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-qwen-agent/src/opentelemetry/instrumentation/genai/qwen_agent/patch.py
@@ -97,10 +97,12 @@ def wrap_agent_call_tool(
 
     invocation = handler.tool(
         tool_name,
-        tool_call_id=find_tool_call_id(kwargs.get("messages"), tool_name),
         tool_type="function",
-        tool_description=getattr(tool, "description", None),
     )
+    invocation.tool_call_id = find_tool_call_id(
+        kwargs.get("messages"), tool_name
+    )
+    invocation.tool_description = getattr(tool, "description", None)
     if invocation.should_capture_content_on_span and tool_args is not None:
         invocation.arguments = tool_args
 

--- a/instrumentation/opentelemetry-instrumentation-google-genai/src/opentelemetry/instrumentation/google_genai/tool_call_wrapper.py
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/src/opentelemetry/instrumentation/google_genai/tool_call_wrapper.py
@@ -81,8 +81,8 @@ def _wrap_tool_function(
             # In the future that could change (see https://github.com/open-telemetry/opentelemetry-specification/pull/4485), and we could possibly stop using json.dumps here.
             with telemetry_handler.tool(
                 tool_function.__name__,
-                tool_description=tool_function.__doc__,
             ) as tool_invocation:
+                tool_invocation.tool_description = tool_function.__doc__
                 # Do this before calling the tool in case that crashes.
                 if tool_invocation.should_capture_content_on_span:
                     tool_invocation.arguments = json.dumps(
@@ -100,8 +100,8 @@ def _wrap_tool_function(
         def wrapped_function(*args, **kwargs):
             with telemetry_handler.tool(
                 tool_function.__name__,
-                tool_description=tool_function.__doc__,
             ) as tool_invocation:
+                tool_invocation.tool_description = tool_function.__doc__
                 # Do this before calling the tool in case that crashes.
                 if tool_invocation.should_capture_content_on_span:
                     tool_invocation.arguments = json.dumps(

--- a/util/opentelemetry-util-genai/.changelog/577.changed
+++ b/util/opentelemetry-util-genai/.changelog/577.changed
@@ -1,0 +1,1 @@
+Remove `tool_call_id` and `tool_description` from `execute_tool` start attributes and set them on the invocation instance instead.

--- a/util/opentelemetry-util-genai/.changelog/577.deprecated
+++ b/util/opentelemetry-util-genai/.changelog/577.deprecated
@@ -1,0 +1,1 @@
+Deprecate passing `tool_call_id` and `tool_description` as keyword arguments to `handler.tool()`.

--- a/util/opentelemetry-util-genai/AGENTS.md
+++ b/util/opentelemetry-util-genai/AGENTS.md
@@ -45,7 +45,7 @@ Factory methods on `TelemetryHandler` (`handler.py`):
 - `embedding(provider, request_model, *, server_address, server_port)` → `EmbeddingInvocation`
 - `retrieval(*, data_source_id, provider, request_model, server_address, server_port)` → `RetrievalInvocation`
 - `fetch_response(provider, *, response_id, server_address, server_port)` → `FetchResponseInvocation`
-- `tool(name, *, tool_type, agent_name)` → `ToolInvocation`
+- `tool(name, *, tool_type, agent_name, tool_call_id=None, tool_description=None)` → `ToolInvocation` (passing tool_call_id/tool_description is deprecated; set invocation.tool_call_id / invocation.tool_description instead)
 - `workflow(name)` → `WorkflowInvocation`
 
 The returned object can also be used as a context manager (`with ... as invocation:`) when the span lifetime maps cleanly to a `with` block.

--- a/util/opentelemetry-util-genai/AGENTS.md
+++ b/util/opentelemetry-util-genai/AGENTS.md
@@ -45,7 +45,7 @@ Factory methods on `TelemetryHandler` (`handler.py`):
 - `embedding(provider, request_model, *, server_address, server_port)` → `EmbeddingInvocation`
 - `retrieval(*, data_source_id, provider, request_model, server_address, server_port)` → `RetrievalInvocation`
 - `fetch_response(provider, *, response_id, server_address, server_port)` → `FetchResponseInvocation`
-- `tool(name, *, arguments, tool_call_id, tool_type, tool_description)` → `ToolInvocation`
+- `tool(name, *, tool_type, agent_name)` → `ToolInvocation`
 - `workflow(name)` → `WorkflowInvocation`
 
 The returned object can also be used as a context manager (`with ... as invocation:`) when the span lifetime maps cleanly to a `with` block.

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_tool_invocation.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_tool_invocation.py
@@ -60,12 +60,18 @@ class ToolInvocation(GenAIInvocation):
         completion_hook: CompletionHook,
         name: str,
         *,
-        tool_call_id: str | None = None,
         tool_type: str | None = None,
-        tool_description: str | None = None,
         agent_name: str | None = None,
+        tool_call_id: str | None = None,
+        tool_description: str | None = None,
     ) -> None:
-        """Use handler.tool(name) instead of calling this directly."""
+        """Use handler.tool(name) instead of calling this directly.
+
+        .. deprecated:: 1.2b0
+            Passing ``tool_call_id`` or ``tool_description`` to the constructor
+            is deprecated. Set ``invocation.tool_call_id`` and
+            ``invocation.tool_description`` on the returned invocation instead.
+        """
         _operation_name = GenAI.GenAiOperationNameValues.EXECUTE_TOOL.value
         super().__init__(
             tracer,
@@ -84,30 +90,17 @@ class ToolInvocation(GenAIInvocation):
         # instrumentation library before assigning these attributes
         # to the invocation.
         self.arguments: AnyValue | None = None
-        self._tool_call_id: str | None = tool_call_id
+        self.tool_call_id: str | None = tool_call_id
+        self.tool_description: str | None = tool_description
         self._tool_type: str | None = tool_type
-        self._tool_description: str | None = tool_description
         self._agent_name: str | None = agent_name
         self._start(self._get_start_attributes())
-
-    @property
-    def tool_call_id(self) -> str | None:
-        """The tool call identifier."""
-        return self._tool_call_id
-
-    @tool_call_id.setter
-    def tool_call_id(self, value: str | None) -> None:
-        self._tool_call_id = value
-        if value is not None and self.span.is_recording():
-            self.span.set_attribute(GenAI.GEN_AI_TOOL_CALL_ID, value)
 
     def _get_start_attributes(self) -> dict[str, AttributeValue]:
         """Return sampling-relevant attributes available at span creation time."""
         optional_attrs = (
             (GenAI.GEN_AI_TOOL_NAME, self._name),
-            (GenAI.GEN_AI_TOOL_CALL_ID, self._tool_call_id),
             (GenAI.GEN_AI_TOOL_TYPE, self._tool_type),
-            (GenAI.GEN_AI_TOOL_DESCRIPTION, self._tool_description),
         )
         return {
             GenAI.GEN_AI_OPERATION_NAME: self._operation_name,
@@ -125,6 +118,8 @@ class ToolInvocation(GenAIInvocation):
         if error is not None:
             self._apply_error_attributes(error)
         optional_attrs = (
+            (GenAI.GEN_AI_TOOL_CALL_ID, self.tool_call_id),
+            (GenAI.GEN_AI_TOOL_DESCRIPTION, self.tool_description),
             (GenAI.GEN_AI_AGENT_NAME, self._agent_name),
             (
                 GenAI.GEN_AI_TOOL_CALL_ARGUMENTS,

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/handler.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/handler.py
@@ -234,8 +234,8 @@ class TelemetryHandler:
         self,
         name: str,
         *,
-        tool_call_id: str | None = None,
         tool_type: str | None = None,
+        tool_call_id: str | None = None,
         tool_description: str | None = None,
     ) -> ToolInvocation:
         """Create and start a tool invocation.
@@ -252,8 +252,8 @@ class TelemetryHandler:
             self._logger,
             self._completion_hook,
             name,
-            tool_call_id=tool_call_id,
             tool_type=tool_type,
+            tool_call_id=tool_call_id,
             tool_description=tool_description,
         )
 
@@ -403,12 +403,17 @@ class TelemetryHandler:
         self,
         name: str,
         *,
-        tool_call_id: str | None = None,
         tool_type: str | None = None,
-        tool_description: str | None = None,
         agent_name: str | None = None,
+        tool_call_id: str | None = None,
+        tool_description: str | None = None,
     ) -> ToolInvocation:
         """Returns a Tool invocation. Starts span when called.
+
+        .. deprecated:: 1.2b0
+            Passing ``tool_call_id`` or ``tool_description`` as keyword
+            arguments is deprecated. Set ``invocation.tool_call_id`` and
+            ``invocation.tool_description`` on the returned invocation instead.
 
         Returned object can be used as a ContextManager which automatically calls `stop` or `fail`
         to finalize the span upon exiting. If not used as a ContextManager, the caller is
@@ -424,10 +429,10 @@ class TelemetryHandler:
             self._logger,
             self._completion_hook,
             name,
-            tool_call_id=tool_call_id,
             tool_type=tool_type,
-            tool_description=tool_description,
             agent_name=agent_name,
+            tool_call_id=tool_call_id,
+            tool_description=tool_description,
         )
 
     def start_invoke_local_agent(

--- a/util/opentelemetry-util-genai/tests/test_toolcall.py
+++ b/util/opentelemetry-util-genai/tests/test_toolcall.py
@@ -198,7 +198,7 @@ def test_tool_span_is_internal_kind():
 
 
 def test_start_tool_passes_sampling_attributes_at_span_creation():
-    """Verify that sampling-relevant attributes are available at start_span() time for tools."""
+    """Verify that only sampling-relevant attributes are available at start_span() time for tools."""
     captured_attributes = {}
 
     class AttributeCapturingSampler:  # pylint: disable=no-self-use
@@ -232,12 +232,28 @@ def test_start_tool_passes_sampling_attributes_at_span_creation():
 
     assert captured_attributes[GenAI.GEN_AI_OPERATION_NAME] == "execute_tool"
     assert captured_attributes[GenAI.GEN_AI_TOOL_NAME] == "get_weather"
-    assert captured_attributes[GenAI.GEN_AI_TOOL_CALL_ID] == "call_123"
     assert captured_attributes[GenAI.GEN_AI_TOOL_TYPE] == "function"
+    assert GenAI.GEN_AI_TOOL_CALL_ID not in captured_attributes
+    assert GenAI.GEN_AI_TOOL_DESCRIPTION not in captured_attributes
+
+    finished_attrs = span_exporter.get_finished_spans()[0].attributes
+    assert finished_attrs[GenAI.GEN_AI_TOOL_CALL_ID] == "call_123"
     assert (
-        captured_attributes[GenAI.GEN_AI_TOOL_DESCRIPTION]
+        finished_attrs[GenAI.GEN_AI_TOOL_DESCRIPTION]
         == "Gets weather for a location"
     )
+
+
+def test_tool_call_id_and_description_on_invocation_instance():
+    span_exporter, handler = _make_span_exporter_and_handler()
+    invocation = handler.tool("get_weather", tool_type="function")
+    invocation.tool_call_id = "call_456"
+    invocation.tool_description = "Weather info"
+    invocation.stop()
+
+    finished_attrs = span_exporter.get_finished_spans()[0].attributes
+    assert finished_attrs[GenAI.GEN_AI_TOOL_CALL_ID] == "call_456"
+    assert finished_attrs[GenAI.GEN_AI_TOOL_DESCRIPTION] == "Weather info"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Removes `gen_ai.tool.call.id` and `gen_ai.tool.description` from `execute_tool` start attributes and populates them at span finish instead.  Neither are marked as sampling relevant in semconv:

https://github.com/open-telemetry/semantic-conventions-genai/blob/3bda5760dcc5727a3c3ca4e898e79fad646988bc/docs/gen-ai/gen-ai-spans.md?plain=1#L1209-L1211 

Deprecates passing them as keyword arguments to `handler.tool()` (so currently released libs won't fail on new utils).
