### PR TITLE
[opentelemetry-util-genai] Add should_capture_content to GenAIInvocation and deprecate should_capture_content_on_spans

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-genai-llama-index/src/opentelemetry/instrumentation/genai/llama_index/_handler.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-llama-index/src/opentelemetry/instrumentation/genai/llama_index/_handler.py
@@ -455,7 +455,7 @@ class LlamaIndexSpanHandler(BaseSpanHandler[_LlamaIndexInvocation]):
             )
             tool_invocation.tool_call_id = tool_call.tool_id
             tool_invocation.tool_description = tool_description
-            if tool_invocation.should_capture_content_on_span:
+            if tool_invocation.should_capture_content:
                 tool_invocation.arguments = cast(
                     dict[str, Any], cast(Any, tool_call).tool_kwargs
                 )
@@ -477,7 +477,7 @@ class LlamaIndexSpanHandler(BaseSpanHandler[_LlamaIndexInvocation]):
                 tool_type="function",
             )
             tool_invocation.tool_description = metadata.description or None
-            if tool_invocation.should_capture_content_on_span:
+            if tool_invocation.should_capture_content:
                 tool_invocation.arguments = _tool_arguments(
                     instance, bound_args
                 )
@@ -519,7 +519,7 @@ class LlamaIndexSpanHandler(BaseSpanHandler[_LlamaIndexInvocation]):
             elif isinstance(result, ToolOutput):
                 tool_output = result
             if tool_output is not None:
-                if span._invocation.should_capture_content_on_span:
+                if span._invocation.should_capture_content:
                     span._invocation.tool_result = tool_output.raw_output
                 if tool_output.is_error:
                     # LlamaIndex reports failures such as unknown tools without an

--- a/instrumentation/opentelemetry-instrumentation-genai-openai-agents/.changelog/593.changed
+++ b/instrumentation/opentelemetry-instrumentation-genai-openai-agents/.changelog/593.changed
@@ -1,0 +1,1 @@
+Bump the minimum `opentelemetry-util-genai` version to 1.2b0.

--- a/instrumentation/opentelemetry-instrumentation-genai-openai-agents/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-genai-openai-agents/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
   "opentelemetry-api ~= 1.43",
   "opentelemetry-instrumentation >= 0.64b0, <1",
   "opentelemetry-semantic-conventions >= 0.64b0, <1",
-  "opentelemetry-util-genai >= 1.1b0, <2"
+  "opentelemetry-util-genai >= 1.2b0.dev, <2",
 ]
 
 [project.optional-dependencies]

--- a/instrumentation/opentelemetry-instrumentation-genai-openai-agents/src/opentelemetry/instrumentation/genai/openai_agents/processor.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-openai-agents/src/opentelemetry/instrumentation/genai/openai_agents/processor.py
@@ -138,7 +138,7 @@ class GenAITracingProcessor(TracingProcessor):
         if (
             isinstance(invocation, ToolInvocation)
             and isinstance(span.span_data, FunctionSpanData)
-            and invocation.should_capture_content_on_span
+            and invocation.should_capture_content
         ):
             arguments = span.span_data.input
             if arguments:

--- a/instrumentation/opentelemetry-instrumentation-genai-openai-agents/tests/requirements.oldest.txt
+++ b/instrumentation/opentelemetry-instrumentation-genai-openai-agents/tests/requirements.oldest.txt
@@ -27,3 +27,6 @@ httpx==0.27.2
 Deprecated==1.2.14
 importlib-metadata==6.11.0
 packaging==24.0
+
+# Drop this once opentelemetry-util-genai 1.2b0 is published.
+-e util/opentelemetry-util-genai

--- a/instrumentation/opentelemetry-instrumentation-genai-openai-agents/tests/test_processor.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-openai-agents/tests/test_processor.py
@@ -91,7 +91,7 @@ def test_function_span_creates_tool_invocation_and_sets_provider_metric() -> (
     handler.tool.return_value = MagicMock(
         spec=ToolInvocation,
         metric_attributes={},
-        should_capture_content_on_span=True,
+        should_capture_content=True,
     )
     processor = GenAITracingProcessor(handler, provider="openai")
     span = _Span(
@@ -129,7 +129,7 @@ def test_function_span_skips_content_when_capture_disabled() -> None:
     handler.tool.return_value = MagicMock(
         spec=ToolInvocation,
         metric_attributes={},
-        should_capture_content_on_span=False,
+        should_capture_content=False,
     )
     processor = GenAITracingProcessor(handler, provider="openai")
     span = _Span(FunctionSpanData(name="get_weather", input=None, output=None))
@@ -154,7 +154,7 @@ def test_function_span_without_output_still_stops() -> None:
     handler.tool.return_value = MagicMock(
         spec=ToolInvocation,
         metric_attributes={},
-        should_capture_content_on_span=True,
+        should_capture_content=True,
     )
     processor = GenAITracingProcessor(handler, provider="openai")
     span = _Span(FunctionSpanData(name="noop", input=None, output=None))

--- a/instrumentation/opentelemetry-instrumentation-genai-qwen-agent/src/opentelemetry/instrumentation/genai/qwen_agent/patch.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-qwen-agent/src/opentelemetry/instrumentation/genai/qwen_agent/patch.py
@@ -103,7 +103,7 @@ def wrap_agent_call_tool(
         kwargs.get("messages"), tool_name
     )
     invocation.tool_description = getattr(tool, "description", None)
-    if invocation.should_capture_content_on_span and tool_args is not None:
+    if invocation.should_capture_content and tool_args is not None:
         invocation.arguments = tool_args
 
     try:
@@ -112,7 +112,7 @@ def wrap_agent_call_tool(
         invocation.fail(error)
         raise
 
-    if invocation.should_capture_content_on_span and result is not None:
+    if invocation.should_capture_content and result is not None:
         invocation.tool_result = (
             result if isinstance(result, str) else str(result)
         )

--- a/instrumentation/opentelemetry-instrumentation-google-genai/src/opentelemetry/instrumentation/google_genai/tool_call_wrapper.py
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/src/opentelemetry/instrumentation/google_genai/tool_call_wrapper.py
@@ -84,12 +84,12 @@ def _wrap_tool_function(
             ) as tool_invocation:
                 tool_invocation.tool_description = tool_function.__doc__
                 # Do this before calling the tool in case that crashes.
-                if tool_invocation.should_capture_content_on_span:
+                if tool_invocation.should_capture_content:
                     tool_invocation.arguments = json.dumps(
                         _get_function_args(tool_function, args, kwargs)
                     )
                 result = await tool_function(*args, **kwargs)
-                if tool_invocation.should_capture_content_on_span:
+                if tool_invocation.should_capture_content:
                     tool_invocation.tool_result = json.dumps(
                         _to_otel_value(result)
                     )
@@ -103,12 +103,12 @@ def _wrap_tool_function(
             ) as tool_invocation:
                 tool_invocation.tool_description = tool_function.__doc__
                 # Do this before calling the tool in case that crashes.
-                if tool_invocation.should_capture_content_on_span:
+                if tool_invocation.should_capture_content:
                     tool_invocation.arguments = json.dumps(
                         _get_function_args(tool_function, args, kwargs)
                     )
                 result = tool_function(*args, **kwargs)
-                if tool_invocation.should_capture_content_on_span:
+                if tool_invocation.should_capture_content:
                     tool_invocation.tool_result = json.dumps(
                         _to_otel_value(result)
                     )

--- a/instrumentation/opentelemetry-instrumentation-google-genai/tests/generate_content/test_e2e.py
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/tests/generate_content/test_e2e.py
@@ -340,9 +340,9 @@ def fixture_otel_mocker():
     autouse=True,
     params=["SPAN_AND_EVENT", "NO_CONTENT"],
 )
-def fixture_setup_content_recording(request):
-    os.environ[OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT] = (
-        request.param
+def fixture_setup_content_recording(request, monkeypatch):
+    monkeypatch.setenv(
+        OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT, request.param
     )
     return request.param
 

--- a/instrumentation/opentelemetry-instrumentation-google-genai/tests/interactions/test_e2e.py
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/tests/interactions/test_e2e.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
-import os
 
 import pytest
 import yaml
@@ -179,9 +178,11 @@ def fixture_client():
 
 
 @pytest.mark.vcr
-def test_sync_interactions_create(client, otel_mocker: OTelMocker):
-    os.environ[OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT] = (
-        "SPAN_AND_EVENT"
+def test_sync_interactions_create(
+    client, otel_mocker: OTelMocker, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setenv(
+        OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT, "SPAN_AND_EVENT"
     )
 
     response = client.interactions.create(
@@ -202,9 +203,11 @@ def test_sync_interactions_create(client, otel_mocker: OTelMocker):
 
 @pytest.mark.vcr
 @pytest.mark.asyncio
-async def test_async_interactions_create(client, otel_mocker: OTelMocker):
-    os.environ[OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT] = (
-        "SPAN_AND_EVENT"
+async def test_async_interactions_create(
+    client, otel_mocker: OTelMocker, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setenv(
+        OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT, "SPAN_AND_EVENT"
     )
 
     response = await client.aio.interactions.create(

--- a/instrumentation/opentelemetry-instrumentation-google-genai/tests/utils/test_tool_call_wrapper.py
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/tests/utils/test_tool_call_wrapper.py
@@ -21,11 +21,6 @@ class TestCase(unittest.TestCase):
     def setUp(self):
         self._otel = otel_mocker.OTelMocker()
         self._otel.install()
-        self._otel_wrapper = TelemetryHandler(
-            tracer_provider=get_tracer_provider(),
-            logger_provider=get_logger_provider(),
-            meter_provider=get_meter_provider(),
-        )
 
     @property
     def otel(self):
@@ -33,7 +28,11 @@ class TestCase(unittest.TestCase):
 
     @property
     def otel_wrapper(self):
-        return self._otel_wrapper
+        return TelemetryHandler(
+            tracer_provider=get_tracer_provider(),
+            logger_provider=get_logger_provider(),
+            meter_provider=get_meter_provider(),
+        )
 
     def wrap(self, tool_or_tools):
         return tool_call_wrapper.wrapped_tool(tool_or_tools, self.otel_wrapper)

--- a/util/opentelemetry-util-genai/.changelog/593.added
+++ b/util/opentelemetry-util-genai/.changelog/593.added
@@ -1,0 +1,1 @@
+Add `GenAIInvocation.should_capture_content` property.

--- a/util/opentelemetry-util-genai/.changelog/593.deprecated
+++ b/util/opentelemetry-util-genai/.changelog/593.deprecated
@@ -1,0 +1,1 @@
+Deprecate `should_capture_content_on_spans()` and `ToolInvocation.should_capture_content_on_span` in favor of `GenAIInvocation.should_capture_content`.

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_agent_invocation.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_agent_invocation.py
@@ -50,7 +50,7 @@ class AgentInvocation(GenAIInvocation):
         server_address: str | None = None,
         server_port: int | None = None,
         agent_name: str | None = None,
-        content_capturing_mode: ContentCapturingMode = ContentCapturingMode.NO_CONTENT,
+        content_capturing_mode: ContentCapturingMode | None = None,
     ) -> None:
         """Use handler.invoke_local_agent() or handler.invoke_remote_agent() instead of calling this directly."""
         _operation_name = GenAI.GenAiOperationNameValues.INVOKE_AGENT.value

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_agent_invocation.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_agent_invocation.py
@@ -49,6 +49,7 @@ class AgentInvocation(GenAIInvocation):
         server_address: str | None = None,
         server_port: int | None = None,
         agent_name: str | None = None,
+        should_capture_content: bool = False,
     ) -> None:
         """Use handler.invoke_local_agent() or handler.invoke_remote_agent() instead of calling this directly."""
         _operation_name = GenAI.GenAiOperationNameValues.INVOKE_AGENT.value
@@ -62,6 +63,7 @@ class AgentInvocation(GenAIInvocation):
             if agent_name
             else _operation_name,
             span_kind=span_kind,
+            should_capture_content=should_capture_content,
         )
         self._provider: str | None = provider
         self._request_model: str | None = request_model

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_agent_invocation.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_agent_invocation.py
@@ -22,6 +22,7 @@ from opentelemetry.util.genai.types import (
     OutputMessage,
     ToolDefinition,
 )
+from opentelemetry.util.genai.utils import ContentCapturingMode
 from opentelemetry.util.types import AttributeValue
 
 
@@ -49,7 +50,7 @@ class AgentInvocation(GenAIInvocation):
         server_address: str | None = None,
         server_port: int | None = None,
         agent_name: str | None = None,
-        should_capture_content: bool = False,
+        content_capturing_mode: ContentCapturingMode = ContentCapturingMode.NO_CONTENT,
     ) -> None:
         """Use handler.invoke_local_agent() or handler.invoke_remote_agent() instead of calling this directly."""
         _operation_name = GenAI.GenAiOperationNameValues.INVOKE_AGENT.value
@@ -63,7 +64,7 @@ class AgentInvocation(GenAIInvocation):
             if agent_name
             else _operation_name,
             span_kind=span_kind,
-            should_capture_content=should_capture_content,
+            content_capturing_mode=content_capturing_mode,
         )
         self._provider: str | None = provider
         self._request_model: str | None = request_model
@@ -173,6 +174,7 @@ class AgentInvocation(GenAIInvocation):
             system_instruction=self.system_instruction,
             tool_definitions=self.tool_definitions,
             for_span=True,
+            content_capturing_mode=self._content_capturing_mode,
         )
 
     def _get_metric_attributes(self) -> dict[str, AttributeValue]:

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_embedding_invocation.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_embedding_invocation.py
@@ -33,7 +33,7 @@ class EmbeddingInvocation(GenAIInvocation):
         request_model: str | None = None,
         server_address: str | None = None,
         server_port: int | None = None,
-        content_capturing_mode: ContentCapturingMode = ContentCapturingMode.NO_CONTENT,
+        content_capturing_mode: ContentCapturingMode | None = None,
     ) -> None:
         """Use handler.embedding(provider) rather than calling this directly."""
         _operation_name = GenAI.GenAiOperationNameValues.EMBEDDINGS.value

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_embedding_invocation.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_embedding_invocation.py
@@ -12,6 +12,7 @@ from opentelemetry.trace import SpanKind, Tracer
 from opentelemetry.util.genai._invocation import Error, GenAIInvocation
 from opentelemetry.util.genai.completion_hook import CompletionHook
 from opentelemetry.util.genai.metrics import InvocationMetricsRecorder
+from opentelemetry.util.genai.utils import ContentCapturingMode
 from opentelemetry.util.types import AttributeValue
 
 
@@ -32,7 +33,7 @@ class EmbeddingInvocation(GenAIInvocation):
         request_model: str | None = None,
         server_address: str | None = None,
         server_port: int | None = None,
-        should_capture_content: bool = False,
+        content_capturing_mode: ContentCapturingMode = ContentCapturingMode.NO_CONTENT,
     ) -> None:
         """Use handler.embedding(provider) rather than calling this directly."""
         _operation_name = GenAI.GenAiOperationNameValues.EMBEDDINGS.value
@@ -46,7 +47,7 @@ class EmbeddingInvocation(GenAIInvocation):
             if request_model
             else _operation_name,
             span_kind=SpanKind.CLIENT,
-            should_capture_content=should_capture_content,
+            content_capturing_mode=content_capturing_mode,
         )
         # e.g., azure.ai.openai, openai, aws.bedrock
         self._provider: str = provider

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_embedding_invocation.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_embedding_invocation.py
@@ -32,6 +32,7 @@ class EmbeddingInvocation(GenAIInvocation):
         request_model: str | None = None,
         server_address: str | None = None,
         server_port: int | None = None,
