### PR TITLE
[`opentelemetry-instrumentation-genai-dspy`] Support copy and deepcopy on wrapped DSPy methods

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -35,7 +35,9 @@ jobs:
           persist-credentials: false
 
       - name: Fetch base branch
-        run: git fetch origin ${GITHUB_BASE_REF} --depth=1
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref || github.base_ref || 'main' }}
+        run: git fetch origin "${BASE_REF}" --depth=1
 
       - name: Ensure no direct changes to CHANGELOG.md
         run: |

--- a/instrumentation/opentelemetry-instrumentation-genai-dspy/.changelog/591.added
+++ b/instrumentation/opentelemetry-instrumentation-genai-dspy/.changelog/591.added
@@ -1,0 +1,1 @@
+Support copy and deepcopy on wrapped DSPy methods to ensure compatibility with DSPy compilation and optimizers.

--- a/instrumentation/opentelemetry-instrumentation-genai-dspy/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-genai-dspy/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
   "opentelemetry-instrumentation >= 0.64b0, <1",
   "opentelemetry-semantic-conventions >= 0.64b0, <1",
   "opentelemetry-util-genai >= 1.2b0.dev, <2",
+  "wrapt >= 1.17.0, < 3.0.0",
 ]
 
 [project.optional-dependencies]

--- a/instrumentation/opentelemetry-instrumentation-genai-dspy/src/opentelemetry/instrumentation/genai/dspy/patch.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-dspy/src/opentelemetry/instrumentation/genai/dspy/patch.py
@@ -49,7 +49,15 @@ _REACT_V2_MODULE = "dspy.predict.react_v2"
 _REACT_V2_CLASS = "ReActV2"
 
 
-class _CopyableBoundFunctionWrapper(BoundFunctionWrapper[Any, Any]):
+if TYPE_CHECKING:
+    _BoundFunctionWrapper = BoundFunctionWrapper[Any, Any]
+    _FunctionWrapper = FunctionWrapper[Any, Any]
+else:
+    _BoundFunctionWrapper = BoundFunctionWrapper
+    _FunctionWrapper = FunctionWrapper
+
+
+class _CopyableBoundFunctionWrapper(_BoundFunctionWrapper):
     """BoundFunctionWrapper that supports copy and deepcopy."""
 
     def __init__(
@@ -113,7 +121,7 @@ class _CopyableBoundFunctionWrapper(BoundFunctionWrapper[Any, Any]):
         )
 
 
-class _CopyableFunctionWrapper(FunctionWrapper[Any, Any]):
+class _CopyableFunctionWrapper(_FunctionWrapper):
     """FunctionWrapper that supports copy and deepcopy."""
 
     __bound_function_wrapper__ = _CopyableBoundFunctionWrapper

--- a/instrumentation/opentelemetry-instrumentation-genai-dspy/src/opentelemetry/instrumentation/genai/dspy/patch.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-dspy/src/opentelemetry/instrumentation/genai/dspy/patch.py
@@ -8,9 +8,10 @@ from __future__ import annotations
 import inspect
 import sys
 from collections.abc import Awaitable, Callable
+from copy import copy, deepcopy
 from typing import TYPE_CHECKING, Any
 
