### PR TITLE
[`opentelemetry-instrumentation-genai-openai-agents`] Record `gen_ai.tool.call.arguments` on execute_tool spans

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-genai-openai-agents/.changelog/588.fixed
+++ b/instrumentation/opentelemetry-instrumentation-genai-openai-agents/.changelog/588.fixed
@@ -1,0 +1,1 @@
+Record ``gen_ai.tool.call.arguments`` on ``execute_tool`` spans.

--- a/instrumentation/opentelemetry-instrumentation-genai-openai-agents/src/opentelemetry/instrumentation/genai/openai_agents/processor.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-openai-agents/src/opentelemetry/instrumentation/genai/openai_agents/processor.py
@@ -135,8 +135,10 @@ class GenAITracingProcessor(TracingProcessor):
         invocation = self._invocations.pop(span, None)
         if invocation is None:
             return
-        if isinstance(invocation, ToolInvocation) and isinstance(
-            span.span_data, FunctionSpanData
+        if (
+            isinstance(invocation, ToolInvocation)
+            and isinstance(span.span_data, FunctionSpanData)
+            and invocation.should_capture_content_on_span
         ):
             arguments = span.span_data.input
             if arguments:

--- a/instrumentation/opentelemetry-instrumentation-genai-openai-agents/src/opentelemetry/instrumentation/genai/openai_agents/processor.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-openai-agents/src/opentelemetry/instrumentation/genai/openai_agents/processor.py
@@ -32,7 +32,9 @@ the openai SDK directly and produces those.
 
 from __future__ import annotations
 
+import json
 import weakref
+from collections.abc import Mapping
 from typing import Any
 
 from agents.tracing import Span, Trace, TracingProcessor
@@ -53,11 +55,20 @@ from opentelemetry.util.genai.invocation import (
     ToolInvocation,
 )
 from opentelemetry.util.genai.types import Error
+from opentelemetry.util.types import AnyValue
 
 # Non-semconv attribute: surfaces the workflow name on the workflow span
 # so callers can query/filter by it. util-genai's WorkflowInvocation
 # only puts the name in the span name, not as an attribute.
 _WORKFLOW_NAME_ATTR = "gen_ai.workflow.name"
+
+
+def _tool_arguments(raw: str) -> AnyValue:
+    try:
+        parsed: AnyValue = json.loads(raw)
+    except ValueError:
+        return raw
+    return parsed if isinstance(parsed, Mapping) else raw
 
 
 class GenAITracingProcessor(TracingProcessor):
@@ -107,8 +118,6 @@ class GenAITracingProcessor(TracingProcessor):
                 tool_type="function",
             )
 
-            invocation.arguments = span_data.input
-
             # ToolInvocation does not include provider in metric attributes
             # by default; set it so gen_ai.client.operation.duration carries
             # the required gen_ai.provider.name attribute.
@@ -129,6 +138,9 @@ class GenAITracingProcessor(TracingProcessor):
         if isinstance(invocation, ToolInvocation) and isinstance(
             span.span_data, FunctionSpanData
         ):