+        should_capture_content: bool = False,
     ) -> None:
         """Use handler.embedding(provider) rather than calling this directly."""
         _operation_name = GenAI.GenAiOperationNameValues.EMBEDDINGS.value
@@ -45,6 +46,7 @@ class EmbeddingInvocation(GenAIInvocation):
             if request_model
             else _operation_name,
             span_kind=SpanKind.CLIENT,
+            should_capture_content=should_capture_content,
         )
         # e.g., azure.ai.openai, openai, aws.bedrock
         self._provider: str = provider

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_fetch_response_invocation.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_fetch_response_invocation.py
@@ -88,7 +88,7 @@ class FetchResponseInvocation(GenAIInvocation):
         server_address: str | None = None,
         server_port: int | None = None,
         error_type_resolver: ErrorTypeResolver | None = None,
-        content_capturing_mode: ContentCapturingMode = ContentCapturingMode.NO_CONTENT,
+        content_capturing_mode: ContentCapturingMode | None = None,
     ) -> None:
         """Use handler.fetch_response() rather than calling this directly."""
         super().__init__(

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_fetch_response_invocation.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_fetch_response_invocation.py
@@ -24,6 +24,7 @@ from opentelemetry.util.genai.types import (
     OutputMessage,
     ToolDefinition,
 )
+from opentelemetry.util.genai.utils import ContentCapturingMode
 from opentelemetry.util.types import AttributeValue
 
 # TODO: Migrate to gen_ai_attributes constants once available in the semconv
@@ -87,7 +88,7 @@ class FetchResponseInvocation(GenAIInvocation):
         server_address: str | None = None,
         server_port: int | None = None,
         error_type_resolver: ErrorTypeResolver | None = None,
-        should_capture_content: bool = False,
+        content_capturing_mode: ContentCapturingMode = ContentCapturingMode.NO_CONTENT,
     ) -> None:
         """Use handler.fetch_response() rather than calling this directly."""
         super().__init__(
@@ -101,7 +102,7 @@ class FetchResponseInvocation(GenAIInvocation):
             span_name=_FETCH_RESPONSE_OPERATION_NAME,
             span_kind=SpanKind.CLIENT,
             error_type_resolver=error_type_resolver,
-            should_capture_content=should_capture_content,
+            content_capturing_mode=content_capturing_mode,
         )
         self._provider: str = provider
         self._response_id: str = response_id
@@ -180,6 +181,7 @@ class FetchResponseInvocation(GenAIInvocation):
                 system_instruction=self.system_instruction,
                 tool_definitions=self.tool_definitions,
                 for_span=True,
+                content_capturing_mode=self._content_capturing_mode,
             )
         )
         attributes.update(self.attributes)

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_fetch_response_invocation.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_fetch_response_invocation.py
@@ -87,6 +87,7 @@ class FetchResponseInvocation(GenAIInvocation):
         server_address: str | None = None,
         server_port: int | None = None,
         error_type_resolver: ErrorTypeResolver | None = None,
+        should_capture_content: bool = False,
     ) -> None:
         """Use handler.fetch_response() rather than calling this directly."""
         super().__init__(
@@ -100,6 +101,7 @@ class FetchResponseInvocation(GenAIInvocation):
             span_name=_FETCH_RESPONSE_OPERATION_NAME,
             span_kind=SpanKind.CLIENT,
             error_type_resolver=error_type_resolver,
+            should_capture_content=should_capture_content,
         )
         self._provider: str = provider
         self._response_id: str = response_id

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_inference_invocation.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_inference_invocation.py
@@ -50,6 +50,7 @@ class InferenceInvocation(GenAIInvocation):
         server_port: int | None = None,
         operation_name: str | None = None,
         error_type_resolver: ErrorTypeResolver | None = None,
+        should_capture_content: bool = False,
     ) -> None:
         operation_name = (
             operation_name or GenAI.GenAiOperationNameValues.CHAT.value
@@ -66,6 +67,7 @@ class InferenceInvocation(GenAIInvocation):
             else operation_name,
             span_kind=SpanKind.CLIENT,
             error_type_resolver=error_type_resolver,
+            should_capture_content=should_capture_content,
         )
         self._provider: str = provider
         self._request_model: str | None = request_model

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_inference_invocation.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_inference_invocation.py
@@ -26,6 +26,7 @@ from opentelemetry.util.genai.types import (
     ToolDefinition,
 )
 from opentelemetry.util.genai.utils import (
+    ContentCapturingMode,
     should_emit_event,
 )
 from opentelemetry.util.types import AttributeValue
@@ -50,7 +51,7 @@ class InferenceInvocation(GenAIInvocation):
         server_port: int | None = None,
         operation_name: str | None = None,
         error_type_resolver: ErrorTypeResolver | None = None,
