### PR TITLE
[`opentelemetry-instrumentation-genai-dspy]` Instrument `dspy.Retrieve` to emit a retrieval span

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-genai-dspy/.changelog/594.added
+++ b/instrumentation/opentelemetry-instrumentation-genai-dspy/.changelog/594.added
@@ -1,0 +1,1 @@
+Instrument dspy.Retrieve to emit GenAI retrieval spans.

--- a/instrumentation/opentelemetry-instrumentation-genai-dspy/README.rst
+++ b/instrumentation/opentelemetry-instrumentation-genai-dspy/README.rst
@@ -8,8 +8,9 @@ OpenTelemetry DSPy Instrumentation
 
 This package provides OpenTelemetry instrumentation for the
 `DSPy framework <https://pypi.org/project/dspy/>`_, emitting Generative AI
-semantic conventions for DSPy Tool executions and ReAct agent loops
-(supporting both ``dspy.ReAct`` and ``dspy.ReActV2``).
+semantic conventions for DSPy Tool executions, ReAct agent loops
+(supporting both ``dspy.ReAct`` and ``dspy.ReActV2``), and ``dspy.Retrieve``
+retrieval operations.
 
 Installation
 ------------

--- a/instrumentation/opentelemetry-instrumentation-genai-dspy/src/opentelemetry/instrumentation/genai/dspy/patch.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-dspy/src/opentelemetry/instrumentation/genai/dspy/patch.py
@@ -12,6 +12,7 @@ from copy import copy, deepcopy
 from importlib import import_module
 from typing import TYPE_CHECKING, Any, cast
 
+import dspy
 from wrapt import (
     BoundFunctionWrapper,
     FunctionWrapper,
@@ -167,7 +168,7 @@ def _wrap_function(
 
 def patch_dspy(handler: TelemetryHandler) -> None:
     """Apply patches to DSPy Tool, ReAct, and Retrieve classes."""
-    import dspy
+    import dspy.predict.react
 
     tool_module = dspy.Tool.__module__
     tool_name = dspy.Tool.__name__
@@ -226,7 +227,6 @@ def patch_dspy(handler: TelemetryHandler) -> None:
 
 def unpatch_dspy() -> None:
     """Remove patches from DSPy classes."""
-    import dspy
     import dspy.predict.react
 
     unwrap(dspy.Tool, "__call__")
@@ -453,8 +453,6 @@ def _start_retrieval_invocation(
 ) -> RetrievalInvocation:
     rm: Any = getattr(instance, "rm", None)
     if rm is None:
-        import dspy
-
         rm = getattr(dspy.settings, "rm", None)
 
     data_source_id: str | None = (

--- a/instrumentation/opentelemetry-instrumentation-genai-dspy/src/opentelemetry/instrumentation/genai/dspy/patch.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-dspy/src/opentelemetry/instrumentation/genai/dspy/patch.py
@@ -455,6 +455,8 @@ def _start_retrieval_invocation(
     if rm is None:
         rm = getattr(dspy.settings, "rm", None)
 
+    # DSPy retrieval models lack a uniform identifier schema, so inspect common index and provider
+    # attributes across the Retrieve instance and configured RM.
     data_source_id: str | None = (
         getattr(instance, "data_source_id", None)
         or getattr(instance, "index_name", None)

--- a/instrumentation/opentelemetry-instrumentation-genai-dspy/src/opentelemetry/instrumentation/genai/dspy/patch.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-dspy/src/opentelemetry/instrumentation/genai/dspy/patch.py
@@ -12,7 +12,6 @@ from copy import copy, deepcopy
 from importlib import import_module
 from typing import TYPE_CHECKING, Any, cast
 
-import dspy
 from wrapt import (
     BoundFunctionWrapper,
     FunctionWrapper,
@@ -168,6 +167,7 @@ def _wrap_function(
 
 def patch_dspy(handler: TelemetryHandler) -> None:
     """Apply patches to DSPy Tool, ReAct, and Retrieve classes."""
+    import dspy
     import dspy.predict.react
 
     tool_module = dspy.Tool.__module__
@@ -227,6 +227,7 @@ def patch_dspy(handler: TelemetryHandler) -> None:
 
 def unpatch_dspy() -> None:
     """Remove patches from DSPy classes."""
+    import dspy
     import dspy.predict.react
 
     unwrap(dspy.Tool, "__call__")
@@ -453,6 +454,8 @@ def _start_retrieval_invocation(
 ) -> RetrievalInvocation:
     rm: Any = getattr(instance, "rm", None)
     if rm is None:
+        import dspy
+
         rm = getattr(dspy.settings, "rm", None)
 
     # DSPy retrieval models lack a uniform identifier schema, so inspect common index and provider

--- a/instrumentation/opentelemetry-instrumentation-genai-dspy/src/opentelemetry/instrumentation/genai/dspy/patch.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-dspy/src/opentelemetry/instrumentation/genai/dspy/patch.py
@@ -432,7 +432,7 @@ def _extract_retrieval_k(
     instance: Any,
     args: tuple[Any, ...],
     kwargs: dict[str, Any],
-) -> float | None:
+) -> int | None:
     k = kwargs.get("k")
     if k is None and len(args) > 1:
         k = args[1]
@@ -440,7 +440,7 @@ def _extract_retrieval_k(
         k = getattr(instance, "k", None)
     if k is not None:
         try:
-            return float(k)
+            return int(k)
         except (ValueError, TypeError):
             return None
     return None

--- a/instrumentation/opentelemetry-instrumentation-genai-dspy/src/opentelemetry/instrumentation/genai/dspy/patch.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-dspy/src/opentelemetry/instrumentation/genai/dspy/patch.py
@@ -507,6 +507,7 @@ def _set_retrieval_invocation_documents(
 
     documents: list[dict[str, Any]] = []
     for psg in passages:
+        # Standard dspy.Retrieve flattens RM passages to strings via psg.long_text.
         if isinstance(psg, str):
             documents.append({"content": psg})
         elif isinstance(psg, Mapping):

--- a/instrumentation/opentelemetry-instrumentation-genai-dspy/src/opentelemetry/instrumentation/genai/dspy/patch.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-dspy/src/opentelemetry/instrumentation/genai/dspy/patch.py
@@ -485,20 +485,20 @@ def _start_retrieval_invocation(
 def _set_retrieval_invocation_documents(
     handler: TelemetryHandler,
     invocation: RetrievalInvocation,
-    result: Any,
+    result: object,
 ) -> None:
     if not handler.should_capture_content():
         return
 
-    passages: Sequence[Any] | None = None
+    passages: Sequence[object] | None = None
     if hasattr(result, "passages"):
-        attr_val: Any = getattr(result, "passages")
+        attr_val = getattr(result, "passages")
         if isinstance(attr_val, Sequence) and not isinstance(
             attr_val, (str, bytes)
         ):
-            passages = cast(Sequence[Any], attr_val)
+            passages = cast(Sequence[object], attr_val)
     elif isinstance(result, Sequence) and not isinstance(result, (str, bytes)):
-        passages = cast(Sequence[Any], result)
+        passages = cast(Sequence[object], result)
     elif isinstance(result, str):
         passages = [result]
 
@@ -506,19 +506,18 @@ def _set_retrieval_invocation_documents(
         return
 
     documents: list[dict[str, Any]] = []
-    for raw_psg in passages:
-        psg: Any = raw_psg
+    for psg in passages:
         if isinstance(psg, str):
             documents.append({"content": psg})
         elif isinstance(psg, Mapping):
-            mapping_psg: Mapping[Any, Any] = cast(Mapping[Any, Any], psg)
-            content_val: Any = mapping_psg.get("long_text") or mapping_psg.get(
+            mapping_psg = cast(Mapping[str, Any], psg)
+            content_val = mapping_psg.get("long_text") or mapping_psg.get(
                 "content"
             )
             doc: dict[str, Any] = {
-                "content": str(content_val)
-                if content_val is not None
-                else str(cast(object, psg))
+                "content": str(
+                    content_val if content_val is not None else mapping_psg
+                )
             }
             if "id" in mapping_psg:
                 doc["id"] = str(mapping_psg["id"])
@@ -529,15 +528,13 @@ def _set_retrieval_invocation_documents(
                     pass
             documents.append(doc)
         elif hasattr(psg, "long_text"):
-            long_text: Any = getattr(psg, "long_text")
+            long_text = getattr(psg, "long_text")
             doc = {"content": str(long_text)}
             if hasattr(psg, "id"):
-                doc_id: Any = getattr(psg, "id")
-                doc["id"] = str(doc_id)
+                doc["id"] = str(getattr(psg, "id"))
             if hasattr(psg, "score"):
-                score: Any = getattr(psg, "score")
                 try:
-                    doc["score"] = float(score)
+                    doc["score"] = float(getattr(psg, "score"))
                 except (ValueError, TypeError):
                     pass
             documents.append(doc)

--- a/instrumentation/opentelemetry-instrumentation-genai-dspy/src/opentelemetry/instrumentation/genai/dspy/patch.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-dspy/src/opentelemetry/instrumentation/genai/dspy/patch.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import inspect
 import sys
-from collections.abc import Awaitable, Callable, Mapping, Sequence
+from collections.abc import Awaitable, Callable, Sequence
 from copy import copy, deepcopy
 from importlib import import_module
 from typing import TYPE_CHECKING, Any, cast
@@ -189,12 +189,6 @@ def patch_dspy(handler: TelemetryHandler) -> None:
         f"{retrieve_name}.forward",
         _retrieve_forward(handler),
     )
-    if hasattr(dspy.Retrieve, "aforward"):
-        _wrap_function(
-            retrieve_module,
-            f"{retrieve_name}.aforward",
-            _retrieve_aforward(handler),
-        )
 
     _wrap_function(
         _REACT_MODULE,
@@ -233,8 +227,6 @@ def unpatch_dspy() -> None:
     unwrap(dspy.Tool, "acall")
 
     unwrap(dspy.Retrieve, "forward")
-    if hasattr(dspy.Retrieve, "aforward"):
-        unwrap(dspy.Retrieve, "aforward")
 
     unwrap(dspy.predict.react.ReAct, "forward")
     unwrap(dspy.predict.react.ReAct, "aforward")
@@ -457,7 +449,7 @@ def _start_retrieval_invocation(
 
         rm = getattr(dspy.settings, "rm", None)
 
-    # DSPy retrieval models lack a uniform identifier schema, so inspect common index and provider
+    # DSPy retrieval models lack a uniform identifier schema, so inspect common index
     # attributes across the Retrieve instance and configured RM.
     data_source_id: str | None = (
         getattr(instance, "data_source_id", None)
@@ -466,17 +458,11 @@ def _start_retrieval_invocation(
         or (getattr(rm, "index_name", None) if rm is not None else None)
         or (getattr(rm, "collection_name", None) if rm is not None else None)
     )
-    provider: str | None = (
-        getattr(instance, "provider", None)
-        or (getattr(rm, "provider", None) if rm is not None else None)
-        or (getattr(rm, "provider_name", None) if rm is not None else None)
-    )
 
     invocation = handler.retrieval(
         data_source_id=str(data_source_id)
         if data_source_id is not None
         else None,
-        provider=str(provider) if provider is not None else None,
     )
 
     invocation.query_text = _extract_retrieval_query(args, kwargs)
@@ -507,44 +493,7 @@ def _set_retrieval_invocation_documents(
     if passages is None:
         return
 
-    documents: list[dict[str, Any]] = []
-    for psg in passages:
-        # Standard dspy.Retrieve flattens RM passages to strings via psg.long_text.
-        if isinstance(psg, str):
-            documents.append({"content": psg})
-        elif isinstance(psg, Mapping):
-            mapping_psg = cast(Mapping[str, Any], psg)
-            content_val = mapping_psg.get("long_text") or mapping_psg.get(
-                "content"
-            )
-            doc: dict[str, Any] = {
-                "content": str(
-                    content_val if content_val is not None else mapping_psg
-                )
-            }
-            if "id" in mapping_psg:
-                doc["id"] = str(mapping_psg["id"])
-            if "score" in mapping_psg:
-                try:
-                    doc["score"] = float(mapping_psg["score"])
-                except (ValueError, TypeError):
-                    pass
-            documents.append(doc)
-        elif hasattr(psg, "long_text"):
-            long_text = getattr(psg, "long_text")
-            doc = {"content": str(long_text)}
-            if hasattr(psg, "id"):
-                doc["id"] = str(getattr(psg, "id"))
-            if hasattr(psg, "score"):
-                try:
-                    doc["score"] = float(getattr(psg, "score"))
-                except (ValueError, TypeError):
-                    pass
-            documents.append(doc)
-        else:
-            documents.append({"content": str(psg)})
-
-    invocation.documents = documents
+    invocation.documents = [{"content": str(psg)} for psg in passages]
 
 
 def _retrieve_forward(
@@ -561,26 +510,6 @@ def _retrieve_forward(
         )
         with invocation:
             result = wrapped(*args, **kwargs)
-            _set_retrieval_invocation_documents(handler, invocation, result)
-            return result
-
-    return traced_method
-
-
-def _retrieve_aforward(
-    handler: TelemetryHandler,
-) -> Callable[..., Any]:
-    async def traced_method(
-        wrapped: Callable[..., Awaitable[Any]],
-        instance: Retrieve,
-        args: tuple[Any, ...],
-        kwargs: dict[str, Any],
-    ) -> Any:
-        invocation = _start_retrieval_invocation(
-            handler, instance, args, kwargs
-        )
-        with invocation:
-            result = await wrapped(*args, **kwargs)
             _set_retrieval_invocation_documents(handler, invocation, result)
             return result
 

--- a/instrumentation/opentelemetry-instrumentation-genai-dspy/src/opentelemetry/instrumentation/genai/dspy/patch.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-dspy/src/opentelemetry/instrumentation/genai/dspy/patch.py
@@ -475,14 +475,8 @@ def _start_retrieval_invocation(
         provider=str(provider) if provider is not None else None,
     )
 
-    query = _extract_retrieval_query(args, kwargs)
-    if query is not None:
-        invocation.query_text = query
-
-    k = _extract_retrieval_k(instance, args, kwargs)
-    if k is not None:
-        invocation.top_k = k
-
+    invocation.query_text = _extract_retrieval_query(args, kwargs)
+    invocation.top_k = _extract_retrieval_k(instance, args, kwargs)
     return invocation
 
 

--- a/instrumentation/opentelemetry-instrumentation-genai-dspy/src/opentelemetry/instrumentation/genai/dspy/patch.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-dspy/src/opentelemetry/instrumentation/genai/dspy/patch.py
@@ -7,10 +7,10 @@ from __future__ import annotations
 
 import inspect
 import sys
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Mapping, Sequence
 from copy import copy, deepcopy
 from importlib import import_module
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from wrapt import (
     BoundFunctionWrapper,
@@ -29,6 +29,7 @@ from opentelemetry.instrumentation.utils import unwrap
 from opentelemetry.util.genai.handler import TelemetryHandler
 from opentelemetry.util.genai.invocation import (
     AgentInvocation,
+    RetrievalInvocation,
     ToolInvocation,
 )
 from opentelemetry.util.genai.types import (
@@ -41,6 +42,7 @@ if TYPE_CHECKING:
     from dspy.adapters.types.tool import Tool
     from dspy.primitives.module import Module
     from dspy.primitives.prediction import Prediction
+    from dspy.retrievers.retrieve import Retrieve
 
 _REACT_MODULE = "dspy.predict.react"
 _REACT_CLASS = "ReAct"
@@ -164,7 +166,7 @@ def _wrap_function(
 
 
 def patch_dspy(handler: TelemetryHandler) -> None:
-    """Apply patches to DSPy Tool and ReAct classes."""
+    """Apply patches to DSPy Tool, ReAct, and Retrieve classes."""
     import dspy
 
     tool_module = dspy.Tool.__module__
@@ -179,6 +181,20 @@ def patch_dspy(handler: TelemetryHandler) -> None:
         f"{tool_name}.acall",
         _tool_acall(handler),
     )
+
+    retrieve_module = dspy.Retrieve.__module__
+    retrieve_name = dspy.Retrieve.__name__
+    _wrap_function(
+        retrieve_module,
+        f"{retrieve_name}.forward",
+        _retrieve_forward(handler),
+    )
+    if hasattr(dspy.Retrieve, "aforward"):
+        _wrap_function(
+            retrieve_module,
+            f"{retrieve_name}.aforward",
+            _retrieve_aforward(handler),
+        )
 
     _wrap_function(
         _REACT_MODULE,
@@ -215,6 +231,10 @@ def unpatch_dspy() -> None:
 
     unwrap(dspy.Tool, "__call__")
     unwrap(dspy.Tool, "acall")
+
+    unwrap(dspy.Retrieve, "forward")
+    if hasattr(dspy.Retrieve, "aforward"):
+        unwrap(dspy.Retrieve, "aforward")
 
     unwrap(dspy.predict.react.ReAct, "forward")
     unwrap(dspy.predict.react.ReAct, "aforward")
@@ -391,6 +411,183 @@ def _react_aforward(
             result = await wrapped(*args, **kwargs)
             if handler.should_capture_content():
                 _set_agent_invocation_output(invocation, instance, result)
+            return result
+
+    return traced_method
+
+
+def _extract_retrieval_query(
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+) -> str | None:
+    if "query" in kwargs and kwargs["query"] is not None:
+        return str(kwargs["query"])
+    if args and args[0] is not None:
+        return str(args[0])
+    return None
+
+
+def _extract_retrieval_k(
+    instance: Any,
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+) -> float | None:
+    k = kwargs.get("k")
+    if k is None and len(args) > 1:
+        k = args[1]
+    if k is None and hasattr(instance, "k"):
+        k = getattr(instance, "k", None)
+    if k is not None:
+        try:
+            return float(k)
+        except (ValueError, TypeError):
+            return None
+    return None
+
+
+def _start_retrieval_invocation(
+    handler: TelemetryHandler,
+    instance: Retrieve,
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+) -> RetrievalInvocation:
+    rm: Any = getattr(instance, "rm", None)
+    if rm is None:
+        import dspy
+
+        rm = getattr(dspy.settings, "rm", None)
+
+    data_source_id: str | None = (
+        getattr(instance, "data_source_id", None)
+        or getattr(instance, "index_name", None)
+        or (getattr(rm, "data_source_id", None) if rm is not None else None)
+        or (getattr(rm, "index_name", None) if rm is not None else None)
+        or (getattr(rm, "collection_name", None) if rm is not None else None)
+    )
+    provider: str | None = (
+        getattr(instance, "provider", None)
+        or (getattr(rm, "provider", None) if rm is not None else None)
+        or (getattr(rm, "provider_name", None) if rm is not None else None)
+    )
+
+    invocation = handler.retrieval(
+        data_source_id=str(data_source_id)
+        if data_source_id is not None
+        else None,
+        provider=str(provider) if provider is not None else None,
+    )
+
+    query = _extract_retrieval_query(args, kwargs)
+    if query is not None:
+        invocation.query_text = query
+
+    k = _extract_retrieval_k(instance, args, kwargs)
+    if k is not None:
+        invocation.top_k = k
+
+    return invocation
+
+
+def _set_retrieval_invocation_documents(
+    handler: TelemetryHandler,
+    invocation: RetrievalInvocation,
+    result: Any,
+) -> None:
+    if not handler.should_capture_content():
+        return
+
+    passages: Sequence[Any] | None = None
+    if hasattr(result, "passages"):
+        attr_val: Any = getattr(result, "passages")
+        if isinstance(attr_val, Sequence) and not isinstance(
+            attr_val, (str, bytes)
+        ):
+            passages = cast(Sequence[Any], attr_val)
+    elif isinstance(result, Sequence) and not isinstance(result, (str, bytes)):
+        passages = cast(Sequence[Any], result)
+    elif isinstance(result, str):
+        passages = [result]
+
+    if passages is None:
+        return
+
+    documents: list[dict[str, Any]] = []
+    for raw_psg in passages:
+        psg: Any = raw_psg
+        if isinstance(psg, str):
+            documents.append({"content": psg})
+        elif isinstance(psg, Mapping):
+            mapping_psg: Mapping[Any, Any] = cast(Mapping[Any, Any], psg)
+            content_val: Any = mapping_psg.get("long_text") or mapping_psg.get(
+                "content"
+            )
+            doc: dict[str, Any] = {
+                "content": str(content_val)
+                if content_val is not None
+                else str(cast(object, psg))
+            }
+            if "id" in mapping_psg:
+                doc["id"] = str(mapping_psg["id"])
+            if "score" in mapping_psg:
+                try:
+                    doc["score"] = float(mapping_psg["score"])
+                except (ValueError, TypeError):
+                    pass
+            documents.append(doc)
+        elif hasattr(psg, "long_text"):
+            long_text: Any = getattr(psg, "long_text")
+            doc = {"content": str(long_text)}
+            if hasattr(psg, "id"):
+                doc_id: Any = getattr(psg, "id")
+                doc["id"] = str(doc_id)
+            if hasattr(psg, "score"):
+                score: Any = getattr(psg, "score")
+                try:
+                    doc["score"] = float(score)
+                except (ValueError, TypeError):
+                    pass
+            documents.append(doc)
+        else:
+            documents.append({"content": str(psg)})
+
+    invocation.documents = documents
+
+
+def _retrieve_forward(
+    handler: TelemetryHandler,
+) -> Callable[..., Any]:
+    def traced_method(
+        wrapped: Callable[..., Any],
+        instance: Retrieve,
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+    ) -> Any:
+        invocation = _start_retrieval_invocation(
+            handler, instance, args, kwargs
+        )
+        with invocation:
+            result = wrapped(*args, **kwargs)
+            _set_retrieval_invocation_documents(handler, invocation, result)
+            return result
+
+    return traced_method
+
+
+def _retrieve_aforward(
+    handler: TelemetryHandler,
+) -> Callable[..., Any]:
+    async def traced_method(
+        wrapped: Callable[..., Awaitable[Any]],
+        instance: Retrieve,
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+    ) -> Any:
+        invocation = _start_retrieval_invocation(
+            handler, instance, args, kwargs
+        )
+        with invocation:
+            result = await wrapped(*args, **kwargs)
+            _set_retrieval_invocation_documents(handler, invocation, result)
             return result
 
     return traced_method

--- a/instrumentation/opentelemetry-instrumentation-genai-dspy/src/opentelemetry/instrumentation/genai/dspy/patch.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-dspy/src/opentelemetry/instrumentation/genai/dspy/patch.py
@@ -168,7 +168,6 @@ def _wrap_function(
 def patch_dspy(handler: TelemetryHandler) -> None:
     """Apply patches to DSPy Tool, ReAct, and Retrieve classes."""
     import dspy
-    import dspy.predict.react
 
     tool_module = dspy.Tool.__module__
     tool_name = dspy.Tool.__name__

--- a/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/conformance/retrieve.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/conformance/retrieve.py
@@ -1,0 +1,60 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Conformance scenario: retrieval execution for DSPy."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import dspy
+
+from opentelemetry.instrumentation.genai.dspy import DSPyInstrumentor
+from opentelemetry.sdk._logs import LoggerProvider
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.test_util_genai.conformance import (
+    ExpectedViolation,
+    Scenario,
+)
+from opentelemetry.test_util_genai.instrumentor import instrument
+
+
+class _DummyPassage:
+    def __init__(self, text: str) -> None:
+        self.long_text = text
+
+
+class _DummyRM:
+    def __call__(self, query: str, k: int = 3, **kwargs: Any) -> list[Any]:
+        return [_DummyPassage(f"Passage {i} for {query}") for i in range(k)]
+
+
+class RetrieveScenario(Scenario):
+    expected_spans = {"retrieval": 1}
+    expected_metrics = ("gen_ai.client.operation.duration",)
+    expected_violations = (
+        ExpectedViolation(
+            advice_id="genai_expected_attribute_missing",
+            message_substring="server.address",
+        ),
+    )
+
+    def run(
+        self,
+        *,
+        tracer_provider: TracerProvider,
+        meter_provider: MeterProvider,
+        logger_provider: LoggerProvider,
+        vcr: Any,
+    ) -> None:
+        dspy.settings.configure(rm=_DummyRM())
+        with instrument(
+            DSPyInstrumentor(),
+            tracer_provider=tracer_provider,
+            logger_provider=logger_provider,
+            meter_provider=meter_provider,
+            content_capture="SPAN_ONLY",
+        ):
+            retrieve = dspy.Retrieve(k=2)
+            retrieve("What is OpenTelemetry?")

--- a/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/test_conformance.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/test_conformance.py
@@ -22,6 +22,7 @@ from opentelemetry.test_util_genai.conformance import (
 
 from .conformance.react import ReActScenario
 from .conformance.react_v2 import ReActV2Scenario
+from .conformance.retrieve import RetrieveScenario
 from .conformance.tool import ToolScenario
 
 
@@ -30,6 +31,7 @@ from .conformance.tool import ToolScenario
     [
         pytest.param(ReActScenario()),
         pytest.param(ReActV2Scenario()),
+        pytest.param(RetrieveScenario()),
         pytest.param(ToolScenario()),
     ],
     ids=lambda s: type(s).__name__,

--- a/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/test_retrieve.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/test_retrieve.py
@@ -1,0 +1,321 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for DSPy Retrieve instrumentation."""
+
+from __future__ import annotations
+
+import copy
+import json
+from typing import Any
+
+import dspy
+import pytest
+
+from opentelemetry.instrumentation.genai.dspy import DSPyInstrumentor
+from opentelemetry.sdk._logs import LoggerProvider
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
+from opentelemetry.semconv._incubating.attributes import (
+    gen_ai_attributes as GenAI,
+)
+from opentelemetry.semconv.attributes import error_attributes
+from opentelemetry.test_util_genai.instrumentor import instrument
+from opentelemetry.trace import StatusCode
+
+
+class _DummyPassage:
+    def __init__(self, text: str) -> None:
+        self.long_text = text
+
+
+class _DummyRM:
+    def __init__(
+        self,
+        data_source_id: str | None = None,
+        provider: str | None = None,
+        should_fail: bool = False,
+    ) -> None:
+        self.data_source_id = data_source_id
+        self.provider = provider
+        self.should_fail = should_fail
+
+    def __call__(self, query: str, k: int = 3, **kwargs: Any) -> list[Any]:
+        if self.should_fail:
+            raise RuntimeError("RM retrieval failure")
+        return [_DummyPassage(f"Passage {i} for {query}") for i in range(k)]
+
+
+def test_sync_retrieve_execution(
+    tracer_provider: TracerProvider,
+    logger_provider: LoggerProvider,
+    meter_provider: MeterProvider,
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    rm = _DummyRM()
+    dspy.settings.configure(rm=rm)
+
+    with instrument(
+        DSPyInstrumentor(),
+        tracer_provider=tracer_provider,
+        logger_provider=logger_provider,
+        meter_provider=meter_provider,
+        content_capture="SPAN_ONLY",
+    ):
+        retrieve = dspy.Retrieve(k=3)
+        res = retrieve("What is OpenTelemetry?")
+        assert len(res.passages) == 3
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+
+    assert span.name == "retrieval"
+    assert span.status.status_code == StatusCode.UNSET
+    attrs = span.attributes or {}
+    assert attrs.get(GenAI.GEN_AI_OPERATION_NAME) == "retrieval"
+    assert attrs.get(GenAI.GEN_AI_REQUEST_TOP_K) == 3.0
+    assert (
+        attrs.get(GenAI.GEN_AI_RETRIEVAL_QUERY_TEXT)
+        == "What is OpenTelemetry?"
+    )
+
+    docs_attr = attrs.get(GenAI.GEN_AI_RETRIEVAL_DOCUMENTS)
+    assert docs_attr is not None
+    docs = json.loads(str(docs_attr))
+    assert len(docs) == 3
+    assert docs[0] == {"content": "Passage 0 for What is OpenTelemetry?"}
+    assert docs[1] == {"content": "Passage 1 for What is OpenTelemetry?"}
+    assert docs[2] == {"content": "Passage 2 for What is OpenTelemetry?"}
+
+
+def test_retrieve_forward_direct_call(
+    tracer_provider: TracerProvider,
+    logger_provider: LoggerProvider,
+    meter_provider: MeterProvider,
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    rm = _DummyRM()
+    dspy.settings.configure(rm=rm)
+
+    with instrument(
+        DSPyInstrumentor(),
+        tracer_provider=tracer_provider,
+        logger_provider=logger_provider,
+        meter_provider=meter_provider,
+        content_capture="SPAN_ONLY",
+    ):
+        retrieve = dspy.Retrieve(k=3)
+        res = retrieve.forward(query="Direct call", k=2)
+        assert len(res.passages) == 2
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    attrs = spans[0].attributes or {}
+    assert attrs.get(GenAI.GEN_AI_REQUEST_TOP_K) == 2.0
+    assert attrs.get(GenAI.GEN_AI_RETRIEVAL_QUERY_TEXT) == "Direct call"
+
+
+def test_retrieve_with_positional_k(
+    tracer_provider: TracerProvider,
+    logger_provider: LoggerProvider,
+    meter_provider: MeterProvider,
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    rm = _DummyRM()
+    dspy.settings.configure(rm=rm)
+
+    with instrument(
+        DSPyInstrumentor(),
+        tracer_provider=tracer_provider,
+        logger_provider=logger_provider,
+        meter_provider=meter_provider,
+        content_capture="SPAN_ONLY",
+    ):
+        retrieve = dspy.Retrieve(k=3)
+        res = retrieve("Positional k query", 4)
+        assert len(res.passages) == 4
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    attrs = spans[0].attributes or {}
+    assert attrs.get(GenAI.GEN_AI_REQUEST_TOP_K) == 4.0
+    assert (
+        attrs.get(GenAI.GEN_AI_RETRIEVAL_QUERY_TEXT)
+        == "Positional k query"
+    )
+
+
+def test_retrieve_without_content_capture(
+    tracer_provider: TracerProvider,
+    logger_provider: LoggerProvider,
+    meter_provider: MeterProvider,
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    rm = _DummyRM()
+    dspy.settings.configure(rm=rm)
+
+    with instrument(
+        DSPyInstrumentor(),
+        tracer_provider=tracer_provider,
+        logger_provider=logger_provider,
+        meter_provider=meter_provider,
+        content_capture="NO_CONTENT",
+    ):
+        retrieve = dspy.Retrieve(k=2)
+        retrieve("Secret query")
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+    attrs = span.attributes or {}
+    assert attrs.get(GenAI.GEN_AI_OPERATION_NAME) == "retrieval"
+    assert attrs.get(GenAI.GEN_AI_REQUEST_TOP_K) == 2.0
+    assert GenAI.GEN_AI_RETRIEVAL_QUERY_TEXT not in attrs
+    assert GenAI.GEN_AI_RETRIEVAL_DOCUMENTS not in attrs
+
+
+def test_retrieve_error_handling(
+    tracer_provider: TracerProvider,
+    logger_provider: LoggerProvider,
+    meter_provider: MeterProvider,
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    rm = _DummyRM(should_fail=True)
+    dspy.settings.configure(rm=rm)
+
+    with instrument(
+        DSPyInstrumentor(),
+        tracer_provider=tracer_provider,
+        logger_provider=logger_provider,
+        meter_provider=meter_provider,
+        content_capture="SPAN_ONLY",
+    ):
+        retrieve = dspy.Retrieve(k=2)
+        with pytest.raises(RuntimeError, match="RM retrieval failure"):
+            retrieve("Failing query")
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.status.status_code == StatusCode.ERROR
+    attrs = span.attributes or {}
+    assert attrs.get(error_attributes.ERROR_TYPE) == "RuntimeError"
+    assert attrs.get(GenAI.GEN_AI_OPERATION_NAME) == "retrieval"
+
+
+def test_retrieve_no_rm_loaded(
+    tracer_provider: TracerProvider,
+    logger_provider: LoggerProvider,
+    meter_provider: MeterProvider,
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    dspy.settings.configure(rm=None)
+
+    with instrument(
+        DSPyInstrumentor(),
+        tracer_provider=tracer_provider,
+        logger_provider=logger_provider,
+        meter_provider=meter_provider,
+        content_capture="SPAN_ONLY",
+    ):
+        retrieve = dspy.Retrieve(k=2)
+        with pytest.raises(AssertionError, match="No RM is loaded."):
+            retrieve("Query with no RM")
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.status.status_code == StatusCode.ERROR
+    attrs = span.attributes or {}
+    assert attrs.get(error_attributes.ERROR_TYPE) == "AssertionError"
+    assert attrs.get(GenAI.GEN_AI_OPERATION_NAME) == "retrieval"
+
+
+def test_retrieve_data_source_and_provider(
+    tracer_provider: TracerProvider,
+    logger_provider: LoggerProvider,
+    meter_provider: MeterProvider,
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    rm = _DummyRM(data_source_id="wiki_collection", provider="weaviate")
+    dspy.settings.configure(rm=rm)
+
+    with instrument(
+        DSPyInstrumentor(),
+        tracer_provider=tracer_provider,
+        logger_provider=logger_provider,
+        meter_provider=meter_provider,
+        content_capture="SPAN_ONLY",
+    ):
+        retrieve = dspy.Retrieve(k=2)
+        retrieve("Provider query")
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.name == "retrieval wiki_collection"
+    attrs = span.attributes or {}
+    assert attrs.get(GenAI.GEN_AI_DATA_SOURCE_ID) == "wiki_collection"
+    assert attrs.get(GenAI.GEN_AI_PROVIDER_NAME) == "weaviate"
+
+
+def test_retrieve_copy_and_deepcopy(
+    tracer_provider: TracerProvider,
+    logger_provider: LoggerProvider,
+    meter_provider: MeterProvider,
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    rm = _DummyRM()
+    dspy.settings.configure(rm=rm)
+
+    with instrument(
+        DSPyInstrumentor(),
+        tracer_provider=tracer_provider,
+        logger_provider=logger_provider,
+        meter_provider=meter_provider,
+        content_capture="SPAN_ONLY",
+    ):
+        retrieve = dspy.Retrieve(k=2)
+        copied = copy.copy(retrieve)
+        assert copied.k == 2
+        copied("Copied query")
+
+        deep_copied = copy.deepcopy(retrieve)
+        assert deep_copied.k == 2
+        deep_copied("Deep copied query")
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 2
+    assert spans[0].name == "retrieval"
+    assert spans[1].name == "retrieval"
+
+
+def test_retrieve_uninstrument(
+    tracer_provider: TracerProvider,
+    logger_provider: LoggerProvider,
+    meter_provider: MeterProvider,
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    rm = _DummyRM()
+    dspy.settings.configure(rm=rm)
+
+    instrumentor = DSPyInstrumentor()
+    instrumentor.instrument(
+        tracer_provider=tracer_provider,
+        logger_provider=logger_provider,
+        meter_provider=meter_provider,
+    )
+
+    retrieve = dspy.Retrieve(k=2)
+    retrieve("Instrumented query")
+    assert len(span_exporter.get_finished_spans()) == 1
+
+    instrumentor.uninstrument()
+    span_exporter.clear()
+
+    retrieve("Uninstrumented query")
+    assert len(span_exporter.get_finished_spans()) == 0

--- a/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/test_retrieve.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/test_retrieve.py
@@ -77,7 +77,8 @@ def test_sync_retrieve_execution(
     assert span.status.status_code == StatusCode.UNSET
     attrs = span.attributes or {}
     assert attrs.get(GenAI.GEN_AI_OPERATION_NAME) == "retrieval"
-    assert attrs.get(GenAI.GEN_AI_REQUEST_TOP_K) == 3.0
+    assert attrs.get(GenAI.GEN_AI_REQUEST_TOP_K) == 3
+    assert isinstance(attrs.get(GenAI.GEN_AI_REQUEST_TOP_K), int)
     assert (
         attrs.get(GenAI.GEN_AI_RETRIEVAL_QUERY_TEXT)
         == "What is OpenTelemetry?"
@@ -115,7 +116,8 @@ def test_retrieve_forward_direct_call(
     spans = span_exporter.get_finished_spans()
     assert len(spans) == 1
     attrs = spans[0].attributes or {}
-    assert attrs.get(GenAI.GEN_AI_REQUEST_TOP_K) == 2.0
+    assert attrs.get(GenAI.GEN_AI_REQUEST_TOP_K) == 2
+    assert isinstance(attrs.get(GenAI.GEN_AI_REQUEST_TOP_K), int)
     assert attrs.get(GenAI.GEN_AI_RETRIEVAL_QUERY_TEXT) == "Direct call"
 
 
@@ -142,7 +144,8 @@ def test_retrieve_with_positional_k(
     spans = span_exporter.get_finished_spans()
     assert len(spans) == 1
     attrs = spans[0].attributes or {}
-    assert attrs.get(GenAI.GEN_AI_REQUEST_TOP_K) == 4.0
+    assert attrs.get(GenAI.GEN_AI_REQUEST_TOP_K) == 4
+    assert isinstance(attrs.get(GenAI.GEN_AI_REQUEST_TOP_K), int)
     assert attrs.get(GenAI.GEN_AI_RETRIEVAL_QUERY_TEXT) == "Positional k query"
 
 
@@ -170,7 +173,8 @@ def test_retrieve_without_content_capture(
     span = spans[0]
     attrs = span.attributes or {}
     assert attrs.get(GenAI.GEN_AI_OPERATION_NAME) == "retrieval"
-    assert attrs.get(GenAI.GEN_AI_REQUEST_TOP_K) == 2.0
+    assert attrs.get(GenAI.GEN_AI_REQUEST_TOP_K) == 2
+    assert isinstance(attrs.get(GenAI.GEN_AI_REQUEST_TOP_K), int)
     assert GenAI.GEN_AI_RETRIEVAL_QUERY_TEXT not in attrs
     assert GenAI.GEN_AI_RETRIEVAL_DOCUMENTS not in attrs
 
@@ -399,7 +403,8 @@ async def test_async_retrieve_aforward(
     assert span.status.status_code == StatusCode.UNSET
     attrs = span.attributes or {}
     assert attrs.get(GenAI.GEN_AI_OPERATION_NAME) == "retrieval"
-    assert attrs.get(GenAI.GEN_AI_REQUEST_TOP_K) == 2.0
+    assert attrs.get(GenAI.GEN_AI_REQUEST_TOP_K) == 2
+    assert isinstance(attrs.get(GenAI.GEN_AI_REQUEST_TOP_K), int)
     assert (
         attrs.get(GenAI.GEN_AI_RETRIEVAL_QUERY_TEXT)
         == "What is OpenTelemetry?"

--- a/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/test_retrieve.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/test_retrieve.py
@@ -143,10 +143,7 @@ def test_retrieve_with_positional_k(
     assert len(spans) == 1
     attrs = spans[0].attributes or {}
     assert attrs.get(GenAI.GEN_AI_REQUEST_TOP_K) == 4.0
-    assert (
-        attrs.get(GenAI.GEN_AI_RETRIEVAL_QUERY_TEXT)
-        == "Positional k query"
-    )
+    assert attrs.get(GenAI.GEN_AI_RETRIEVAL_QUERY_TEXT) == "Positional k query"
 
 
 def test_retrieve_without_content_capture(

--- a/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/test_retrieve.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/test_retrieve.py
@@ -84,8 +84,8 @@ def test_sync_retrieve_execution(
     )
 
     docs_attr = attrs.get(GenAI.GEN_AI_RETRIEVAL_DOCUMENTS)
-    assert docs_attr is not None
-    docs = json.loads(str(docs_attr))
+    assert isinstance(docs_attr, str)
+    docs = json.loads(docs_attr)
     assert len(docs) == 3
     assert docs[0] == {"content": "Passage 0 for What is OpenTelemetry?"}
     assert docs[1] == {"content": "Passage 1 for What is OpenTelemetry?"}
@@ -316,3 +316,141 @@ def test_retrieve_uninstrument(
 
     retrieve("Uninstrumented query")
     assert len(span_exporter.get_finished_spans()) == 0
+
+
+@pytest.mark.skipif(
+    not hasattr(dspy.Retrieve, "aforward"),
+    reason="dspy.Retrieve.aforward not available in this DSPy version",
+)
+@pytest.mark.anyio
+async def test_async_retrieve_execution(
+    tracer_provider: TracerProvider,
+    logger_provider: LoggerProvider,
+    meter_provider: MeterProvider,
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    rm = _DummyRM()
+
+    with (
+        dspy.context(rm=rm),
+        instrument(
+            DSPyInstrumentor(),
+            tracer_provider=tracer_provider,
+            logger_provider=logger_provider,
+            meter_provider=meter_provider,
+            content_capture="SPAN_ONLY",
+        ),
+    ):
+        retrieve = dspy.Retrieve(k=2)
+        res = await retrieve.aforward("What is OpenTelemetry?")
+        assert len(res.passages) == 2
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.name == "retrieval"
+    assert span.status.status_code == StatusCode.UNSET
+    attrs = span.attributes or {}
+    assert attrs.get(GenAI.GEN_AI_OPERATION_NAME) == "retrieval"
+
+
+@pytest.mark.anyio
+async def test_async_retrieve_aforward(
+    tracer_provider: TracerProvider,
+    logger_provider: LoggerProvider,
+    meter_provider: MeterProvider,
+    span_exporter: InMemorySpanExporter,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def dummy_aforward(
+        self: Any, query: str, k: int | None = None, **kwargs: Any
+    ) -> Any:
+        k = k if k is not None else self.k
+        return dspy.Prediction(
+            passages=[f"Async passage {i} for {query}" for i in range(k)]
+        )
+
+    if not hasattr(dspy.Retrieve, "aforward"):
+        monkeypatch.setattr(
+            dspy.Retrieve, "aforward", dummy_aforward, raising=False
+        )
+
+    rm = _DummyRM()
+
+    with (
+        dspy.context(rm=rm),
+        instrument(
+            DSPyInstrumentor(),
+            tracer_provider=tracer_provider,
+            logger_provider=logger_provider,
+            meter_provider=meter_provider,
+            content_capture="SPAN_ONLY",
+        ),
+    ):
+        retrieve = dspy.Retrieve(k=3)
+        res = await retrieve.aforward("What is OpenTelemetry?", k=2)
+        assert len(res.passages) == 2
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+
+    assert span.name == "retrieval"
+    assert span.status.status_code == StatusCode.UNSET
+    attrs = span.attributes or {}
+    assert attrs.get(GenAI.GEN_AI_OPERATION_NAME) == "retrieval"
+    assert attrs.get(GenAI.GEN_AI_REQUEST_TOP_K) == 2.0
+    assert (
+        attrs.get(GenAI.GEN_AI_RETRIEVAL_QUERY_TEXT)
+        == "What is OpenTelemetry?"
+    )
+
+    docs_attr = attrs.get(GenAI.GEN_AI_RETRIEVAL_DOCUMENTS)
+    assert isinstance(docs_attr, str)
+    docs = json.loads(docs_attr)
+    assert len(docs) == 2
+    assert docs[0] == {"content": "Async passage 0 for What is OpenTelemetry?"}
+    assert docs[1] == {"content": "Async passage 1 for What is OpenTelemetry?"}
+
+
+@pytest.mark.anyio
+async def test_async_retrieve_aforward_error(
+    tracer_provider: TracerProvider,
+    logger_provider: LoggerProvider,
+    meter_provider: MeterProvider,
+    span_exporter: InMemorySpanExporter,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def failing_aforward(
+        self: Any, query: str, k: int | None = None, **kwargs: Any
+    ) -> Any:
+        raise RuntimeError("Async RM retrieval failure")
+
+    if not hasattr(dspy.Retrieve, "aforward"):
+        monkeypatch.setattr(
+            dspy.Retrieve, "aforward", failing_aforward, raising=False
+        )
+
+    rm = _DummyRM()
+
+    with (
+        dspy.context(rm=rm),
+        instrument(
+            DSPyInstrumentor(),
+            tracer_provider=tracer_provider,
+            logger_provider=logger_provider,
+            meter_provider=meter_provider,
+            content_capture="SPAN_ONLY",
+        ),
+    ):
+        retrieve = dspy.Retrieve(k=2)
+        with pytest.raises(RuntimeError, match="Async RM retrieval failure"):
+            await retrieve.aforward("Failing query")
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.status.status_code == StatusCode.ERROR
+    attrs = span.attributes or {}
+    assert attrs.get(error_attributes.ERROR_TYPE) == "RuntimeError"
+    assert attrs.get(GenAI.GEN_AI_OPERATION_NAME) == "retrieval"

--- a/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/test_retrieve.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/test_retrieve.py
@@ -36,11 +36,9 @@ class _DummyRM:
     def __init__(
         self,
         data_source_id: str | None = None,
-        provider: str | None = None,
         should_fail: bool = False,
     ) -> None:
         self.data_source_id = data_source_id
-        self.provider = provider
         self.should_fail = should_fail
 
     def __call__(self, query: str, k: int = 3, **kwargs: Any) -> list[Any]:
@@ -236,13 +234,13 @@ def test_retrieve_no_rm_loaded(
     assert attrs.get(GenAI.GEN_AI_OPERATION_NAME) == "retrieval"
 
 
-def test_retrieve_data_source_and_provider(
+def test_retrieve_data_source_id(
     tracer_provider: TracerProvider,
     logger_provider: LoggerProvider,
     meter_provider: MeterProvider,
     span_exporter: InMemorySpanExporter,
 ) -> None:
-    rm = _DummyRM(data_source_id="wiki_collection", provider="weaviate")
+    rm = _DummyRM(data_source_id="wiki_collection")
     dspy.settings.configure(rm=rm)
 
     with instrument(
@@ -261,7 +259,7 @@ def test_retrieve_data_source_and_provider(
     assert span.name == "retrieval wiki_collection"
     attrs = span.attributes or {}
     assert attrs.get(GenAI.GEN_AI_DATA_SOURCE_ID) == "wiki_collection"
-    assert attrs.get(GenAI.GEN_AI_PROVIDER_NAME) == "weaviate"
+    assert GenAI.GEN_AI_PROVIDER_NAME not in attrs
 
 
 def test_retrieve_copy_and_deepcopy(
@@ -320,142 +318,3 @@ def test_retrieve_uninstrument(
 
     retrieve("Uninstrumented query")
     assert len(span_exporter.get_finished_spans()) == 0
-
-
-@pytest.mark.skipif(
-    not hasattr(dspy.Retrieve, "aforward"),
-    reason="dspy.Retrieve.aforward not available in this DSPy version",
-)
-@pytest.mark.anyio
-async def test_async_retrieve_execution(
-    tracer_provider: TracerProvider,
-    logger_provider: LoggerProvider,
-    meter_provider: MeterProvider,
-    span_exporter: InMemorySpanExporter,
-) -> None:
-    rm = _DummyRM()
-
-    with (
-        dspy.context(rm=rm),
-        instrument(
-            DSPyInstrumentor(),
-            tracer_provider=tracer_provider,
-            logger_provider=logger_provider,
-            meter_provider=meter_provider,
-            content_capture="SPAN_ONLY",
-        ),
-    ):
-        retrieve = dspy.Retrieve(k=2)
-        res = await retrieve.aforward("What is OpenTelemetry?")
-        assert len(res.passages) == 2
-
-    spans = span_exporter.get_finished_spans()
-    assert len(spans) == 1
-    span = spans[0]
-    assert span.name == "retrieval"
-    assert span.status.status_code == StatusCode.UNSET
-    attrs = span.attributes or {}
-    assert attrs.get(GenAI.GEN_AI_OPERATION_NAME) == "retrieval"
-
-
-@pytest.mark.anyio
-async def test_async_retrieve_aforward(
-    tracer_provider: TracerProvider,
-    logger_provider: LoggerProvider,
-    meter_provider: MeterProvider,
-    span_exporter: InMemorySpanExporter,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    async def dummy_aforward(
-        self: Any, query: str, k: int | None = None, **kwargs: Any
-    ) -> Any:
-        k = k if k is not None else self.k
-        return dspy.Prediction(
-            passages=[f"Async passage {i} for {query}" for i in range(k)]
-        )
-
-    if not hasattr(dspy.Retrieve, "aforward"):
-        monkeypatch.setattr(
-            dspy.Retrieve, "aforward", dummy_aforward, raising=False
-        )
-
-    rm = _DummyRM()
-
-    with (
-        dspy.context(rm=rm),
-        instrument(
-            DSPyInstrumentor(),
-            tracer_provider=tracer_provider,
-            logger_provider=logger_provider,
-            meter_provider=meter_provider,
-            content_capture="SPAN_ONLY",
-        ),
-    ):
-        retrieve = dspy.Retrieve(k=3)
-        res = await retrieve.aforward("What is OpenTelemetry?", k=2)
-        assert len(res.passages) == 2
-
-    spans = span_exporter.get_finished_spans()
-    assert len(spans) == 1
-    span = spans[0]
-
-    assert span.name == "retrieval"
-    assert span.status.status_code == StatusCode.UNSET
-    attrs = span.attributes or {}
-    assert attrs.get(GenAI.GEN_AI_OPERATION_NAME) == "retrieval"
-    assert attrs.get(GenAI.GEN_AI_REQUEST_TOP_K) == 2
-    assert isinstance(attrs.get(GenAI.GEN_AI_REQUEST_TOP_K), int)
-    assert (
-        attrs.get(GenAI.GEN_AI_RETRIEVAL_QUERY_TEXT)
-        == "What is OpenTelemetry?"
-    )
-
-    docs_attr = attrs.get(GenAI.GEN_AI_RETRIEVAL_DOCUMENTS)
-    assert isinstance(docs_attr, str)
-    docs = json.loads(docs_attr)
-    assert len(docs) == 2
-    assert docs[0] == {"content": "Async passage 0 for What is OpenTelemetry?"}
-    assert docs[1] == {"content": "Async passage 1 for What is OpenTelemetry?"}
-
-
-@pytest.mark.anyio
-async def test_async_retrieve_aforward_error(
-    tracer_provider: TracerProvider,
-    logger_provider: LoggerProvider,
-    meter_provider: MeterProvider,
-    span_exporter: InMemorySpanExporter,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    async def failing_aforward(
-        self: Any, query: str, k: int | None = None, **kwargs: Any
-    ) -> Any:
-        raise RuntimeError("Async RM retrieval failure")
-
-    if not hasattr(dspy.Retrieve, "aforward"):
-        monkeypatch.setattr(
-            dspy.Retrieve, "aforward", failing_aforward, raising=False
-        )
-
-    rm = _DummyRM()
-
-    with (
-        dspy.context(rm=rm),
-        instrument(
-            DSPyInstrumentor(),
-            tracer_provider=tracer_provider,
-            logger_provider=logger_provider,
-            meter_provider=meter_provider,
-            content_capture="SPAN_ONLY",
-        ),
-    ):
-        retrieve = dspy.Retrieve(k=2)
-        with pytest.raises(RuntimeError, match="Async RM retrieval failure"):
-            await retrieve.aforward("Failing query")
-
-    spans = span_exporter.get_finished_spans()
-    assert len(spans) == 1
-    span = spans[0]
-    assert span.status.status_code == StatusCode.ERROR
-    attrs = span.attributes or {}
-    assert attrs.get(error_attributes.ERROR_TYPE) == "RuntimeError"
-    assert attrs.get(GenAI.GEN_AI_OPERATION_NAME) == "retrieval"


### PR DESCRIPTION
Instruments `dspy.Retrieve.forward` to emit`retrieval` spans with query text, `top_k`, and retrieved document attributes.