-from wrapt import wrap_function_wrapper
+from wrapt import BoundFunctionWrapper, FunctionWrapper, wrap_object
 
 from opentelemetry.instrumentation.genai.dspy.utils import (
     SENTINEL_TOOL_NAMES,
@@ -42,29 +43,77 @@ _REACT_V2_MODULE = "dspy.predict.react_v2"
 _REACT_V2_CLASS = "ReActV2"
 
 
+class _CopyableBoundFunctionWrapper(BoundFunctionWrapper[Any, Any]):
+    """BoundFunctionWrapper that supports copy and deepcopy."""
+
+    def __copy__(self) -> Any:
+        wrapped: Any = self.__wrapped__
+        return copy(wrapped)
+
+    def __deepcopy__(self, memo: dict[Any, Any]) -> Any:
+        if self._self_instance is not None:
+            copied_instance: Any = deepcopy(self._self_instance, memo)
+            attr_name: str | None = getattr(self, "__name__", None)
+            if attr_name and hasattr(copied_instance, attr_name):
+                return getattr(copied_instance, attr_name)
+        return copy(self)
+
+
+class _CopyableFunctionWrapper(FunctionWrapper[Any, Any]):
+    """FunctionWrapper that supports copy and deepcopy."""
+
+    __bound_function_wrapper__ = _CopyableBoundFunctionWrapper
+
+    def __copy__(self) -> _CopyableFunctionWrapper:
+        wrapped: Any = self.__wrapped__
+        wrapper: Any = self._self_wrapper
+        return _CopyableFunctionWrapper(
+            copy(wrapped),
+            wrapper,
+            self._self_enabled,
+        )
+
+    def __deepcopy__(self, memo: dict[Any, Any]) -> _CopyableFunctionWrapper:
+        wrapped: Any = self.__wrapped__
+        wrapper: Any = self._self_wrapper
+        return _CopyableFunctionWrapper(
+            deepcopy(wrapped, memo),
+            wrapper,
+            self._self_enabled,
+        )
+
+
+def _wrap_function(
+    target: Any,
+    name: str,
+    wrapper: Callable[..., Any],
+) -> None:
+    wrap_object(target, name, _CopyableFunctionWrapper, (wrapper,))
+
+
 def patch_dspy(handler: TelemetryHandler) -> None:
     """Apply patches to DSPy Tool and ReAct classes."""
     import dspy
 
     tool_module = dspy.Tool.__module__
     tool_name = dspy.Tool.__name__
-    wrap_function_wrapper(
+    _wrap_function(
         tool_module,
         f"{tool_name}.__call__",
         _tool_call(handler),
     )
-    wrap_function_wrapper(
+    _wrap_function(
         tool_module,
         f"{tool_name}.acall",
         _tool_acall(handler),
     )
 
-    wrap_function_wrapper(
+    _wrap_function(
         _REACT_MODULE,
         f"{_REACT_CLASS}.forward",
         _react_forward(handler, "dspy.ReAct"),
     )
-    wrap_function_wrapper(
+    _wrap_function(
         _REACT_MODULE,
         f"{_REACT_CLASS}.aforward",
         _react_aforward(handler, "dspy.ReAct"),
@@ -74,13 +123,13 @@ def patch_dspy(handler: TelemetryHandler) -> None:
         sys.modules.get(_REACT_V2_MODULE), _REACT_V2_CLASS, None
     )
     if react_v2_cls is not None:
-        wrap_function_wrapper(
+        _wrap_function(
             _REACT_V2_MODULE,
             f"{_REACT_V2_CLASS}.forward",
             _react_forward(handler, "dspy.ReActV2"),
         )
         if hasattr(react_v2_cls, "aforward"):
-            wrap_function_wrapper(
+            _wrap_function(
                 _REACT_V2_MODULE,
                 f"{_REACT_V2_CLASS}.aforward",
                 _react_aforward(handler, "dspy.ReActV2"),

--- a/instrumentation/opentelemetry-instrumentation-genai-dspy/src/opentelemetry/instrumentation/genai/dspy/patch.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-dspy/src/opentelemetry/instrumentation/genai/dspy/patch.py
@@ -9,9 +9,15 @@ import inspect
 import sys
 from collections.abc import Awaitable, Callable
 from copy import copy, deepcopy
+from importlib import import_module
 from typing import TYPE_CHECKING, Any
 
-from wrapt import BoundFunctionWrapper, FunctionWrapper, wrap_object
+from wrapt import (
+    BoundFunctionWrapper,
+    FunctionWrapper,
+    apply_patch,
+    resolve_path,
+)
 
 from opentelemetry.instrumentation.genai.dspy.utils import (
     SENTINEL_TOOL_NAMES,
@@ -46,9 +52,40 @@ _REACT_V2_CLASS = "ReActV2"
 class _CopyableBoundFunctionWrapper(BoundFunctionWrapper[Any, Any]):
     """BoundFunctionWrapper that supports copy and deepcopy."""
 
-    def __copy__(self) -> Any:
-        wrapped: Any = self.__wrapped__
-        return copy(wrapped)
+    def __init__(
+        self,
+        wrapped: Any,
+        instance: Any = None,
+        wrapper: Any = None,
+        enabled: Any = None,
+        binding: str = "callable",
+        parent: Any = None,
+        owner: Any = None,
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
+        init_args: tuple[Any, ...] = (
+            wrapped,
+            instance,
+            wrapper,
+            enabled,
+            binding,
+            parent,
+            owner,
+            *args,
+        )
+        super().__init__(*init_args, **kwargs)
+
+    def __copy__(self) -> _CopyableBoundFunctionWrapper:
+        return _CopyableBoundFunctionWrapper(
+            self.__wrapped__,
+            self._self_instance,
+            self._self_wrapper,
+            self._self_enabled,
+            self._self_binding,
+            self._self_parent,
+            self._self_owner,
+        )
 
     def __deepcopy__(self, memo: dict[Any, Any]) -> Any:
         if self._self_instance is not None:
@@ -56,7 +93,24 @@ class _CopyableBoundFunctionWrapper(BoundFunctionWrapper[Any, Any]):
             attr_name: str | None = getattr(self, "__name__", None)
             if attr_name and hasattr(copied_instance, attr_name):
                 return getattr(copied_instance, attr_name)
-        return copy(self)
+            return _CopyableBoundFunctionWrapper(
+                deepcopy(self.__wrapped__, memo),
+                copied_instance,
+                self._self_wrapper,
+                self._self_enabled,
+                self._self_binding,
+                self._self_parent,
+                self._self_owner,
+            )
+        return _CopyableBoundFunctionWrapper(
+            deepcopy(self.__wrapped__, memo),
+            None,
+            self._self_wrapper,
+            self._self_enabled,
+            self._self_binding,
+            self._self_parent,
+            self._self_owner,
+        )
 
 
 class _CopyableFunctionWrapper(FunctionWrapper[Any, Any]):
@@ -88,7 +142,17 @@ def _wrap_function(
     name: str,
     wrapper: Callable[..., Any],
 ) -> None:
-    wrap_object(target, name, _CopyableFunctionWrapper, (wrapper,))
+    """Wrap a target attribute with _CopyableFunctionWrapper.
+
+    Resolves target if given as a module name string, traverses dotted attribute
+    paths to find the owning object, and applies the wrapper.
+    """
+    if isinstance(target, str):
+        target = import_module(target)
+
+    parent, attribute, original = resolve_path(target, name)
+    wrapped = _CopyableFunctionWrapper(original, wrapper)
+    apply_patch(parent, attribute, wrapped)
 
 
 def patch_dspy(handler: TelemetryHandler) -> None:

--- a/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/test_instrumentor.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/test_instrumentor.py
@@ -3,6 +3,9 @@
 
 """Tests for the DSPy instrumentor lifecycle."""
 
+import copy
+from importlib import import_module
+
 import dspy
 import pytest
 
@@ -44,10 +47,6 @@ def test_copy_and_deepcopy_wrapped_callables(
     instrument_dspy: DSPyInstrumentor,
     span_exporter,
 ) -> None:
-    import copy
-
-    import dspy
-
     tool = dspy.Tool(
         func=lambda x: f"result:{x}", name="test_tool", desc="A test tool"
     )
@@ -79,9 +78,8 @@ def test_copy_and_deepcopy_wrapped_callables(
     assert forward_deepcopy is not None
 
     try:
-        import dspy.predict.react_v2
-
-        react_v2_cls = getattr(dspy.predict.react_v2, "ReActV2", None)
+        react_v2_mod = import_module("dspy.predict.react_v2")
+        react_v2_cls = getattr(react_v2_mod, "ReActV2", None)
         if react_v2_cls is not None:
             react_v2 = react_v2_cls("question -> answer", tools=[tool])
             assert copy.copy(react_v2) is not None
@@ -101,28 +99,23 @@ async def test_copy_and_deepcopy_async_tool(
     instrument_dspy: DSPyInstrumentor,
     span_exporter,
 ) -> None:
-    import copy
-
-    import dspy
-
     async def async_fn(x: str) -> str:
         return f"async:{x}"
 
     tool = dspy.Tool(
         func=async_fn, name="async_test_tool", desc="An async test tool"
     )
-    if hasattr(tool, "acall"):
-        tool_copy = copy.copy(tool)
-        tool_deepcopy = copy.deepcopy(tool)
-        acall_copy = copy.copy(tool.acall)
-        acall_deepcopy = copy.deepcopy(tool.acall)
+    tool_copy = copy.copy(tool)
+    tool_deepcopy = copy.deepcopy(tool)
+    acall_copy = copy.copy(tool.acall)
+    acall_deepcopy = copy.deepcopy(tool.acall)
 
-        assert await tool_copy.acall(x="foo") == "async:foo"
-        assert await tool_deepcopy.acall(x="bar") == "async:bar"
-        assert await acall_copy(x="baz") == "async:baz"
-        assert await acall_deepcopy(x="qux") == "async:qux"
+    assert await tool_copy.acall(x="foo") == "async:foo"
+    assert await tool_deepcopy.acall(x="bar") == "async:bar"
+    assert await acall_copy(x="baz") == "async:baz"
+    assert await acall_deepcopy(x="qux") == "async:qux"
 
-        spans = span_exporter.get_finished_spans()
-        assert len(spans) == 4
-        for span in spans:
-            assert span.name == "execute_tool async_test_tool"
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 4
+    for span in spans:
+        assert span.name == "execute_tool async_test_tool"

--- a/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/test_instrumentor.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/test_instrumentor.py
@@ -3,6 +3,9 @@
 
 """Tests for the DSPy instrumentor lifecycle."""
 
+import dspy
+import pytest
+
 from opentelemetry.instrumentation.genai.dspy import DSPyInstrumentor
 from opentelemetry.sdk._logs import LoggerProvider
 from opentelemetry.sdk.metrics import MeterProvider
@@ -35,3 +38,91 @@ def test_instrument_with_global_providers() -> None:
     instrumentor = DSPyInstrumentor()
     instrumentor.instrument()
     instrumentor.uninstrument()
+
+
+def test_copy_and_deepcopy_wrapped_callables(
+    instrument_dspy: DSPyInstrumentor,
+    span_exporter,
+) -> None:
+    import copy
+
+    import dspy
+
+    tool = dspy.Tool(
+        func=lambda x: f"result:{x}", name="test_tool", desc="A test tool"
+    )
+    react = dspy.ReAct("question -> answer", tools=[tool])
+
+    tool_copy = copy.copy(tool)
+    tool_deepcopy = copy.deepcopy(tool)
+    call_copy = copy.copy(tool.__call__)
+    call_deepcopy = copy.deepcopy(tool.__call__)
+
+    assert tool_copy(x="foo") == "result:foo"
+    assert tool_deepcopy(x="bar") == "result:bar"
+    assert call_copy(x="baz") == "result:baz"
+    assert call_deepcopy(x="qux") == "result:qux"
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 4
+    for span in spans:
+        assert span.name == "execute_tool test_tool"
+
+    react_copy = copy.copy(react)
+    react_deepcopy = copy.deepcopy(react)
+    forward_copy = copy.copy(react.forward)
+    forward_deepcopy = copy.deepcopy(react.forward)
+
+    assert react_copy is not None
+    assert react_deepcopy is not None
+    assert forward_copy is not None
+    assert forward_deepcopy is not None
+
+    try:
+        import dspy.predict.react_v2
+
+        react_v2_cls = getattr(dspy.predict.react_v2, "ReActV2", None)
+        if react_v2_cls is not None:
+            react_v2 = react_v2_cls("question -> answer", tools=[tool])
+            assert copy.copy(react_v2) is not None
+            assert copy.deepcopy(react_v2) is not None
+            assert copy.copy(react_v2.forward) is not None
+            assert copy.deepcopy(react_v2.forward) is not None
+    except (ImportError, AttributeError):
+        pass
+
+
+@pytest.mark.skipif(
+    not hasattr(dspy.Tool, "acall"),
+    reason="dspy.Tool.acall not available in this DSPy version",
+)
+@pytest.mark.anyio
+async def test_copy_and_deepcopy_async_tool(
+    instrument_dspy: DSPyInstrumentor,
+    span_exporter,
+) -> None:
+    import copy
+
+    import dspy
+
+    async def async_fn(x: str) -> str:
+        return f"async:{x}"
+
+    tool = dspy.Tool(
+        func=async_fn, name="async_test_tool", desc="An async test tool"
+    )
+    if hasattr(tool, "acall"):
+        tool_copy = copy.copy(tool)
+        tool_deepcopy = copy.deepcopy(tool)
+        acall_copy = copy.copy(tool.acall)
+        acall_deepcopy = copy.deepcopy(tool.acall)
+
+        assert await tool_copy.acall(x="foo") == "async:foo"
+        assert await tool_deepcopy.acall(x="bar") == "async:bar"
+        assert await acall_copy(x="baz") == "async:baz"
+        assert await acall_deepcopy(x="qux") == "async:qux"
+
+        spans = span_exporter.get_finished_spans()
+        assert len(spans) == 4
+        for span in spans:
+            assert span.name == "execute_tool async_test_tool"

--- a/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/test_instrumentor.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/test_instrumentor.py
@@ -4,10 +4,11 @@
 """Tests for the DSPy instrumentor lifecycle."""
 
 import copy
-from importlib import import_module
 
 import dspy
 import pytest
+from tests.test_react import MockExtract, MockSyncPredict, add
+from tests.test_react_v2 import MockSyncPredictV2
 
 from opentelemetry.instrumentation.genai.dspy import DSPyInstrumentor
 from opentelemetry.sdk._logs import LoggerProvider
@@ -47,9 +48,7 @@ def test_copy_and_deepcopy_wrapped_callables(
     instrument_dspy: DSPyInstrumentor,
     span_exporter,
 ) -> None:
-    tool = dspy.Tool(
-        func=lambda x: f"result:{x}", name="test_tool", desc="A test tool"
-    )
+    tool = dspy.Tool(add, name="add", desc="Add two numbers.")
     react = dspy.ReAct("question -> answer", tools=[tool])
 
     tool_copy = copy.copy(tool)
@@ -57,15 +56,18 @@ def test_copy_and_deepcopy_wrapped_callables(
     call_copy = copy.copy(tool.__call__)
     call_deepcopy = copy.deepcopy(tool.__call__)
 
-    assert tool_copy(x="foo") == "result:foo"
-    assert tool_deepcopy(x="bar") == "result:bar"
-    assert call_copy(x="baz") == "result:baz"
-    assert call_deepcopy(x="qux") == "result:qux"
+    assert tool_copy(x=2, y=2) == 4
+    assert tool_deepcopy(x=2, y=2) == 4
+    assert call_copy(x=2, y=2) == 4
+    assert call_deepcopy(x=2, y=2) == 4
 
     spans = span_exporter.get_finished_spans()
     assert len(spans) == 4
     for span in spans:
-        assert span.name == "execute_tool test_tool"
+        assert span.name == "execute_tool add"
+
+    react.react = MockSyncPredict()
+    react.extract = MockExtract()
 
     react_copy = copy.copy(react)
     react_deepcopy = copy.deepcopy(react)
@@ -77,17 +79,71 @@ def test_copy_and_deepcopy_wrapped_callables(
     assert forward_copy is not None
     assert forward_deepcopy is not None
 
-    try:
-        react_v2_mod = import_module("dspy.predict.react_v2")
-        react_v2_cls = getattr(react_v2_mod, "ReActV2", None)
-        if react_v2_cls is not None:
-            react_v2 = react_v2_cls("question -> answer", tools=[tool])
-            assert copy.copy(react_v2) is not None
-            assert copy.deepcopy(react_v2) is not None
-            assert copy.copy(react_v2.forward) is not None
-            assert copy.deepcopy(react_v2.forward) is not None
-    except (ImportError, AttributeError):
-        pass
+    res = react_deepcopy(question="What is 2 + 2?")
+    assert res.answer == "4"
+
+    spans = span_exporter.get_finished_spans()
+    span_names = [s.name for s in spans]
+    assert "invoke_agent dspy.ReAct" in span_names
+    assert "execute_tool add" in span_names
+
+
+def test_copy_and_deepcopy_react_v2(
+    instrument_dspy: DSPyInstrumentor,
+    span_exporter,
+) -> None:
+    react_v2_mod = pytest.importorskip("dspy.predict.react_v2")
+    react_v2_cls = getattr(react_v2_mod, "ReActV2", None)
+    if react_v2_cls is None:
+        pytest.skip("ReActV2 not available")
+
+    tool = dspy.Tool(add, name="add", desc="Add two numbers.")
+    react_v2 = react_v2_cls("question -> answer", tools=[tool])
+    react_v2.react = MockSyncPredictV2()
+
+    react_v2_copy = copy.copy(react_v2)
+    react_v2_deepcopy = copy.deepcopy(react_v2)
+    assert react_v2_copy is not None
+    assert react_v2_deepcopy is not None
+    assert copy.copy(react_v2.forward) is not None
+    assert copy.deepcopy(react_v2.forward) is not None
+
+    res = react_v2_deepcopy(question="What is 2 + 2?")
+    assert res.answer == "4"
+
+    spans = span_exporter.get_finished_spans()
+    span_names = [s.name for s in spans]
+    assert "invoke_agent dspy.ReActV2" in span_names
+    assert "execute_tool add" in span_names
+
+
+def test_deepcopy_agent_as_tool_module_tree(
+    instrument_dspy: DSPyInstrumentor,
+    span_exporter,
+) -> None:
+    base_tool = dspy.Tool(add, name="add", desc="Add two numbers.")
+    sub = dspy.ReAct("question -> answer", tools=[base_tool])
+    sub.react = MockSyncPredict()
+    sub.extract = MockExtract()
+
+    subagent_tool = dspy.Tool(
+        func=sub.forward, name="subagent", desc="Subagent tool"
+    )
+    outer = dspy.ReAct("question -> answer", tools=[subagent_tool])
+    outer.react = MockSyncPredict(
+        tool_name="subagent", tool_args={"question": "What is 2 + 2?"}
+    )
+    outer.extract = MockExtract()
+
+    outer_copy = copy.deepcopy(outer)
+    res = outer_copy(question="start")
+    assert res.answer == "4"
+
+    spans = span_exporter.get_finished_spans()
+    span_names = [s.name for s in spans]
+    assert "execute_tool add" in span_names
+    assert "execute_tool subagent" in span_names
+    assert span_names.count("invoke_agent dspy.ReAct") == 2
 
 
 @pytest.mark.skipif(

--- a/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/test_react.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/test_react.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import json
+from typing import Any
 from unittest import mock
 
 import dspy
@@ -37,16 +38,24 @@ async def async_multiply(a: int, b: int) -> int:
 
 
 class MockSyncPredict:
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        tool_name: str = "add",
+        tool_args: dict[str, Any] | None = None,
+    ) -> None:
         self.count = 0
+        self.tool_name = tool_name
+        self.tool_args = (
+            tool_args if tool_args is not None else {"x": 2, "y": 2}
+        )
 
     def __call__(self, **kwargs: object) -> object:
         self.count += 1
 
         class Pred:
-            next_thought = "Need to calculate 2 + 2"
-            next_tool_name = "add"
-            next_tool_args = {"x": 2, "y": 2}
+            next_thought = f"Need to calculate {self.tool_name}"
+            next_tool_name = self.tool_name
+            next_tool_args = self.tool_args
 
         class FinishPred:
             next_thought = "Done calculation"

--- a/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/test_react_v2.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/test_react_v2.py
@@ -10,6 +10,7 @@ import json
 import dspy
 import pytest
 from dspy.adapters.types.tool import ToolCalls
+from tests.test_react import MockExtract, MockSyncPredict
 
 from opentelemetry.instrumentation.genai.dspy import DSPyInstrumentor
 from opentelemetry.sdk._logs import LoggerProvider
@@ -194,29 +195,6 @@ def test_react_v2_missing_tolerated(
     import dspy.predict.react_v2
 
     monkeypatch.delattr(dspy.predict.react_v2, "ReActV2", raising=False)
-
-    class MockSyncPredict:
-        def __init__(self) -> None:
-            self.count = 0
-
-        def __call__(self, **kwargs: object) -> object:
-            self.count += 1
-
-            class Pred:
-                next_thought = "Need to add 2 and 2"
-                next_tool_name = "add"
-                next_tool_args = {"x": 2, "y": 2}
-
-            class FinishPred:
-                next_thought = "Done calculation"
-                next_tool_name = "finish"
-                next_tool_args = {}
-
-            return Pred() if self.count == 1 else FinishPred()
-
-    class MockExtract:
-        def __call__(self, **kwargs: object) -> dict[str, str]:
-            return {"answer": "4"}
 
     with instrument(
         DSPyInstrumentor(),

--- a/uv.lock
+++ b/uv.lock
@@ -3643,6 +3643,7 @@ dependencies = [
     { name = "opentelemetry-instrumentation" },
     { name = "opentelemetry-semantic-conventions" },
     { name = "opentelemetry-util-genai" },
+    { name = "wrapt" },
 ]
 
 [package.optional-dependencies]
@@ -3657,6 +3658,7 @@ requires-dist = [
     { name = "opentelemetry-instrumentation", specifier = ">=0.64b0,<1" },
     { name = "opentelemetry-semantic-conventions", specifier = ">=0.64b0,<1" },
     { name = "opentelemetry-util-genai", editable = "util/opentelemetry-util-genai" },
+    { name = "wrapt", specifier = ">=1.17.0,<3.0.0" },
 ]
 provides-extras = ["instruments"]
 


### PR DESCRIPTION
Implements copy and deepcopy support on wrapped DSPy functions and bound methods.

DSPy optimizers and teleprompters (such as `dspy.compile`, `BootstrapFewShot`, and `MIPRO`) rely heavily on `copy.copy` and `copy.deepcopy` to clone module trees and bound method callables during prompt optimization. Without custom wrapper copy handlers, copying wrapped DSPy callables raises `NotImplementedError: object proxy must define __deepcopy__()`.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] Followed the style guidelines of this project
- [x] Changelog updated if the change requires an entry
- [x] Unit tests added
- [x] Documentation updated