-        should_capture_content: bool = False,
+        content_capturing_mode: ContentCapturingMode = ContentCapturingMode.NO_CONTENT,
     ) -> None:
         operation_name = (
             operation_name or GenAI.GenAiOperationNameValues.CHAT.value
@@ -67,7 +68,7 @@ class InferenceInvocation(GenAIInvocation):
             else operation_name,
             span_kind=SpanKind.CLIENT,
             error_type_resolver=error_type_resolver,
-            should_capture_content=should_capture_content,
+            content_capturing_mode=content_capturing_mode,
         )
         self._provider: str = provider
         self._request_model: str | None = request_model
@@ -121,6 +122,7 @@ class InferenceInvocation(GenAIInvocation):
             system_instruction=self.system_instruction,
             tool_definitions=self.tool_definitions,
             for_span=for_span,
+            content_capturing_mode=self._content_capturing_mode,
         )
 
     def _get_finish_reasons(self) -> list[str] | None:

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_inference_invocation.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_inference_invocation.py
@@ -51,7 +51,7 @@ class InferenceInvocation(GenAIInvocation):
         server_port: int | None = None,
         operation_name: str | None = None,
         error_type_resolver: ErrorTypeResolver | None = None,
-        content_capturing_mode: ContentCapturingMode = ContentCapturingMode.NO_CONTENT,
+        content_capturing_mode: ContentCapturingMode | None = None,
     ) -> None:
         operation_name = (
             operation_name or GenAI.GenAiOperationNameValues.CHAT.value
@@ -304,6 +304,8 @@ class LLMInvocation:
         metrics_recorder: InvocationMetricsRecorder,
         logger: Logger,
         completion_hook: CompletionHook,
+        *,
+        content_capturing_mode: ContentCapturingMode | None = None,
     ) -> None:
         """Create and start an InferenceInvocation from this data container. Called by handler.start_llm()."""
         inv = InferenceInvocation(
@@ -315,6 +317,7 @@ class LLMInvocation:
             request_model=self.request_model,
             server_address=self.server_address,
             server_port=self.server_port,
+            content_capturing_mode=content_capturing_mode,
         )
         inv.input_messages = self.input_messages
         inv.output_messages = self.output_messages

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_invocation.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_invocation.py
@@ -73,7 +73,7 @@ class GenAIInvocation(AbstractContextManager["GenAIInvocation"]):
         metric_attributes: dict[str, AttributeValue] | None = None,
         error_type_resolver: ErrorTypeResolver | None = None,
         *,
-        content_capturing_mode: ContentCapturingMode = ContentCapturingMode.NO_CONTENT,
+        content_capturing_mode: ContentCapturingMode | None = None,
     ) -> None:
         self._tracer = tracer
         self._metrics_recorder = metrics_recorder
@@ -82,7 +82,9 @@ class GenAIInvocation(AbstractContextManager["GenAIInvocation"]):
         self._error_type_resolver = error_type_resolver
         self._operation_name: str = operation_name
         self._content_capturing_mode: ContentCapturingMode = (
-            content_capturing_mode
+            get_content_capturing_mode()
+            if content_capturing_mode is None
+            else content_capturing_mode
         )
         self.attributes: dict[str, AttributeValue] = (
             {} if attributes is None else attributes
@@ -114,6 +116,13 @@ class GenAIInvocation(AbstractContextManager["GenAIInvocation"]):
             ContentCapturingMode.EVENT_ONLY,
             ContentCapturingMode.SPAN_AND_EVENT,
         ) or not isinstance(self._completion_hook, _NoOpCompletionHook)
+
+    @property
+    def _should_capture_content_on_span(self) -> bool:
+        return self._content_capturing_mode in (
+            ContentCapturingMode.SPAN_ONLY,
+            ContentCapturingMode.SPAN_AND_EVENT,
+        )
 
     def _start(
         self, attributes: dict[str, AttributeValue] | None = None

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_invocation.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_invocation.py
@@ -69,6 +69,8 @@ class GenAIInvocation(AbstractContextManager["GenAIInvocation"]):
         attributes: dict[str, AttributeValue] | None = None,
         metric_attributes: dict[str, AttributeValue] | None = None,
         error_type_resolver: ErrorTypeResolver | None = None,
+        *,
+        should_capture_content: bool = False,
     ) -> None:
         self._tracer = tracer
         self._metrics_recorder = metrics_recorder
@@ -76,6 +78,7 @@ class GenAIInvocation(AbstractContextManager["GenAIInvocation"]):
         self._completion_hook = completion_hook
         self._error_type_resolver = error_type_resolver
         self._operation_name: str = operation_name
+        self._should_capture_content: bool = should_capture_content
         self.attributes: dict[str, AttributeValue] = (
             {} if attributes is None else attributes
         )
@@ -97,6 +100,11 @@ class GenAIInvocation(AbstractContextManager["GenAIInvocation"]):
         self._request_stream: bool | None = None
         self._ttfc_seconds: float | None = None
         self._stream_last_chunk_at: float | None = None