+            arguments = span.span_data.input
+            if arguments:
+                invocation.arguments = _tool_arguments(arguments)
             output = span.span_data.output
             if output is not None:
                 invocation.tool_result = (

--- a/instrumentation/opentelemetry-instrumentation-genai-openai-agents/tests/cassettes/test_runner_records_tool_call_arguments.yaml
+++ b/instrumentation/opentelemetry-instrumentation-genai-openai-agents/tests/cassettes/test_runner_records_tool_call_arguments.yaml
@@ -1,0 +1,491 @@
+interactions:
+- request:
+    body: |-
+      {
+        "include": [],
+        "input": [
+          {
+            "content": "what is the weather in Barcelona?",
+            "role": "user"
+          }
+        ],
+        "model": "gpt-4o-mini",
+        "prompt_cache_key": "agents-sdk:run:1c830f37632e4cdca8317169ce1fc896",
+        "tools": [
+          {
+            "name": "_get_weather",
+            "parameters": {
+              "properties": {
+                "city": {
+                  "title": "City",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "city"
+              ],
+              "title": "_get_weather_args",
+              "type": "object",
+              "additionalProperties": false
+            },
+            "strict": true,
+            "type": "function",
+            "description": "Return a canned forecast for the requested city."
+          }
+        ]
+      }
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - Bearer test_openai_api_key
+      connection:
+      - keep-alive
+      content-length:
+      - '471'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      user-agent:
+      - Agents/Python 0.22.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 3.1.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.12.13
+    method: POST
+    uri: https://api.openai.com/v1/responses
+  response:
+    body:
+      string: |-
+        {
+          "id": "resp_049be054d2c264e3006a9910eef7c487d090a61248660132d9",
+          "object": "response",
+          "created_at": 1788416238,
+          "status": "completed",
+          "background": false,
+          "billing": {
+            "payer": "developer"
+          },
+          "completed_at": 1788416240,
+          "error": null,
+          "frequency_penalty": 0.0,
+          "incomplete_details": null,
+          "instructions": null,
+          "max_output_tokens": null,
+          "max_tool_calls": null,
+          "model": "gpt-4o-mini-2024-07-18",
+          "moderation": null,
+          "output": [
+            {
+              "id": "fc_049be054d2c264e3006a9910f0610c87d0a663161c77a94852",
+              "type": "function_call",
+              "status": "completed",
+              "arguments": "{\"city\":\"Barcelona\"}",
+              "call_id": "call_47t9aH50qU357sccNgrzt01I",
+              "name": "_get_weather"
+            }
+          ],
+          "parallel_tool_calls": true,
+          "presence_penalty": 0.0,
+          "previous_response_id": null,
+          "prompt_cache_key": "agents-sdk:run:1c830f37632e4cdca8317169ce1fc896",
+          "prompt_cache_retention": "in_memory",
+          "reasoning": {
+            "context": null,
+            "effort": null,
+            "summary": null
+          },
+          "safety_identifier": null,
+          "service_tier": "default",
+          "store": true,
+          "temperature": 1.0,
+          "text": {
+            "format": {
+              "type": "text"
+            },
+            "verbosity": "medium"
+          },
+          "tool_choice": "auto",
+          "tool_usage": {
+            "image_gen": {
+              "input_tokens": 0,
+              "input_tokens_details": {
+                "image_tokens": 0,
+                "text_tokens": 0
+              },
+              "output_tokens": 0,
+              "output_tokens_details": {
+                "image_tokens": 0,
+                "text_tokens": 0
+              },
+              "total_tokens": 0
+            },
+            "web_search": {
+              "num_requests": 0
+            }
+          },
+          "tools": [
+            {
+              "type": "function",
+              "description": "Return a canned forecast for the requested city.",
+              "name": "_get_weather",
+              "output_schema": null,
+              "parameters": {
+                "properties": {
+                  "city": {
+                    "title": "City",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "city"
+                ],
+                "title": "_get_weather_args",
+                "type": "object",
+                "additionalProperties": false
+              },
+              "strict": true
+            }
+          ],
+          "top_logprobs": 0,
+          "top_p": 1.0,
+          "truncation": "disabled",
+          "usage": {
+            "input_tokens": 57,
+            "input_tokens_details": {
+              "cache_write_tokens": 0,
+              "cached_tokens": 0
+            },
+            "output_tokens": 16,
+            "output_tokens_details": {
+              "reasoning_tokens": 0
+            },
+            "total_tokens": 73
+          },
+          "user": null,
+          "metadata": {}
+        }
+    headers:
+      access-control-expose-headers:
+      - X-Request-ID
+      - CF-Ray
+      - CF-Ray
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      cf-ray:
+      - a352a16facdfbe62-SJC
+      connection:
+      - keep-alive
+      content-length:
+      - '2465'
+      content-type:
+      - application/json
+      date:
+      - Thu, 03 Sep 2026 06:17:20 GMT
+      openai-organization: test_openai_org_id
+      openai-processing-ms:
+      - '1668'
+      openai-project: test_openai_project_id
+      openai-version:
+      - '2020-10-01'
+      server:
+      - cloudflare
+      set-cookie: test_set_cookie
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+      x-content-type-options:
+      - nosniff
+      x-ratelimit-limit-requests:
+      - '5000'
+      x-ratelimit-limit-tokens:
+      - '4000000'
+      x-ratelimit-remaining-requests:
+      - '4999'
+      x-ratelimit-remaining-tokens:
+      - '3999726'
+      x-ratelimit-reset-requests:
+      - 12ms
+      x-ratelimit-reset-tokens:
+      - 4ms
+      x-request-id:
+      - req_c8d31b7a1c984605980f38fb02796c87
+    status:
+      code: 200
+      message: OK
+- request:
+    body: |-
+      {
+        "include": [],
+        "input": [
+          {
+            "content": "what is the weather in Barcelona?",
+            "role": "user"
+          },
+          {
+            "arguments": "{\"city\":\"Barcelona\"}",
+            "call_id": "call_47t9aH50qU357sccNgrzt01I",
+            "name": "_get_weather",
+            "type": "function_call",
+            "id": "fc_049be054d2c264e3006a9910f0610c87d0a663161c77a94852",
+            "status": "completed"
+          },
+          {
+            "call_id": "call_47t9aH50qU357sccNgrzt01I",
+            "output": "The forecast for Barcelona is sunny.",
+            "type": "function_call_output"
+          }
+        ],
+        "model": "gpt-4o-mini",
+        "prompt_cache_key": "agents-sdk:run:1c830f37632e4cdca8317169ce1fc896",
+        "tools": [
+          {
+            "name": "_get_weather",
+            "parameters": {
+              "properties": {
+                "city": {
+                  "title": "City",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "city"
+              ],
+              "title": "_get_weather_args",
+              "type": "object",
+              "additionalProperties": false
+            },
+            "strict": true,
+            "type": "function",
+            "description": "Return a canned forecast for the requested city."
+          }
+        ]
+      }
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - Bearer test_openai_api_key
+      connection:
+      - keep-alive
+      content-length:
+      - '803'
+      content-type:
+      - application/json
+      cookie:
+      - test_cookie
+      host:
+      - api.openai.com
+      user-agent:
+      - Agents/Python 0.22.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 3.1.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.12.13
+    method: POST
+    uri: https://api.openai.com/v1/responses
+  response:
+    body:
+      string: |-
+        {
+          "id": "resp_049be054d2c264e3006a9910f0e6dc87d0b214b3d55eb44d6a",
+          "object": "response",
+          "created_at": 1788416240,
+          "status": "completed",
+          "background": false,
+          "billing": {
+            "payer": "developer"
+          },
+          "completed_at": 1788416242,
+          "error": null,
+          "frequency_penalty": 0.0,
+          "incomplete_details": null,
+          "instructions": null,
+          "max_output_tokens": null,
+          "max_tool_calls": null,
+          "model": "gpt-4o-mini-2024-07-18",
+          "moderation": null,
+          "output": [
+            {
+              "id": "msg_049be054d2c264e3006a9910f2bc1887d08e083ba37193607c",
+              "type": "message",
+              "status": "completed",
+              "content": [
+                {
+                  "type": "output_text",
+                  "annotations": [],
+                  "logprobs": [],
+                  "text": "The weather in Barcelona is sunny. Enjoy your day!"
+                }
+              ],
+              "role": "assistant"
+            }
+          ],
+          "parallel_tool_calls": true,
+          "presence_penalty": 0.0,
+          "previous_response_id": null,
+          "prompt_cache_key": "agents-sdk:run:1c830f37632e4cdca8317169ce1fc896",
+          "prompt_cache_retention": "in_memory",
+          "reasoning": {
+            "context": null,
+            "effort": null,
+            "summary": null
+          },
+          "safety_identifier": null,
+          "service_tier": "default",
+          "store": true,
+          "temperature": 1.0,
+          "text": {
+            "format": {
+              "type": "text"
+            },
+            "verbosity": "medium"
+          },
+          "tool_choice": "auto",
+          "tool_usage": {
+            "image_gen": {
+              "input_tokens": 0,
+              "input_tokens_details": {
+                "image_tokens": 0,
+                "text_tokens": 0
+              },
+              "output_tokens": 0,
+              "output_tokens_details": {
+                "image_tokens": 0,
+                "text_tokens": 0
+              },
+              "total_tokens": 0
+            },
+            "web_search": {
+              "num_requests": 0
+            }
+          },
+          "tools": [
+            {
+              "type": "function",
+              "description": "Return a canned forecast for the requested city.",
+              "name": "_get_weather",
+              "output_schema": null,
+              "parameters": {
+                "properties": {
+                  "city": {
+                    "title": "City",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "city"
+                ],
+                "title": "_get_weather_args",
+                "type": "object",
+                "additionalProperties": false
+              },
+              "strict": true
+            }
+          ],
+          "top_logprobs": 0,
+          "top_p": 1.0,
+          "truncation": "disabled",
+          "usage": {
+            "input_tokens": 89,
+            "input_tokens_details": {
+              "cache_write_tokens": 0,
+              "cached_tokens": 0
+            },
+            "output_tokens": 13,
+            "output_tokens_details": {
+              "reasoning_tokens": 0
+            },
+            "total_tokens": 102
+          },
+          "user": null,
+          "metadata": {}
+        }
+    headers:
+      Set-Cookie: test_set_cookie
+      access-control-expose-headers:
+      - X-Request-ID
+      - CF-Ray
+      - CF-Ray
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      cf-ray:
+      - a352a181087cbe62-SJC
+      connection:
+      - keep-alive
+      content-length:
+      - '2568'
+      content-type:
+      - application/json
+      date:
+      - Thu, 03 Sep 2026 06:17:22 GMT
+      openai-organization: test_openai_org_id
+      openai-processing-ms:
+      - '2077'
+      openai-project: test_openai_project_id
+      openai-version:
+      - '2020-10-01'
+      server:
+      - cloudflare
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+      x-content-type-options:
+      - nosniff
+      x-ratelimit-limit-requests:
+      - '5000'
+      x-ratelimit-limit-tokens:
+      - '4000000'
+      x-ratelimit-remaining-requests:
+      - '4999'
+      x-ratelimit-remaining-tokens:
+      - '3999694'
+      x-ratelimit-reset-requests:
+      - 12ms
+      x-ratelimit-reset-tokens:
+      - 4ms
+      x-request-id:
+      - req_ccd52e3fa4794384a8ea141f73194807
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/instrumentation/opentelemetry-instrumentation-genai-openai-agents/tests/test_instrumentor.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-openai-agents/tests/test_instrumentor.py
@@ -122,6 +122,49 @@ def _failing_tool() -> str:
     raise ValueError("database connection failed")
 
 
+@agents.function_tool
+def _get_weather(city: str) -> str:
+    """Return a canned forecast for the requested city."""
+
+    return f"The forecast for {city} is sunny."
+
+
+@pytest.mark.vcr
+@pytest.mark.asyncio
+async def test_runner_records_tool_call_arguments(
+    tracer_provider: TracerProvider,
+    logger_provider: Any,
+    meter_provider: Any,
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    with instrument(
+        OpenAIAgentsInstrumentor(),
+        tracer_provider=tracer_provider,
+        logger_provider=logger_provider,
+        meter_provider=meter_provider,
+        content_capture="SPAN_ONLY",
+    ):
+        agent = agents.Agent(
+            name="test_agent",
+            model="gpt-4o-mini",
+            tools=[_get_weather],
+        )
+        await agents.Runner.run(agent, "what is the weather in Barcelona?")
+
+    spans = {s.name: s for s in span_exporter.get_finished_spans()}
+    assert "execute_tool _get_weather" in spans
+    tool_span = spans["execute_tool _get_weather"]
+    assert tool_span.attributes is not None
+    assert (
+        tool_span.attributes["gen_ai.tool.call.arguments"]
+        == '{"city":"Barcelona"}'
+    )
+    assert (
+        tool_span.attributes["gen_ai.tool.call.result"]
+        == "The forecast for Barcelona is sunny."
+    )
+
+
 @pytest.mark.vcr
 @pytest.mark.asyncio
 async def test_runner_failing_tool_records_span_error(

--- a/instrumentation/opentelemetry-instrumentation-genai-openai-agents/tests/test_processor.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-openai-agents/tests/test_processor.py
@@ -95,7 +95,7 @@ def test_function_span_creates_tool_invocation_and_sets_provider_metric() -> (
     span = _Span(
         FunctionSpanData(
             name="get_weather",
-            input='{"city":"BCN"}',
+            input=None,
             output=None,
         )
     )
@@ -107,15 +107,17 @@ def test_function_span_creates_tool_invocation_and_sets_provider_metric() -> (
     )
     tool_invocation = handler.tool.return_value
 
-    assert tool_invocation.arguments == '{"city":"BCN"}'
     assert (
         tool_invocation.metric_attributes["gen_ai.provider.name"] == "openai"
     )
 
-    # Output gets populated on the agents library span_data after the
-    # tool runs; our on_span_end reads it.
+    # Input and output both get populated on the agents library span_data
+    # while the tool runs, i.e. after on_span_start; our on_span_end reads
+    # them.
+    span.span_data.input = '{"city":"BCN"}'
     span.span_data.output = "sunny"
     processor.on_span_end(span)
+    assert tool_invocation.arguments == {"city": "BCN"}
     assert tool_invocation.tool_result == "sunny"
     tool_invocation.stop.assert_called_once_with()
 
@@ -191,6 +193,78 @@ def test_shutdown_stops_open_invocations() -> None:
     assert len(processor._invocations) == 0
 
 
+def test_tool_content_captured_from_span_end(
+    tracer_provider: TracerProvider,
+    span_exporter: InMemorySpanExporter,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Arguments the agents library fills in mid-span still land on the span."""
+    monkeypatch.setenv(
+        OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT, "SPAN_ONLY"
+    )
+    handler = TelemetryHandler(tracer_provider=tracer_provider)
+    processor = GenAITracingProcessor(handler, provider="openai")
+    span = _Span(FunctionSpanData(name="get_weather", input=None, output=None))
+
+    processor.on_span_start(span)
+    span.span_data.input = '{"city":"Barcelona"}'
+    span.span_data.output = "sunny"
+    processor.on_span_end(span)
+
+    (tool_span,) = span_exporter.get_finished_spans()
+    assert tool_span.attributes is not None
+    assert (
+        tool_span.attributes["gen_ai.tool.call.arguments"]
+        == '{"city":"Barcelona"}'
+    )
+    assert tool_span.attributes["gen_ai.tool.call.result"] == "sunny"
+
+
+@pytest.mark.parametrize(
+    ("span_data_input", "expected"),
+    [
+        # The spacing LiteLLM produces for Anthropic normalizes to the same
+        # value as the compact JSON the OpenAI APIs forward.
+        ('{"city": "Barcelona"}', '{"city":"Barcelona"}'),
+        ('{"city":"Barcelona"}', '{"city":"Barcelona"}'),
+        # A provider may emit something that isn't valid JSON, or valid JSON
+        # that isn't an object; neither may change the attribute's type.
+        ("city=Barcelona", "city=Barcelona"),
+        ("[1,2]", "[1,2]"),
+        ("42", "42"),
+        ("null", "null"),
+        # No arguments to record: `trace_include_sensitive_data=False` leaves
+        # `input` None, and tool types without arguments leave it empty.
+        (None, None),
+        ("", None),
+    ],
+)
+def test_tool_arguments_value_shapes(
+    span_data_input: str | None,
+    expected: str | None,
+    tracer_provider: TracerProvider,
+    span_exporter: InMemorySpanExporter,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT, "SPAN_ONLY"
+    )
+    handler = TelemetryHandler(tracer_provider=tracer_provider)
+    processor = GenAITracingProcessor(handler, provider="openai")
+    span = _Span(FunctionSpanData(name="get_weather", input=None, output=None))
+
+    processor.on_span_start(span)
+    span.span_data.input = span_data_input
+    processor.on_span_end(span)
+
+    (tool_span,) = span_exporter.get_finished_spans()
+    assert tool_span.attributes is not None
+    if expected is None:
+        assert "gen_ai.tool.call.arguments" not in tool_span.attributes
+    else:
+        assert tool_span.attributes["gen_ai.tool.call.arguments"] == expected
+
+
 def test_no_content_captured_when_capture_env_unset(
     tracer_provider: TracerProvider,
     span_exporter: InMemorySpanExporter,
@@ -201,15 +275,11 @@ def test_no_content_captured_when_capture_env_unset(
     )
     handler = TelemetryHandler(tracer_provider=tracer_provider)
     processor = GenAITracingProcessor(handler, provider="openai")
-    span = _Span(
-        FunctionSpanData(
-            name="get_weather",
-            input='{"city":"Barcelona"}',
-            output="sunny",
-        )
-    )
+    span = _Span(FunctionSpanData(name="get_weather", input=None, output=None))
 
     processor.on_span_start(span)
+    span.span_data.input = '{"city":"Barcelona"}'
+    span.span_data.output = "sunny"
     processor.on_span_end(span)
 
     (tool_span,) = span_exporter.get_finished_spans()

--- a/instrumentation/opentelemetry-instrumentation-genai-openai-agents/tests/test_processor.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-openai-agents/tests/test_processor.py
@@ -89,7 +89,9 @@ def test_function_span_creates_tool_invocation_and_sets_provider_metric() -> (
 ):
     handler = _build_handler()
     handler.tool.return_value = MagicMock(
-        spec=ToolInvocation, metric_attributes={}
+        spec=ToolInvocation,
+        metric_attributes={},
+        should_capture_content_on_span=True,
     )
     processor = GenAITracingProcessor(handler, provider="openai")
     span = _Span(
@@ -122,10 +124,37 @@ def test_function_span_creates_tool_invocation_and_sets_provider_metric() -> (
     tool_invocation.stop.assert_called_once_with()
 
 
+def test_function_span_skips_content_when_capture_disabled() -> None:
+    handler = _build_handler()
+    handler.tool.return_value = MagicMock(
+        spec=ToolInvocation,
+        metric_attributes={},
+        should_capture_content_on_span=False,
+    )
+    processor = GenAITracingProcessor(handler, provider="openai")
+    span = _Span(FunctionSpanData(name="get_weather", input=None, output=None))
+
+    processor.on_span_start(span)
+    span.span_data.input = '{"city":"BCN"}'
+    span.span_data.output = "sunny"
+    processor.on_span_end(span)
+
+    tool_invocation = handler.tool.return_value
+    # A spec'd mock rejects reads of attributes nothing assigned, so these
+    # assert the processor skipped the serialization work entirely.
+    with pytest.raises(AttributeError):
+        _ = tool_invocation.arguments
+    with pytest.raises(AttributeError):
+        _ = tool_invocation.tool_result
+    tool_invocation.stop.assert_called_once_with()
+
+
 def test_function_span_without_output_still_stops() -> None:
     handler = _build_handler()
     handler.tool.return_value = MagicMock(
-        spec=ToolInvocation, metric_attributes={}
+        spec=ToolInvocation,
+        metric_attributes={},
+        should_capture_content_on_span=True,
     )
     processor = GenAITracingProcessor(handler, provider="openai")
     span = _Span(FunctionSpanData(name="noop", input=None, output=None))


### PR DESCRIPTION
# Description

`execute_tool` spans never carried `gen_ai.tool.call.arguments`, even with
content capture enabled. The processor read `FunctionSpanData.input` in
`on_span_start`, but the agents library assigns it inside the
`with function_span(...)` block, so the read always saw `None`. This reads it in
`on_span_end` instead, next to the existing `output` read, and deserializes it
to the object semconv specifies.

`input` stays `None` when a run sets `RunConfig.trace_include_sensitive_data=False`,
so the attribute is absent for those runs. A string that does not parse to a
JSON object is recorded as-is.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

New `test_runner_records_tool_call_arguments` drives `Runner.run` against a
cassette and asserts the attribute on the exported span. New parametrized
`test_tool_arguments_value_shapes` covers the argument string shapes providers
produce, plus the `None` and empty cases. Three existing tests pre-set
`FunctionSpanData.input` at construction, which the real SDK never does and
which is why they passed while the attribute was missing; they now assign it
after `on_span_start`.

- [x] `openai-agents` suite: 30 passed at the declared floor
      (`openai-agents==0.3.3`) and at latest (`openai-agents==0.22.0`)
- [x] `py314-test-instrumentation-genai-openai_agents-conformance`: 1 passed
- [x] `tox -e precommit` (ruff, ruff-format, rstcheck) and `pyright` clean

# Checklist

- [x] Followed the style guidelines of this project
- [x] Changelog updated if the change requires an entry
- [x] Unit tests added
- [ ] Documentation updated