+
+    @property
+    def should_capture_content(self) -> bool:
+        """Return True when message content should be captured for this invocation."""
+        return self._should_capture_content
 
     def _start(
         self, attributes: dict[str, AttributeValue] | None = None

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_invocation.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_invocation.py
@@ -23,7 +23,10 @@ from opentelemetry.semconv.attributes import error_attributes
 from opentelemetry.trace import INVALID_SPAN as _INVALID_SPAN
 from opentelemetry.trace import Span, SpanKind, Tracer, set_span_in_context
 from opentelemetry.trace.status import Status, StatusCode
-from opentelemetry.util.genai.completion_hook import CompletionHook
+from opentelemetry.util.genai.completion_hook import (
+    CompletionHook,
+    _NoOpCompletionHook,
+)
 from opentelemetry.util.genai.types import (
     Error,
     ErrorTypeResolver,
@@ -70,7 +73,7 @@ class GenAIInvocation(AbstractContextManager["GenAIInvocation"]):
         metric_attributes: dict[str, AttributeValue] | None = None,
         error_type_resolver: ErrorTypeResolver | None = None,
         *,
-        should_capture_content: bool = False,
+        content_capturing_mode: ContentCapturingMode = ContentCapturingMode.NO_CONTENT,
     ) -> None:
         self._tracer = tracer
         self._metrics_recorder = metrics_recorder
@@ -78,7 +81,9 @@ class GenAIInvocation(AbstractContextManager["GenAIInvocation"]):
         self._completion_hook = completion_hook
         self._error_type_resolver = error_type_resolver
         self._operation_name: str = operation_name
-        self._should_capture_content: bool = should_capture_content
+        self._content_capturing_mode: ContentCapturingMode = (
+            content_capturing_mode
+        )
         self.attributes: dict[str, AttributeValue] = (
             {} if attributes is None else attributes
         )
@@ -104,7 +109,11 @@ class GenAIInvocation(AbstractContextManager["GenAIInvocation"]):
     @property
     def should_capture_content(self) -> bool:
         """Return True when message content should be captured for this invocation."""
-        return self._should_capture_content
+        return self._content_capturing_mode in (
+            ContentCapturingMode.SPAN_ONLY,
+            ContentCapturingMode.EVENT_ONLY,
+            ContentCapturingMode.SPAN_AND_EVENT,
+        ) or not isinstance(self._completion_hook, _NoOpCompletionHook)
 
     def _start(
         self, attributes: dict[str, AttributeValue] | None = None
@@ -250,6 +259,7 @@ def get_content_attributes(
     system_instruction: Sequence[MessagePart],
     tool_definitions: Sequence[ToolDefinition] | None,
     for_span: bool,
+    content_capturing_mode: ContentCapturingMode | None = None,
 ) -> dict[str, Any]:
     """Serialize messages, system instructions, and tool definitions into attributes.
 
@@ -260,8 +270,14 @@ def get_content_attributes(
         tool_definitions: Tool definitions to serialize (may be None).
         for_span: If True, serialize for span attributes (JSON string);
                   if False, serialize for event attributes (list of dicts).
+        content_capturing_mode: Configured content capturing mode; if None,
+                                reads from environment.
     """
-    mode = get_content_capturing_mode()
+    mode = (
+        get_content_capturing_mode()
+        if content_capturing_mode is None
+        else content_capturing_mode
+    )
     allowed_modes = (
         (
             ContentCapturingMode.SPAN_ONLY,

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_retrieval_invocation.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_retrieval_invocation.py
@@ -15,10 +15,7 @@ from opentelemetry.trace import SpanKind, Tracer
 from opentelemetry.util.genai._invocation import Error, GenAIInvocation
 from opentelemetry.util.genai.completion_hook import CompletionHook
 from opentelemetry.util.genai.metrics import InvocationMetricsRecorder
-from opentelemetry.util.genai.utils import (
-    gen_ai_json_dumps,
-    should_capture_content_on_spans,
-)
+from opentelemetry.util.genai.utils import gen_ai_json_dumps
 from opentelemetry.util.types import AttributeValue
 
 
@@ -54,6 +51,7 @@ class RetrievalInvocation(GenAIInvocation):
         request_model: str | None = None,
         server_address: str | None = None,
         server_port: int | None = None,
+        should_capture_content: bool = False,
     ) -> None:
         """Use handler.retrieval() instead of calling this directly."""
         _operation_name = GenAI.GenAiOperationNameValues.RETRIEVAL.value
@@ -67,6 +65,7 @@ class RetrievalInvocation(GenAIInvocation):
             if data_source_id
             else _operation_name,
             span_kind=SpanKind.CLIENT,
+            should_capture_content=should_capture_content,
         )
         self._data_source_id: str | None = data_source_id
         self._provider: str | None = provider
@@ -108,10 +107,7 @@ class RetrievalInvocation(GenAIInvocation):
         return attrs
 
     def _get_content_attributes_for_span(self) -> dict[str, AttributeValue]:
-        if (
-            not self.span.is_recording()
-            or not should_capture_content_on_spans()
-        ):
+        if not self.span.is_recording() or not self.should_capture_content:
             return {}
         optional_attrs: tuple[tuple[str, AttributeValue | None], ...] = (
             (GenAI.GEN_AI_RETRIEVAL_QUERY_TEXT, self.query_text),

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_retrieval_invocation.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_retrieval_invocation.py
@@ -15,7 +15,10 @@ from opentelemetry.trace import SpanKind, Tracer
 from opentelemetry.util.genai._invocation import Error, GenAIInvocation
 from opentelemetry.util.genai.completion_hook import CompletionHook
 from opentelemetry.util.genai.metrics import InvocationMetricsRecorder
-from opentelemetry.util.genai.utils import gen_ai_json_dumps
+from opentelemetry.util.genai.utils import (
+    ContentCapturingMode,
+    gen_ai_json_dumps,
+)
 from opentelemetry.util.types import AttributeValue
 
 
@@ -51,7 +54,7 @@ class RetrievalInvocation(GenAIInvocation):
         request_model: str | None = None,
         server_address: str | None = None,
         server_port: int | None = None,
-        should_capture_content: bool = False,
+        content_capturing_mode: ContentCapturingMode = ContentCapturingMode.NO_CONTENT,
     ) -> None:
         """Use handler.retrieval() instead of calling this directly."""
         _operation_name = GenAI.GenAiOperationNameValues.RETRIEVAL.value
@@ -65,7 +68,7 @@ class RetrievalInvocation(GenAIInvocation):
             if data_source_id
             else _operation_name,
             span_kind=SpanKind.CLIENT,
-            should_capture_content=should_capture_content,
+            content_capturing_mode=content_capturing_mode,
         )
         self._data_source_id: str | None = data_source_id
         self._provider: str | None = provider
@@ -107,7 +110,14 @@ class RetrievalInvocation(GenAIInvocation):
         return attrs
 
     def _get_content_attributes_for_span(self) -> dict[str, AttributeValue]:
-        if not self.span.is_recording() or not self.should_capture_content:
+        if (
+            not self.span.is_recording()
+            or self._content_capturing_mode
+            not in (
+                ContentCapturingMode.SPAN_ONLY,
+                ContentCapturingMode.SPAN_AND_EVENT,
+            )
+        ):
             return {}
         optional_attrs: tuple[tuple[str, AttributeValue | None], ...] = (
             (GenAI.GEN_AI_RETRIEVAL_QUERY_TEXT, self.query_text),

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_retrieval_invocation.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_retrieval_invocation.py
@@ -54,7 +54,7 @@ class RetrievalInvocation(GenAIInvocation):
         request_model: str | None = None,
         server_address: str | None = None,
         server_port: int | None = None,
-        content_capturing_mode: ContentCapturingMode = ContentCapturingMode.NO_CONTENT,
+        content_capturing_mode: ContentCapturingMode | None = None,
     ) -> None:
         """Use handler.retrieval() instead of calling this directly."""
         _operation_name = GenAI.GenAiOperationNameValues.RETRIEVAL.value
@@ -112,11 +112,7 @@ class RetrievalInvocation(GenAIInvocation):
     def _get_content_attributes_for_span(self) -> dict[str, AttributeValue]:
         if (
             not self.span.is_recording()
-            or self._content_capturing_mode
-            not in (
-                ContentCapturingMode.SPAN_ONLY,
-                ContentCapturingMode.SPAN_AND_EVENT,
-            )
+            or not self._should_capture_content_on_span
         ):
             return {}
         optional_attrs: tuple[tuple[str, AttributeValue | None], ...] = (

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_tool_invocation.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_tool_invocation.py
@@ -11,7 +11,10 @@ from opentelemetry.trace import SpanKind, Tracer
 from opentelemetry.util.genai._invocation import Error, GenAIInvocation
 from opentelemetry.util.genai.completion_hook import CompletionHook
 from opentelemetry.util.genai.metrics import InvocationMetricsRecorder
-from opentelemetry.util.genai.utils import gen_ai_json_dumps
+from opentelemetry.util.genai.utils import (
+    ContentCapturingMode,
+    gen_ai_json_dumps,
+)
 from opentelemetry.util.types import AnyValue, AttributeValue
 
 
@@ -61,7 +64,7 @@ class ToolInvocation(GenAIInvocation):
         agent_name: str | None = None,
         tool_call_id: str | None = None,
         tool_description: str | None = None,
-        should_capture_content: bool = False,
+        content_capturing_mode: ContentCapturingMode = ContentCapturingMode.NO_CONTENT,
     ) -> None:
         """Use handler.tool(name) instead of calling this directly.
 
@@ -79,7 +82,7 @@ class ToolInvocation(GenAIInvocation):
             operation_name=_operation_name,
             span_name=f"{_operation_name} {name}" if name else _operation_name,
             span_kind=SpanKind.INTERNAL,
-            should_capture_content=should_capture_content,
+            content_capturing_mode=content_capturing_mode,
         )
         self._name: str = name
         self.tool_result: AnyValue | None = None
@@ -96,12 +99,15 @@ class ToolInvocation(GenAIInvocation):
 
     @property
     def should_capture_content_on_span(self) -> bool:
-        """Returns whether content capture is enabled.
+        """Returns whether content capture is enabled on spans.
 
         .. deprecated:: 1.2b0
             Use :attr:`should_capture_content` instead.
         """
-        return self.should_capture_content
+        return self._content_capturing_mode in (
+            ContentCapturingMode.SPAN_ONLY,
+            ContentCapturingMode.SPAN_AND_EVENT,
+        )
 
     def _get_start_attributes(self) -> dict[str, AttributeValue]:
         """Return sampling-relevant attributes available at span creation time."""
@@ -124,6 +130,10 @@ class ToolInvocation(GenAIInvocation):
     def _apply_finish(self, error: Error | None = None) -> None:
         if error is not None:
             self._apply_error_attributes(error)
+        capture_content_on_span = self._content_capturing_mode in (
+            ContentCapturingMode.SPAN_ONLY,
+            ContentCapturingMode.SPAN_AND_EVENT,
+        )
         optional_attrs = (
             (GenAI.GEN_AI_TOOL_CALL_ID, self.tool_call_id),
             (GenAI.GEN_AI_TOOL_DESCRIPTION, self.tool_description),
@@ -131,13 +141,13 @@ class ToolInvocation(GenAIInvocation):
             (
                 GenAI.GEN_AI_TOOL_CALL_ARGUMENTS,
                 _any_value_to_attribute_value(self.arguments)
-                if self.should_capture_content and self.arguments is not None
+                if capture_content_on_span and self.arguments is not None
                 else None,
             ),
             (
                 GenAI.GEN_AI_TOOL_CALL_RESULT,
                 _any_value_to_attribute_value(self.tool_result)
-                if self.should_capture_content and self.tool_result is not None
+                if capture_content_on_span and self.tool_result is not None
                 else None,
             ),
         )

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_tool_invocation.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_tool_invocation.py
@@ -11,10 +11,7 @@ from opentelemetry.trace import SpanKind, Tracer
 from opentelemetry.util.genai._invocation import Error, GenAIInvocation
 from opentelemetry.util.genai.completion_hook import CompletionHook
 from opentelemetry.util.genai.metrics import InvocationMetricsRecorder
-from opentelemetry.util.genai.utils import (
-    gen_ai_json_dumps,
-    should_capture_content_on_spans,
-)
+from opentelemetry.util.genai.utils import gen_ai_json_dumps
 from opentelemetry.util.types import AnyValue, AttributeValue
 
 
@@ -64,6 +61,7 @@ class ToolInvocation(GenAIInvocation):
         agent_name: str | None = None,
         tool_call_id: str | None = None,
         tool_description: str | None = None,
+        should_capture_content: bool = False,
     ) -> None:
         """Use handler.tool(name) instead of calling this directly.
 
@@ -81,8 +79,8 @@ class ToolInvocation(GenAIInvocation):
             operation_name=_operation_name,
             span_name=f"{_operation_name} {name}" if name else _operation_name,
             span_kind=SpanKind.INTERNAL,
+            should_capture_content=should_capture_content,
         )
-        self.should_capture_content_on_span = should_capture_content_on_spans()
         self._name: str = name
         self.tool_result: AnyValue | None = None
         # Since arguments and tool_result can be expensive to serialize,
@@ -95,6 +93,15 @@ class ToolInvocation(GenAIInvocation):
         self._tool_type: str | None = tool_type
         self._agent_name: str | None = agent_name
         self._start(self._get_start_attributes())
+
+    @property
+    def should_capture_content_on_span(self) -> bool:
+        """Returns whether content capture is enabled.
+
+        .. deprecated:: 1.2b0
+            Use :attr:`should_capture_content` instead.
+        """
+        return self.should_capture_content
 
     def _get_start_attributes(self) -> dict[str, AttributeValue]:
         """Return sampling-relevant attributes available at span creation time."""
@@ -124,15 +131,13 @@ class ToolInvocation(GenAIInvocation):
             (
                 GenAI.GEN_AI_TOOL_CALL_ARGUMENTS,
                 _any_value_to_attribute_value(self.arguments)
-                if self.should_capture_content_on_span
-                and self.arguments is not None
+                if self.should_capture_content and self.arguments is not None
                 else None,
             ),
             (
                 GenAI.GEN_AI_TOOL_CALL_RESULT,
                 _any_value_to_attribute_value(self.tool_result)
-                if self.should_capture_content_on_span
-                and self.tool_result is not None
+                if self.should_capture_content and self.tool_result is not None
                 else None,
             ),
         )

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_tool_invocation.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_tool_invocation.py
@@ -64,7 +64,7 @@ class ToolInvocation(GenAIInvocation):
         agent_name: str | None = None,
         tool_call_id: str | None = None,
         tool_description: str | None = None,
-        content_capturing_mode: ContentCapturingMode = ContentCapturingMode.NO_CONTENT,
+        content_capturing_mode: ContentCapturingMode | None = None,
     ) -> None:
         """Use handler.tool(name) instead of calling this directly.
 
@@ -104,10 +104,7 @@ class ToolInvocation(GenAIInvocation):
         .. deprecated:: 1.2b0
             Use :attr:`should_capture_content` instead.
         """
-        return self._content_capturing_mode in (
-            ContentCapturingMode.SPAN_ONLY,
-            ContentCapturingMode.SPAN_AND_EVENT,
-        )
+        return self._should_capture_content_on_span
 
     def _get_start_attributes(self) -> dict[str, AttributeValue]:
         """Return sampling-relevant attributes available at span creation time."""
@@ -130,10 +127,7 @@ class ToolInvocation(GenAIInvocation):
     def _apply_finish(self, error: Error | None = None) -> None:
         if error is not None:
             self._apply_error_attributes(error)
-        capture_content_on_span = self._content_capturing_mode in (
-            ContentCapturingMode.SPAN_ONLY,
-            ContentCapturingMode.SPAN_AND_EVENT,
-        )
+        capture_content_on_span = self._should_capture_content_on_span
         optional_attrs = (
             (GenAI.GEN_AI_TOOL_CALL_ID, self.tool_call_id),
             (GenAI.GEN_AI_TOOL_DESCRIPTION, self.tool_description),

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_workflow_invocation.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_workflow_invocation.py
@@ -41,7 +41,7 @@ class WorkflowInvocation(GenAIInvocation):
         completion_hook: CompletionHook,
         name: str | None,
         *,
-        content_capturing_mode: ContentCapturingMode = ContentCapturingMode.NO_CONTENT,
+        content_capturing_mode: ContentCapturingMode | None = None,
     ) -> None:
         """Use handler.workflow(name) rather than calling this directly."""
         _operation_name = "invoke_workflow"
@@ -72,10 +72,7 @@ class WorkflowInvocation(GenAIInvocation):
         return attrs
 
     def _get_messages_for_span(self) -> dict[str, AttributeValue]:
-        if self._content_capturing_mode not in (
-            ContentCapturingMode.SPAN_ONLY,
-            ContentCapturingMode.SPAN_AND_EVENT,
-        ):
+        if not self._should_capture_content_on_span:
             return {}
         optional_attrs = (
             (

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_workflow_invocation.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_workflow_invocation.py
@@ -17,7 +17,10 @@ from opentelemetry.util.genai.types import (
     InputMessage,
     OutputMessage,
 )
-from opentelemetry.util.genai.utils import gen_ai_json_dumps
+from opentelemetry.util.genai.utils import (
+    ContentCapturingMode,
+    gen_ai_json_dumps,
+)
 from opentelemetry.util.types import AttributeValue
 
 
@@ -38,7 +41,7 @@ class WorkflowInvocation(GenAIInvocation):
         completion_hook: CompletionHook,
         name: str | None,
         *,
-        should_capture_content: bool = False,
+        content_capturing_mode: ContentCapturingMode = ContentCapturingMode.NO_CONTENT,
     ) -> None:
         """Use handler.workflow(name) rather than calling this directly."""
         _operation_name = "invoke_workflow"
@@ -50,7 +53,7 @@ class WorkflowInvocation(GenAIInvocation):
             operation_name=_operation_name,
             span_name=f"{_operation_name} {name}" if name else _operation_name,
             span_kind=SpanKind.INTERNAL,
-            should_capture_content=should_capture_content,
+            content_capturing_mode=content_capturing_mode,
         )
         self._name: str | None = name
         self.conversation_id: str | None = None
@@ -69,7 +72,10 @@ class WorkflowInvocation(GenAIInvocation):
         return attrs
 
     def _get_messages_for_span(self) -> dict[str, AttributeValue]:
-        if not self.should_capture_content:
+        if self._content_capturing_mode not in (
+            ContentCapturingMode.SPAN_ONLY,
+            ContentCapturingMode.SPAN_AND_EVENT,
+        ):
             return {}
         optional_attrs = (
             (

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_workflow_invocation.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_workflow_invocation.py
@@ -17,10 +17,7 @@ from opentelemetry.util.genai.types import (
     InputMessage,
     OutputMessage,
 )
-from opentelemetry.util.genai.utils import (
-    gen_ai_json_dumps,
-    should_capture_content_on_spans,
-)
+from opentelemetry.util.genai.utils import gen_ai_json_dumps
 from opentelemetry.util.types import AttributeValue
 
 
@@ -40,6 +37,8 @@ class WorkflowInvocation(GenAIInvocation):
         logger: Logger,
         completion_hook: CompletionHook,
         name: str | None,
+        *,
+        should_capture_content: bool = False,
     ) -> None:
         """Use handler.workflow(name) rather than calling this directly."""
         _operation_name = "invoke_workflow"
@@ -51,6 +50,7 @@ class WorkflowInvocation(GenAIInvocation):
             operation_name=_operation_name,
             span_name=f"{_operation_name} {name}" if name else _operation_name,
             span_kind=SpanKind.INTERNAL,
+            should_capture_content=should_capture_content,
         )
         self._name: str | None = name
         self.conversation_id: str | None = None
@@ -69,7 +69,7 @@ class WorkflowInvocation(GenAIInvocation):
         return attrs
 
     def _get_messages_for_span(self) -> dict[str, AttributeValue]:
-        if not should_capture_content_on_spans():
+        if not self.should_capture_content:
             return {}
         optional_attrs = (
             (

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/handler.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/handler.py
@@ -158,6 +158,7 @@ class TelemetryHandler:
             server_address=server_address,
             server_port=server_port,
             operation_name=operation_name,
+            should_capture_content=self._capture_content,
         )
 
     def start_llm(self, invocation: LLMInvocation) -> LLMInvocation:
@@ -199,6 +200,7 @@ class TelemetryHandler:
             request_model=request_model,
             server_address=server_address,
             server_port=server_port,
+            should_capture_content=self._capture_content,
         )
 
     def retrieval(
@@ -228,6 +230,7 @@ class TelemetryHandler:
             request_model=request_model,
             server_address=server_address,
             server_port=server_port,
+            should_capture_content=self._capture_content,
         )
 
     def start_tool(
@@ -255,6 +258,7 @@ class TelemetryHandler:
             tool_type=tool_type,
             tool_call_id=tool_call_id,
             tool_description=tool_description,
+            should_capture_content=self._capture_content,
         )
 
     def start_workflow(
@@ -276,6 +280,7 @@ class TelemetryHandler:
             self._logger,
             self._completion_hook,
             name,
+            should_capture_content=self._capture_content,
         )
 
     def stop_llm(self, invocation: LLMInvocation) -> LLMInvocation:  # pylint: disable=no-self-use
@@ -335,6 +340,7 @@ class TelemetryHandler:
             server_port=server_port,
             operation_name=operation_name,
             error_type_resolver=error_type_resolver,
+            should_capture_content=self._capture_content,
         )
 
     def embedding(
@@ -362,6 +368,7 @@ class TelemetryHandler:
             request_model=request_model,
             server_address=server_address,
             server_port=server_port,
+            should_capture_content=self._capture_content,
         )
 
     def fetch_response(
@@ -397,6 +404,7 @@ class TelemetryHandler:
             server_address=server_address,
             server_port=server_port,
             error_type_resolver=error_type_resolver,
+            should_capture_content=self._capture_content,
         )
 
     def tool(
@@ -421,7 +429,7 @@ class TelemetryHandler:
 
         Only set data attributes on the invocation object, do not modify the span or context.
         Recommended to set ``invocation.arguments`` and ``invocation.tool_result`` on the
-        invocation object but only if `invocation.should_capture_content_on_span` is True.
+        invocation object but only if `invocation.should_capture_content` is True.
         """
         return ToolInvocation(
             self._tracer,
@@ -433,6 +441,7 @@ class TelemetryHandler:
             agent_name=agent_name,
             tool_call_id=tool_call_id,
             tool_description=tool_description,
+            should_capture_content=self._capture_content,
         )
 
     def start_invoke_local_agent(
@@ -459,6 +468,7 @@ class TelemetryHandler:
             span_kind=SpanKind.INTERNAL,
             request_model=request_model,
             agent_name=agent_name,
+            should_capture_content=self._capture_content,
         )
 
     def start_invoke_remote_agent(
@@ -491,6 +501,7 @@ class TelemetryHandler:
             agent_name=agent_name,
             server_address=server_address,
             server_port=server_port,
+            should_capture_content=self._capture_content,
         )
 
     def invoke_local_agent(
@@ -517,6 +528,7 @@ class TelemetryHandler:
             span_kind=SpanKind.INTERNAL,
             request_model=request_model,
             agent_name=agent_name,
+            should_capture_content=self._capture_content,
         )
 
     def invoke_remote_agent(
@@ -549,6 +561,7 @@ class TelemetryHandler:
             agent_name=agent_name,
             server_address=server_address,
             server_port=server_port,
+            should_capture_content=self._capture_content,
         )
 
     def workflow(
@@ -569,6 +582,7 @@ class TelemetryHandler:
             self._logger,
             self._completion_hook,
             name,
+            should_capture_content=self._capture_content,
         )
 
 

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/handler.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/handler.py
@@ -102,9 +102,10 @@ class TelemetryHandler:
             logger_provider,
             schema_url=schema_url,
         )
+        self._content_capturing_mode = get_content_capturing_mode()
         self._completion_hook = completion_hook or _NoOpCompletionHook()
         self._capture_content = (
-            get_content_capturing_mode()
+            self._content_capturing_mode
             in (
                 ContentCapturingMode.SPAN_ONLY,
                 ContentCapturingMode.EVENT_ONLY,
@@ -158,7 +159,7 @@ class TelemetryHandler:
             server_address=server_address,
             server_port=server_port,
             operation_name=operation_name,
-            should_capture_content=self._capture_content,
+            content_capturing_mode=self._content_capturing_mode,
         )
 
     def start_llm(self, invocation: LLMInvocation) -> LLMInvocation:
@@ -200,7 +201,7 @@ class TelemetryHandler:
             request_model=request_model,
             server_address=server_address,
             server_port=server_port,
-            should_capture_content=self._capture_content,
+            content_capturing_mode=self._content_capturing_mode,
         )
 
     def retrieval(
@@ -230,7 +231,7 @@ class TelemetryHandler:
             request_model=request_model,
             server_address=server_address,
             server_port=server_port,
-            should_capture_content=self._capture_content,
+            content_capturing_mode=self._content_capturing_mode,
         )
 
     def start_tool(
@@ -258,7 +259,7 @@ class TelemetryHandler:
             tool_type=tool_type,
             tool_call_id=tool_call_id,
             tool_description=tool_description,
-            should_capture_content=self._capture_content,
+            content_capturing_mode=self._content_capturing_mode,
         )
 
     def start_workflow(
@@ -280,7 +281,7 @@ class TelemetryHandler:
             self._logger,
             self._completion_hook,
             name,
-            should_capture_content=self._capture_content,
+            content_capturing_mode=self._content_capturing_mode,
         )
 
     def stop_llm(self, invocation: LLMInvocation) -> LLMInvocation:  # pylint: disable=no-self-use
@@ -340,7 +341,7 @@ class TelemetryHandler:
             server_port=server_port,
             operation_name=operation_name,
             error_type_resolver=error_type_resolver,
-            should_capture_content=self._capture_content,
+            content_capturing_mode=self._content_capturing_mode,
         )
 
     def embedding(
@@ -368,7 +369,7 @@ class TelemetryHandler:
             request_model=request_model,
             server_address=server_address,
             server_port=server_port,
-            should_capture_content=self._capture_content,
+            content_capturing_mode=self._content_capturing_mode,
         )
 
     def fetch_response(
@@ -404,7 +405,7 @@ class TelemetryHandler:
             server_address=server_address,
             server_port=server_port,
             error_type_resolver=error_type_resolver,
-            should_capture_content=self._capture_content,
+            content_capturing_mode=self._content_capturing_mode,
         )
 
     def tool(
@@ -441,7 +442,7 @@ class TelemetryHandler:
             agent_name=agent_name,
             tool_call_id=tool_call_id,
             tool_description=tool_description,
-            should_capture_content=self._capture_content,
+            content_capturing_mode=self._content_capturing_mode,
         )
 
     def start_invoke_local_agent(
@@ -468,7 +469,7 @@ class TelemetryHandler:
             span_kind=SpanKind.INTERNAL,
             request_model=request_model,
             agent_name=agent_name,
-            should_capture_content=self._capture_content,
+            content_capturing_mode=self._content_capturing_mode,
         )
 
     def start_invoke_remote_agent(
@@ -501,7 +502,7 @@ class TelemetryHandler:
             agent_name=agent_name,
             server_address=server_address,
             server_port=server_port,
-            should_capture_content=self._capture_content,
+            content_capturing_mode=self._content_capturing_mode,
         )
 
     def invoke_local_agent(
@@ -528,7 +529,7 @@ class TelemetryHandler:
             span_kind=SpanKind.INTERNAL,
             request_model=request_model,
             agent_name=agent_name,
-            should_capture_content=self._capture_content,
+            content_capturing_mode=self._content_capturing_mode,
         )
 
     def invoke_remote_agent(
@@ -561,7 +562,7 @@ class TelemetryHandler:
             agent_name=agent_name,
             server_address=server_address,
             server_port=server_port,
-            should_capture_content=self._capture_content,
+            content_capturing_mode=self._content_capturing_mode,
         )
 
     def workflow(
@@ -582,7 +583,7 @@ class TelemetryHandler:
             self._logger,
             self._completion_hook,
             name,
-            should_capture_content=self._capture_content,
+            content_capturing_mode=self._content_capturing_mode,
         )
 
 

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/handler.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/handler.py
@@ -173,6 +173,7 @@ class TelemetryHandler:
             self._metrics_recorder,
             self._logger,
             self._completion_hook,
+            content_capturing_mode=self._content_capturing_mode,
         )
         return invocation
 

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/utils.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/utils.py
@@ -127,7 +127,17 @@ def should_emit_event() -> bool:
 
 
 def should_capture_content_on_spans() -> bool:
-    """Returns whether capture content is enabled on spans."""
+    """Returns whether capture content is enabled on spans.
+
+    .. warning::
+        This function reads environment variables on every call and should NOT
+        be called on the hot path.
+
+    .. deprecated:: 1.2b0
+        Use :attr:`~opentelemetry.util.genai.invocation.GenAIInvocation.should_capture_content`
+        or :meth:`~opentelemetry.util.genai.handler.TelemetryHandler.should_capture_content`
+        instead.
+    """
     return get_content_capturing_mode() in (
         ContentCapturingMode.SPAN_ONLY,
         ContentCapturingMode.SPAN_AND_EVENT,

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/utils.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/utils.py
@@ -129,9 +129,8 @@ def should_emit_event() -> bool:
 def should_capture_content_on_spans() -> bool:
     """Returns whether capture content is enabled on spans.
 
-    .. warning::
-        This function reads environment variables on every call and should NOT
-        be called on the hot path.
+    This function reads environment variables on every call and should NOT
+    be called on the hot path.
 
     .. deprecated:: 1.2b0
         Use :attr:`~opentelemetry.util.genai.invocation.GenAIInvocation.should_capture_content`

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/utils.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/utils.py
@@ -133,8 +133,8 @@ def should_capture_content_on_spans() -> bool:
     be called on the hot path.
 
     .. deprecated:: 1.2b0
-        Use :attr:`~opentelemetry.util.genai.invocation.GenAIInvocation.should_capture_content`
-        or :meth:`~opentelemetry.util.genai.handler.TelemetryHandler.should_capture_content`
+        Use ``GenAIInvocation.should_capture_content``
+        or ``TelemetryHandler.should_capture_content``
         instead.
     """
     return get_content_capturing_mode() in (

--- a/util/opentelemetry-util-genai/tests/test_handler_agent.py
+++ b/util/opentelemetry-util-genai/tests/test_handler_agent.py
@@ -337,18 +337,19 @@ class TestLocalAgentInvocation(unittest.TestCase):  # pylint: disable=too-many-p
 class TestAgentInvocationContent(unittest.TestCase):
     def setUp(self):
         self.span_exporter = InMemorySpanExporter()
-        tracer_provider = TracerProvider()
-        tracer_provider.add_span_processor(
+        self.tracer_provider = TracerProvider()
+        self.tracer_provider.add_span_processor(
             SimpleSpanProcessor(self.span_exporter)
         )
-        self.handler = TelemetryHandler(tracer_provider=tracer_provider)
+        self.handler = TelemetryHandler(tracer_provider=self.tracer_provider)
 
     @patch(
-        "opentelemetry.util.genai._invocation.get_content_capturing_mode",
+        "opentelemetry.util.genai.handler.get_content_capturing_mode",
         return_value=ContentCapturingMode.SPAN_AND_EVENT,
     )
     def test_system_instruction_on_span(self, _mock_cap):
-        invocation = self.handler.invoke_local_agent()
+        handler = TelemetryHandler(tracer_provider=self.tracer_provider)
+        invocation = handler.invoke_local_agent()
         invocation.system_instruction = [
             TextPart(content="You are a helpful assistant."),
         ]
@@ -375,11 +376,12 @@ class TestAgentInvocationContent(unittest.TestCase):
         assert GenAI.GEN_AI_TOOL_DEFINITIONS in attrs
 
     @patch(
-        "opentelemetry.util.genai._invocation.get_content_capturing_mode",
+        "opentelemetry.util.genai.handler.get_content_capturing_mode",
         return_value=ContentCapturingMode.SPAN_AND_EVENT,
     )
     def test_messages_on_span(self, _mock_cap):
-        invocation = self.handler.invoke_local_agent()
+        handler = TelemetryHandler(tracer_provider=self.tracer_provider)
+        invocation = handler.invoke_local_agent()
         invocation.input_messages = [
             InputMessage(role="user", parts=[TextPart(content="Hello")])
         ]

--- a/util/opentelemetry-util-genai/tests/test_handler_agent.py
+++ b/util/opentelemetry-util-genai/tests/test_handler_agent.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import os
 import unittest
 from unittest.mock import patch
 
@@ -18,6 +19,9 @@ from opentelemetry.semconv._incubating.attributes import (
 from opentelemetry.semconv.attributes import server_attributes
 from opentelemetry.test.test_base import TestBase
 from opentelemetry.trace import INVALID_SPAN, SpanKind
+from opentelemetry.util.genai.environment_variables import (
+    OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT,
+)
 from opentelemetry.util.genai.handler import TelemetryHandler
 from opentelemetry.util.genai.types import (
     ContentCapturingMode,
@@ -411,6 +415,34 @@ class TestAgentInvocationContent(unittest.TestCase):
         attrs = self.span_exporter.get_finished_spans()[0].attributes
         assert GenAI.GEN_AI_SYSTEM_INSTRUCTIONS not in attrs
         assert GenAI.GEN_AI_INPUT_MESSAGES not in attrs
+
+    @patch.dict(
+        os.environ,
+        {OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT: "EVENT_ONLY"},
+    )
+    def test_messages_omitted_from_span_in_event_only_mode(self):
+        handler = TelemetryHandler(tracer_provider=self.tracer_provider)
+        invocation = handler.invoke_local_agent()
+        assert invocation.should_capture_content is True
+        invocation.system_instruction = [
+            TextPart(content="You are a helpful assistant."),
+        ]
+        invocation.input_messages = [
+            InputMessage(role="user", parts=[TextPart(content="Hello")])
+        ]
+        invocation.output_messages = [
+            OutputMessage(
+                role="assistant",
+                parts=[TextPart(content="Hi!")],
+                finish_reason="stop",
+            )
+        ]
+        invocation.stop()
+
+        attrs = self.span_exporter.get_finished_spans()[0].attributes or {}
+        assert GenAI.GEN_AI_SYSTEM_INSTRUCTIONS not in attrs
+        assert GenAI.GEN_AI_INPUT_MESSAGES not in attrs
+        assert GenAI.GEN_AI_OUTPUT_MESSAGES not in attrs
 
 
 class TestRemoteAgentInvocation(unittest.TestCase):

--- a/util/opentelemetry-util-genai/tests/test_handler_fetch_response.py
+++ b/util/opentelemetry-util-genai/tests/test_handler_fetch_response.py
@@ -269,8 +269,15 @@ class TelemetryHandlerFetchResponseContentTest(_FetchResponseTestBase):
     # opt-in content
     # ------------------------------------------------------------------
 
-    def _fetch_with_content(self) -> None:
-        invocation = self._fetch_response()
+    def _fetch_with_content(
+        self, handler: TelemetryHandler | None = None
+    ) -> None:
+        if handler is not None:
+            invocation = handler.fetch_response(
+                "openai", response_id=RESPONSE_ID
+            )
+        else:
+            invocation = self._fetch_response()
         invocation.output_messages = [
             OutputMessage(
                 role="assistant",
@@ -293,7 +300,11 @@ class TelemetryHandlerFetchResponseContentTest(_FetchResponseTestBase):
             os.environ,
             {OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT: "SPAN_ONLY"},
         ):
-            self._fetch_with_content()
+            handler = TelemetryHandler(
+                tracer_provider=self.tracer_provider,
+                meter_provider=self.meter_provider,
+            )
+            self._fetch_with_content(handler)
 
         attrs = self._get_finished_spans()[0].attributes
         self.assertEqual(

--- a/util/opentelemetry-util-genai/tests/test_handler_fetch_response.py
+++ b/util/opentelemetry-util-genai/tests/test_handler_fetch_response.py
@@ -330,3 +330,18 @@ class TelemetryHandlerFetchResponseContentTest(_FetchResponseTestBase):
         attrs = self._get_finished_spans()[0].attributes
         self.assertNotIn(GenAI.GEN_AI_OUTPUT_MESSAGES, attrs)
         self.assertNotIn(GenAI.GEN_AI_SYSTEM_INSTRUCTIONS, attrs)
+
+    def test_content_suppressed_on_span_in_event_only_mode(self) -> None:
+        with patch.dict(
+            os.environ,
+            {OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT: "EVENT_ONLY"},
+        ):
+            handler = TelemetryHandler(
+                tracer_provider=self.tracer_provider,
+                meter_provider=self.meter_provider,
+            )
+            self._fetch_with_content(handler)
+
+        attrs = self._get_finished_spans()[0].attributes
+        self.assertNotIn(GenAI.GEN_AI_OUTPUT_MESSAGES, attrs)
+        self.assertNotIn(GenAI.GEN_AI_SYSTEM_INSTRUCTIONS, attrs)

--- a/util/opentelemetry-util-genai/tests/test_handler_retrieval.py
+++ b/util/opentelemetry-util-genai/tests/test_handler_retrieval.py
@@ -198,6 +198,29 @@ class TelemetryHandlerRetrievalTest(_RetrievalTestBase):  # pylint: disable=too-
         self.assertIsInstance(raw, str)
         self.assertEqual(json.loads(raw), docs)
 
+    @patch.dict(
+        os.environ,
+        {
+            OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT: "EVENT_ONLY",
+        },
+    )
+    def test_stop_suppresses_query_text_and_docs_in_event_only_mode(
+        self,
+    ) -> None:
+        handler = TelemetryHandler(tracer_provider=self.tracer_provider)
+        docs = [{"id": "doc_1", "score": 0.95}]
+        invocation = handler.retrieval()
+        assert invocation.should_capture_content is True
+        invocation.query_text = "What is the capital of France?"
+        invocation.documents = docs
+        invocation.stop()
+
+        spans = self._get_finished_spans()
+        self.assertNotIn(
+            GenAI.GEN_AI_RETRIEVAL_QUERY_TEXT, spans[0].attributes
+        )
+        self.assertNotIn(GenAI.GEN_AI_RETRIEVAL_DOCUMENTS, spans[0].attributes)
+
     def test_stop_suppresses_documents_when_content_capture_disabled(
         self,
     ) -> None:

--- a/util/opentelemetry-util-genai/tests/test_handler_retrieval.py
+++ b/util/opentelemetry-util-genai/tests/test_handler_retrieval.py
@@ -158,7 +158,8 @@ class TelemetryHandlerRetrievalTest(_RetrievalTestBase):  # pylint: disable=too-
         },
     )
     def test_stop_sets_query_text_when_content_capture_enabled(self) -> None:
-        invocation = self.handler.retrieval()
+        handler = TelemetryHandler(tracer_provider=self.tracer_provider)
+        invocation = handler.retrieval()
         invocation.query_text = "What is the capital of France?"
         invocation.stop()
 
@@ -186,8 +187,9 @@ class TelemetryHandlerRetrievalTest(_RetrievalTestBase):  # pylint: disable=too-
         },
     )
     def test_stop_sets_documents_when_content_capture_enabled(self) -> None:
+        handler = TelemetryHandler(tracer_provider=self.tracer_provider)
         docs = [{"id": "doc_1", "score": 0.95}, {"id": "doc_2", "score": 0.87}]
-        invocation = self.handler.retrieval()
+        invocation = handler.retrieval()
         invocation.documents = docs
         invocation.stop()
 

--- a/util/opentelemetry-util-genai/tests/test_toolcall.py
+++ b/util/opentelemetry-util-genai/tests/test_toolcall.py
@@ -398,3 +398,23 @@ def test_tool_start_attributes_omit_agent_name_at_sampling_time():
     assert GenAI.GEN_AI_AGENT_NAME not in captured_attributes
     finalized = span_exporter.get_finished_spans()[0].attributes
     assert finalized[GenAI.GEN_AI_AGENT_NAME] == "weather_agent"
+
+
+def test_tool_should_capture_content_defaults_to_false():
+    handler = _make_handler()
+    invocation = handler.tool("get_weather")
+    assert invocation.should_capture_content is False
+    assert invocation.should_capture_content_on_span is False
+    invocation.stop()
+
+
+@patch.dict(
+    os.environ,
+    {OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT: "SPAN_ONLY"},
+)
+def test_tool_should_capture_content_enabled():
+    handler = _make_handler()
+    invocation = handler.tool("get_weather")
+    assert invocation.should_capture_content is True
+    assert invocation.should_capture_content_on_span is True
+    invocation.stop()

--- a/util/opentelemetry-util-genai/tests/test_toolcall.py
+++ b/util/opentelemetry-util-genai/tests/test_toolcall.py
@@ -23,7 +23,7 @@ from opentelemetry.util.genai.environment_variables import (
     OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT,
 )
 from opentelemetry.util.genai.handler import TelemetryHandler
-from opentelemetry.util.genai.invocation import GenAIInvocation
+from opentelemetry.util.genai.invocation import GenAIInvocation, ToolInvocation
 from opentelemetry.util.genai.types import (
     CompactionPart,
     InputMessage,
@@ -464,3 +464,34 @@ def test_tool_content_not_on_span_with_completion_hook():
     attrs = finished[0].attributes or {}
     assert GenAI.GEN_AI_TOOL_CALL_ARGUMENTS not in attrs
     assert GenAI.GEN_AI_TOOL_CALL_RESULT not in attrs
+
+
+@patch.dict(
+    os.environ,
+    {OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT: "SPAN_ONLY"},
+)
+def test_direct_invocation_instantiation_falls_back_to_env():
+    span_exporter = InMemorySpanExporter()
+    tracer_provider = TracerProvider()
+    tracer_provider.add_span_processor(SimpleSpanProcessor(span_exporter))
+    tracer = tracer_provider.get_tracer(__name__)
+    mock_recorder = MagicMock()
+    mock_logger = MagicMock()
+    mock_hook = MagicMock(spec=CompletionHook)
+
+    invocation = ToolInvocation(
+        tracer=tracer,
+        metrics_recorder=mock_recorder,
+        logger=mock_logger,
+        completion_hook=mock_hook,
+        name="direct_tool",
+    )
+    assert invocation.should_capture_content is True
+    assert invocation.should_capture_content_on_span is True
+    invocation.arguments = {"arg": "val"}
+    invocation.stop()
+
+    finished = span_exporter.get_finished_spans()
+    assert len(finished) == 1
+    attrs = finished[0].attributes or {}
+    assert GenAI.GEN_AI_TOOL_CALL_ARGUMENTS in attrs

--- a/util/opentelemetry-util-genai/tests/test_toolcall.py
+++ b/util/opentelemetry-util-genai/tests/test_toolcall.py
@@ -4,7 +4,7 @@
 """Tests for ToolCallRequestPart and ToolInvocation inheritance structure"""
 
 import os
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -18,6 +18,7 @@ from opentelemetry.semconv._incubating.attributes import (
     gen_ai_attributes as GenAI,
 )
 from opentelemetry.trace import SpanKind
+from opentelemetry.util.genai.completion_hook import CompletionHook
 from opentelemetry.util.genai.environment_variables import (
     OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT,
 )
@@ -418,3 +419,48 @@ def test_tool_should_capture_content_enabled():
     assert invocation.should_capture_content is True
     assert invocation.should_capture_content_on_span is True
     invocation.stop()
+
+
+@patch.dict(
+    os.environ,
+    {OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT: "EVENT_ONLY"},
+)
+def test_tool_content_not_on_span_in_event_only_mode():
+    span_exporter = InMemorySpanExporter()
+    tracer_provider = TracerProvider()
+    tracer_provider.add_span_processor(SimpleSpanProcessor(span_exporter))
+    handler = TelemetryHandler(tracer_provider=tracer_provider)
+    invocation = handler.tool("get_weather")
+    assert invocation.should_capture_content is True
+    assert invocation.should_capture_content_on_span is False
+    invocation.arguments = {"city": "Paris"}
+    invocation.tool_result = "sunny"
+    invocation.stop()
+
+    finished = span_exporter.get_finished_spans()
+    assert len(finished) == 1
+    attrs = finished[0].attributes or {}
+    assert GenAI.GEN_AI_TOOL_CALL_ARGUMENTS not in attrs
+    assert GenAI.GEN_AI_TOOL_CALL_RESULT not in attrs
+
+
+def test_tool_content_not_on_span_with_completion_hook():
+    mock_hook = MagicMock(spec=CompletionHook)
+    span_exporter = InMemorySpanExporter()
+    tracer_provider = TracerProvider()
+    tracer_provider.add_span_processor(SimpleSpanProcessor(span_exporter))
+    handler = TelemetryHandler(
+        tracer_provider=tracer_provider, completion_hook=mock_hook
+    )
+    invocation = handler.tool("get_weather")
+    assert invocation.should_capture_content is True
+    assert invocation.should_capture_content_on_span is False
+    invocation.arguments = {"city": "Paris"}
+    invocation.tool_result = "sunny"
+    invocation.stop()
+
+    finished = span_exporter.get_finished_spans()
+    assert len(finished) == 1
+    attrs = finished[0].attributes or {}
+    assert GenAI.GEN_AI_TOOL_CALL_ARGUMENTS not in attrs
+    assert GenAI.GEN_AI_TOOL_CALL_RESULT not in attrs

--- a/util/opentelemetry-util-genai/tests/test_utils.py
+++ b/util/opentelemetry-util-genai/tests/test_utils.py
@@ -31,6 +31,7 @@ from opentelemetry.semconv.attributes import (
 )
 from opentelemetry.semconv.schemas import Schemas
 from opentelemetry.trace.status import StatusCode
+from opentelemetry.util.genai._inference_invocation import LLMInvocation
 from opentelemetry.util.genai.handler import (
     TelemetryHandler,
     get_telemetry_handler,
@@ -443,6 +444,46 @@ class TestTelemetryHandler(unittest.TestCase):
                 "extra_manual": "yes",
             },
         )
+
+    @patch.dict(
+        os.environ,
+        {
+            "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT": "SPAN_ONLY",
+            "OTEL_INSTRUMENTATION_GENAI_EMIT_EVENT": "false",
+        },
+    )
+    def test_start_llm_captures_content_on_span(self):
+        handler = TelemetryHandler(tracer_provider=self.tracer_provider)
+        inv = LLMInvocation(request_model="legacy-model")
+        handler.start_llm(inv)
+        inv.input_messages = [_create_input_message("hi")]
+        inv.output_messages = [_create_output_message("hello")]
+        handler.stop_llm(inv)
+
+        span = _get_single_span(self.span_exporter)
+        attrs = _get_span_attributes(span)
+        assert GenAI.GEN_AI_INPUT_MESSAGES in attrs
+        assert GenAI.GEN_AI_OUTPUT_MESSAGES in attrs
+
+    @patch.dict(
+        os.environ,
+        {
+            "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT": "EVENT_ONLY",
+            "OTEL_INSTRUMENTATION_GENAI_EMIT_EVENT": "false",
+        },
+    )
+    def test_inference_messages_omitted_from_span_in_event_only_mode(self):
+        handler = TelemetryHandler(tracer_provider=self.tracer_provider)
+        with handler.inference(
+            "test-provider", request_model="test-model"
+        ) as inv:
+            inv.input_messages = [_create_input_message("hi")]
+            inv.output_messages = [_create_output_message("hello")]
+
+        span = _get_single_span(self.span_exporter)
+        attrs = _get_span_attributes(span)
+        assert GenAI.GEN_AI_INPUT_MESSAGES not in attrs
+        assert GenAI.GEN_AI_OUTPUT_MESSAGES not in attrs
 
     def test_start_inference_passes_sampling_attributes_at_span_creation(self):
         """Verify that sampling-relevant attributes are available at start_span() time."""

--- a/util/opentelemetry-util-genai/tests/test_utils.py
+++ b/util/opentelemetry-util-genai/tests/test_utils.py
@@ -296,8 +296,8 @@ class TestShouldCaptureContent(unittest.TestCase):
 class TestTelemetryHandler(unittest.TestCase):
     def setUp(self):
         self.span_exporter = InMemorySpanExporter()
-        tracer_provider = TracerProvider()
-        tracer_provider.add_span_processor(
+        self.tracer_provider = TracerProvider()
+        self.tracer_provider.add_span_processor(
             SimpleSpanProcessor(self.span_exporter)
         )
         self.log_exporter = InMemoryLogRecordExporter()
@@ -306,7 +306,8 @@ class TestTelemetryHandler(unittest.TestCase):
             SimpleLogRecordProcessor(self.log_exporter)
         )
         self.telemetry_handler = get_telemetry_handler(
-            tracer_provider=tracer_provider, logger_provider=logger_provider
+            tracer_provider=self.tracer_provider,
+            logger_provider=logger_provider,
         )
 
     def tearDown(self):
@@ -328,7 +329,8 @@ class TestTelemetryHandler(unittest.TestCase):
         chat_generation = _create_output_message("hello back")
         system_instruction = _create_system_instruction()
 
-        with self.telemetry_handler.inference(
+        handler = TelemetryHandler(tracer_provider=self.tracer_provider)
+        with handler.inference(
             "test-provider",
             request_model="test-model",
             server_address="custom.server.com",
@@ -411,7 +413,8 @@ class TestTelemetryHandler(unittest.TestCase):
         message = _create_input_message("hi")
         chat_generation = _create_output_message("ok")
 
-        invocation = self.telemetry_handler.inference(
+        handler = TelemetryHandler(tracer_provider=self.tracer_provider)
+        invocation = handler.inference(
             "test-provider", request_model="manual-model"
         )
         invocation.input_messages = [message]

--- a/util/opentelemetry-util-genai/tests/test_utils_events.py
+++ b/util/opentelemetry-util-genai/tests/test_utils_events.py
@@ -20,7 +20,10 @@ from opentelemetry.semconv._incubating.attributes import (
     gen_ai_attributes as GenAI,
 )
 from opentelemetry.semconv.attributes import error_attributes
-from opentelemetry.util.genai.handler import get_telemetry_handler
+from opentelemetry.util.genai.handler import (
+    TelemetryHandler,
+    get_telemetry_handler,
+)
 from opentelemetry.util.genai.types import Error
 
 from .test_utils import (
@@ -46,6 +49,8 @@ class TestTelemetryHandlerEvents(unittest.TestCase):
         logger_provider.add_log_record_processor(
             SimpleLogRecordProcessor(self.log_exporter)
         )
+        self.tracer_provider = tracer_provider
+        self.logger_provider = logger_provider
         self.telemetry_handler = get_telemetry_handler(
             tracer_provider=tracer_provider, logger_provider=logger_provider
         )
@@ -64,7 +69,11 @@ class TestTelemetryHandlerEvents(unittest.TestCase):
         },
     )
     def test_emits_llm_event(self):
-        invocation = self.telemetry_handler.inference(
+        handler = TelemetryHandler(
+            tracer_provider=self.tracer_provider,
+            logger_provider=self.logger_provider,
+        )
+        invocation = handler.inference(
             "test-provider", request_model="event-model"
         )
         invocation.input_messages = [_create_input_message("test query")]
@@ -150,7 +159,11 @@ class TestTelemetryHandlerEvents(unittest.TestCase):
         chat_generation = _create_output_message("combined response")
         system_instruction = _create_system_instruction("System prompt here")
 
-        invocation = self.telemetry_handler.inference(
+        handler = TelemetryHandler(
+            tracer_provider=self.tracer_provider,
+            logger_provider=self.logger_provider,
+        )
+        invocation = handler.inference(
             "test-provider", request_model="combined-model"
         )
         invocation.input_messages = [message]
@@ -335,7 +348,11 @@ class TestTelemetryHandlerEvents(unittest.TestCase):
         chat_generation = _create_output_message("span and event response")
         system_instruction = _create_system_instruction("System prompt")
 
-        invocation = self.telemetry_handler.inference(
+        handler = TelemetryHandler(
+            tracer_provider=self.tracer_provider,
+            logger_provider=self.logger_provider,
+        )
+        invocation = handler.inference(
             "test-provider", request_model="span-and-event-model"
         )
         invocation.input_messages = [message]

--- a/util/opentelemetry-util-genai/tests/test_utils_events.py
+++ b/util/opentelemetry-util-genai/tests/test_utils_events.py
@@ -147,6 +147,12 @@ class TestTelemetryHandlerEvents(unittest.TestCase):
         self.assertEqual(log_record.trace_id, span.context.trace_id)
         self.assertEqual(log_record.span_id, span.context.span_id)
 
+        # In EVENT_ONLY mode, messages must not be attached to span
+        span_attrs = span.attributes or {}
+        self.assertNotIn(GenAI.GEN_AI_INPUT_MESSAGES, span_attrs)
+        self.assertNotIn(GenAI.GEN_AI_OUTPUT_MESSAGES, span_attrs)
+        self.assertNotIn(GenAI.GEN_AI_SYSTEM_INSTRUCTIONS, span_attrs)
+
     @patch.dict(
         os.environ,
         {

--- a/util/opentelemetry-util-genai/tests/test_workflow_invocation.py
+++ b/util/opentelemetry-util-genai/tests/test_workflow_invocation.py
@@ -1,14 +1,22 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 import unittest
+from unittest.mock import patch
 
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
     InMemorySpanExporter,
 )
+from opentelemetry.semconv._incubating.attributes import (
+    gen_ai_attributes as GenAI,
+)
 from opentelemetry.trace import INVALID_SPAN
+from opentelemetry.util.genai.environment_variables import (
+    OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT,
+)
 from opentelemetry.util.genai.handler import TelemetryHandler
 from opentelemetry.util.genai.types import (
     InputMessage,
@@ -20,11 +28,11 @@ from opentelemetry.util.genai.types import (
 class TestWorkflowInvocation(unittest.TestCase):
     def setUp(self):
         self.span_exporter = InMemorySpanExporter()
-        tracer_provider = TracerProvider()
-        tracer_provider.add_span_processor(
+        self.tracer_provider = TracerProvider()
+        self.tracer_provider.add_span_processor(
             SimpleSpanProcessor(self.span_exporter)
         )
-        self.handler = TelemetryHandler(tracer_provider=tracer_provider)
+        self.handler = TelemetryHandler(tracer_provider=self.tracer_provider)
 
     def test_default_values(self):
         invocation = self.handler.workflow(name=None)
@@ -113,3 +121,28 @@ class TestWorkflowInvocation(unittest.TestCase):
         spans = self.span_exporter.get_finished_spans()
         assert spans[0].attributes is not None
         assert spans[0].attributes[GenAI.GEN_AI_CONVERSATION_ID] == "conv-123"
+
+    @patch.dict(
+        os.environ,
+        {OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT: "EVENT_ONLY"},
+    )
+    def test_messages_omitted_from_span_in_event_only_mode(self):
+        handler = TelemetryHandler(tracer_provider=self.tracer_provider)
+        invocation = handler.workflow(name="test")
+        assert invocation.should_capture_content is True
+        invocation.input_messages = [
+            InputMessage(role="user", parts=[TextPart(content="query")])
+        ]
+        invocation.output_messages = [
+            OutputMessage(
+                role="assistant",
+                parts=[TextPart(content="answer")],
+                finish_reason="stop",
+            )
+        ]
+        invocation.stop()
+
+        span = self.span_exporter.get_finished_spans()[0]
+        attrs = span.attributes or {}
+        assert GenAI.GEN_AI_INPUT_MESSAGES not in attrs
+        assert GenAI.GEN_AI_OUTPUT_MESSAGES not in attrs


### PR DESCRIPTION
## What does this change do?

Adds a `should_capture_content` boolean property to `GenAIInvocation` initialized by `TelemetryHandler`, and switches invocations and tool wrappers to it. Deprecates `should_capture_content_on_spans()` in `utils.py` and `should_capture_content_on_span` on `ToolInvocation`.

## Why?

Reading environment variables on every call is not awesome on the hot path. Env vars are harder to patch for tests and harder to migrate to declarative config in the future, so limiting number of times we read env vars is future-proof  and makes things easier.

In addition, checking only spans does not make sense because we probably want to have events for each operation eventually.
