### PR TITLE
Add cache_write_input_tokens and modality token usage attributes

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-genai-agno/src/opentelemetry/instrumentation/genai/agno/stream.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-agno/src/opentelemetry/instrumentation/genai/agno/stream.py
@@ -61,7 +61,7 @@ class _AgentStreamMixin:
                     metrics.cache_read_tokens
                 )
             if getattr(metrics, "cache_write_tokens", None) is not None:
-                self._self_agent_invocation.cache_creation_input_tokens = (
+                self._self_agent_invocation.cache_write_input_tokens = (
                     metrics.cache_write_tokens
                 )
 

--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/src/opentelemetry/instrumentation/genai/anthropic/messages_extractors.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/src/opentelemetry/instrumentation/genai/anthropic/messages_extractors.py
@@ -167,7 +167,7 @@ def set_invocation_response_attributes(
     tokens = extract_usage_tokens(message.usage)
     invocation.input_tokens = tokens.input_tokens
     invocation.output_tokens = tokens.output_tokens
-    invocation.cache_creation_input_tokens = tokens.cache_creation_input_tokens
+    invocation.cache_write_input_tokens = tokens.cache_creation_input_tokens
     invocation.cache_read_input_tokens = tokens.cache_read_input_tokens
 
     if capture_content:

--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/conformance/inference.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/conformance/inference.py
@@ -16,7 +16,6 @@ from opentelemetry.sdk._logs import LoggerProvider
 from opentelemetry.sdk.metrics import MeterProvider
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.test_util_genai.conformance import (
-    ExpectedViolation,
     Scenario,
 )
 from opentelemetry.test_util_genai.instrumentor import instrument
@@ -27,12 +26,6 @@ class InferenceScenario(Scenario):
     expected_metrics = (
         "gen_ai.client.operation.duration",
         "gen_ai.client.token.usage",
-    )
-    expected_violations = (
-        ExpectedViolation(
-            advice_id="missing_attribute",
-            message_substring="gen_ai.usage.cache_creation.input_tokens",
-        ),
     )
 
     def run(

--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/conformance/inference_raw_response.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/conformance/inference_raw_response.py
@@ -23,7 +23,6 @@ from opentelemetry.sdk._logs import LoggerProvider
 from opentelemetry.sdk.metrics import MeterProvider
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.test_util_genai.conformance import (
-    ExpectedViolation,
     Scenario,
 )
 from opentelemetry.test_util_genai.instrumentor import instrument
@@ -40,12 +39,6 @@ class InferenceRawResponseScenario(Scenario):
     expected_metrics = (
         "gen_ai.client.operation.duration",
         "gen_ai.client.token.usage",
-    )
-    expected_violations = (
-        ExpectedViolation(
-            advice_id="missing_attribute",
-            message_substring="gen_ai.usage.cache_creation.input_tokens",
-        ),
     )
 
     def run(
@@ -89,12 +82,6 @@ class InferenceRawResponseStreamingScenario(Scenario):
         "gen_ai.client.token.usage",
         "gen_ai.client.operation.time_to_first_chunk",
         "gen_ai.client.operation.time_per_output_chunk",
-    )
-    expected_violations = (
-        ExpectedViolation(
-            advice_id="missing_attribute",
-            message_substring="gen_ai.usage.cache_creation.input_tokens",
-        ),
     )
 
     def run(

--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/conformance/inference_streaming.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/conformance/inference_streaming.py
@@ -22,7 +22,6 @@ from opentelemetry.sdk.metrics import MeterProvider
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.test.weaver_live_check import LiveCheckReport
 from opentelemetry.test_util_genai.conformance import (
-    ExpectedViolation,
     Scenario,
 )
 from opentelemetry.test_util_genai.instrumentor import instrument
@@ -35,12 +34,6 @@ class InferenceStreamingScenario(Scenario):
         "gen_ai.client.token.usage",
         "gen_ai.client.operation.time_to_first_chunk",
         "gen_ai.client.operation.time_per_output_chunk",
-    )
-    expected_violations = (
-        ExpectedViolation(
-            advice_id="missing_attribute",
-            message_substring="gen_ai.usage.cache_creation.input_tokens",
-        ),
     )
 
     def validate(self, report: LiveCheckReport) -> None:

--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/conformance/tool_calling.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/conformance/tool_calling.py
@@ -16,7 +16,6 @@ from opentelemetry.sdk._logs import LoggerProvider
 from opentelemetry.sdk.metrics import MeterProvider
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.test_util_genai.conformance import (
-    ExpectedViolation,
     Scenario,
 )
 from opentelemetry.test_util_genai.instrumentor import instrument
@@ -27,12 +26,6 @@ class ToolCallingScenario(Scenario):
     expected_metrics = (
         "gen_ai.client.operation.duration",
         "gen_ai.client.token.usage",
-    )
-    expected_violations = (
-        ExpectedViolation(
-            advice_id="missing_attribute",
-            message_substring="gen_ai.usage.cache_creation.input_tokens",
-        ),
     )
 
     def run(

--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/test_async_messages.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/test_async_messages.py
@@ -878,13 +878,6 @@ async def test_async_messages_create_aggregates_cache_tokens(
     assert len(spans) == 1
     span = spans[0]
 
-    assert (
-        GenAIAttributes.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS
-        in span.attributes
-    )
-    assert (
-        GenAIAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS in span.attributes
-    )
     assert span.attributes[
         GenAIAttributes.GEN_AI_USAGE_INPUT_TOKENS
     ] == expected_input_tokens(response.usage)
@@ -894,16 +887,26 @@ async def test_async_messages_create_aggregates_cache_tokens(
     )
     cache_creation = getattr(response.usage, "cache_creation_input_tokens", 0)
     cache_read = getattr(response.usage, "cache_read_input_tokens", 0)
-    assert (
-        span.attributes[
-            GenAIAttributes.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS
-        ]
-        == cache_creation
-    )
-    assert (
-        span.attributes[GenAIAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS]
-        == cache_read
-    )
+    if cache_creation:
+        assert (
+            span.attributes["gen_ai.usage.cache_write.input_tokens"]
+            == cache_creation
+        )
+    else:
+        assert "gen_ai.usage.cache_write.input_tokens" not in span.attributes
+    assert "gen_ai.usage.cache_creation.input_tokens" not in span.attributes
+    if cache_read:
+        assert (
+            span.attributes[
+                GenAIAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS
+            ]
+            == cache_read
+        )
+    else:
+        assert (
+            GenAIAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS
+            not in span.attributes
+        )
 
 
 @pytest.mark.asyncio
@@ -943,13 +946,6 @@ async def test_async_messages_create_streaming_aggregates_cache_tokens(
     span = spans[0]
 
     assert (
-        GenAIAttributes.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS
-        in span.attributes
-    )
-    assert (
-        GenAIAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS in span.attributes
-    )
-    assert (
         span.attributes[GenAIAttributes.GEN_AI_USAGE_INPUT_TOKENS]
         == input_tokens
     )
@@ -957,16 +953,26 @@ async def test_async_messages_create_streaming_aggregates_cache_tokens(
         span.attributes[GenAIAttributes.GEN_AI_USAGE_OUTPUT_TOKENS]
         == output_tokens
     )
-    assert (
-        span.attributes[
-            GenAIAttributes.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS
-        ]
-        == cache_creation
-    )
-    assert (
-        span.attributes[GenAIAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS]
-        == cache_read
-    )
+    if cache_creation:
+        assert (
+            span.attributes["gen_ai.usage.cache_write.input_tokens"]
+            == cache_creation
+        )
+    else:
+        assert "gen_ai.usage.cache_write.input_tokens" not in span.attributes
+    assert "gen_ai.usage.cache_creation.input_tokens" not in span.attributes
+    if cache_read:
+        assert (
+            span.attributes[
+                GenAIAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS
+            ]
+            == cache_read
+        )
+    else:
+        assert (
+            GenAIAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS
+            not in span.attributes
+        )
 
 
 @pytest.mark.asyncio

--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/test_messages_extractors.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/test_messages_extractors.py
@@ -3,8 +3,12 @@
 
 """Tests for Anthropic message parameter extraction."""
 
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
 from opentelemetry.instrumentation.genai.anthropic.messages_extractors import (
     extract_params,
+    set_invocation_response_attributes,
 )
 
 
@@ -47,3 +51,25 @@ def test_extract_params_ignores_non_mapping_extra_body():
     assert params.temperature is None
     assert params.top_p is None
     assert params.top_k is None
+
+
+def test_set_invocation_response_attributes_records_cache_tokens():
+    invocation = MagicMock()
+    message = SimpleNamespace(
+        id="msg_123",
+        model="claude-3-7-sonnet-20250219",
+        stop_reason="end_turn",
+        usage=SimpleNamespace(
+            input_tokens=10,
+            output_tokens=20,
+            cache_creation_input_tokens=15,
+            cache_read_input_tokens=5,
+        ),
+    )
+    set_invocation_response_attributes(
+        invocation, message, capture_content=False
+    )
+    assert invocation.input_tokens == 30
+    assert invocation.output_tokens == 20
+    assert invocation.cache_write_input_tokens == 15
+    assert invocation.cache_read_input_tokens == 5

--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/test_sync_messages.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/test_sync_messages.py
@@ -1217,13 +1217,6 @@ def test_sync_messages_create_aggregates_cache_tokens(
     assert len(spans) == 1
     span = spans[0]
 
-    assert (
-        GenAIAttributes.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS
-        in span.attributes
-    )
-    assert (
-        GenAIAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS in span.attributes
-    )
     assert span.attributes[
         GenAIAttributes.GEN_AI_USAGE_INPUT_TOKENS
     ] == expected_input_tokens(response.usage)
@@ -1233,16 +1226,26 @@ def test_sync_messages_create_aggregates_cache_tokens(
     )
     cache_creation = getattr(response.usage, "cache_creation_input_tokens", 0)
     cache_read = getattr(response.usage, "cache_read_input_tokens", 0)
-    assert (
-        span.attributes[
-            GenAIAttributes.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS
-        ]
-        == cache_creation
-    )
-    assert (
-        span.attributes[GenAIAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS]
-        == cache_read
-    )
+    if cache_creation:
+        assert (
+            span.attributes["gen_ai.usage.cache_write.input_tokens"]
+            == cache_creation
+        )
+    else:
+        assert "gen_ai.usage.cache_write.input_tokens" not in span.attributes
+    assert "gen_ai.usage.cache_creation.input_tokens" not in span.attributes
+    if cache_read:
+        assert (
+            span.attributes[
+                GenAIAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS
+            ]
+            == cache_read
+        )
+    else:
+        assert (
+            GenAIAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS
+            not in span.attributes
+        )
 
 
 @pytest.mark.vcr()
@@ -1282,13 +1285,6 @@ def test_sync_messages_create_streaming_aggregates_cache_tokens(
     span = spans[0]
 
     assert (
-        GenAIAttributes.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS
-        in span.attributes
-    )
-    assert (
-        GenAIAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS in span.attributes
-    )
-    assert (
         span.attributes[GenAIAttributes.GEN_AI_USAGE_INPUT_TOKENS]
         == input_tokens
     )
@@ -1296,16 +1292,26 @@ def test_sync_messages_create_streaming_aggregates_cache_tokens(
         span.attributes[GenAIAttributes.GEN_AI_USAGE_OUTPUT_TOKENS]
         == output_tokens
     )
-    assert (
-        span.attributes[
-            GenAIAttributes.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS
-        ]
-        == cache_creation
-    )
-    assert (
-        span.attributes[GenAIAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS]
-        == cache_read
-    )
+    if cache_creation:
+        assert (
+            span.attributes["gen_ai.usage.cache_write.input_tokens"]
+            == cache_creation
+        )
+    else:
+        assert "gen_ai.usage.cache_write.input_tokens" not in span.attributes
+    assert "gen_ai.usage.cache_creation.input_tokens" not in span.attributes
+    if cache_read:
+        assert (
+            span.attributes[
+                GenAIAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS
+            ]
+            == cache_read
+        )
+    else:
+        assert (
+            GenAIAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS
+            not in span.attributes
+        )
 
 
 @pytest.mark.vcr()

--- a/instrumentation/opentelemetry-instrumentation-genai-bedrock/tests/test_invoke_model.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-bedrock/tests/test_invoke_model.py
@@ -115,12 +115,7 @@ def test_invoke_model_anthropic_messages(
     )
     assert span.attributes[GenAIAttributes.GEN_AI_USAGE_INPUT_TOKENS] == 12
     assert span.attributes[GenAIAttributes.GEN_AI_USAGE_OUTPUT_TOKENS] == 8
-    assert (
-        span.attributes[
-            GenAIAttributes.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS
-        ]
-        == 2
-    )
+    assert span.attributes["gen_ai.usage.cache_write.input_tokens"] == 2
     assert (
         span.attributes[GenAIAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS]
         == 4

--- a/instrumentation/opentelemetry-instrumentation-genai-bedrock/tests/test_invoke_model_stream.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-bedrock/tests/test_invoke_model_stream.py
@@ -461,12 +461,7 @@ def test_stream_wrapper_anthropic_with_cache_tokens(
         span.attributes[GenAIAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS]
         == 30
     )
-    assert (
-        span.attributes[
-            GenAIAttributes.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS
-        ]
-        == 10
-    )
+    assert span.attributes["gen_ai.usage.cache_write.input_tokens"] == 10
     assert span.attributes[GenAIAttributes.GEN_AI_RESPONSE_FINISH_REASONS] == (
         "stop",
     )

--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/tests/test_llm_call.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/tests/test_llm_call.py
@@ -1378,12 +1378,7 @@ def test_chat_anthropic_claude_sonnet_cache_token_details(
     assert len(spans) == 1
     span = spans[0]
 
-    assert (
-        span.attributes.get(
-            gen_ai_attributes.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS
-        )
-        == 5
-    )
+    assert span.attributes.get("gen_ai.usage.cache_write.input_tokens") == 5
 
     assert (
         span.attributes.get(

--- a/instrumentation/opentelemetry-instrumentation-genai-openai/.changelog/613.added
+++ b/instrumentation/opentelemetry-instrumentation-genai-openai/.changelog/613.added
@@ -1,0 +1,1 @@
+Record `cache_write_input_tokens`, `audio_input_tokens`, and `audio_output_tokens` from response usage.

--- a/instrumentation/opentelemetry-instrumentation-genai-openai/.changelog/613.added
+++ b/instrumentation/opentelemetry-instrumentation-genai-openai/.changelog/613.added
@@ -1,1 +1,1 @@
-Record `cache_write_input_tokens`, `audio_input_tokens`, and `audio_output_tokens` from response usage.
+Record `cache_write_input_tokens` from response usage.

--- a/instrumentation/opentelemetry-instrumentation-genai-openai/src/opentelemetry/instrumentation/genai/openai/response_extractors.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-openai/src/opentelemetry/instrumentation/genai/openai/response_extractors.py
@@ -109,8 +109,6 @@ class UsageTokens:
     cache_creation_input_tokens: int | None = None
     cache_read_input_tokens: int | None = None
     cache_write_input_tokens: int | None = None
-    audio_input_tokens: int | None = None
-    audio_output_tokens: int | None = None
 
 
 def _get_field(value: object, field_name: str) -> object | None:
@@ -596,27 +594,20 @@ def extract_usage_tokens(usage: ResponseUsage | None) -> UsageTokens:
         else None
     )
     cache_write = (
-        getattr(details, "cache_write_input_tokens", None)
+        getattr(details, "cache_write_tokens", None)
         if details is not None
         else None
-    ) or cache_creation
-    output_details = getattr(usage, "output_tokens_details", None)
+    )
+    if cache_write is None:
+        cache_write = cache_creation
     return UsageTokens(
         input_tokens=usage.input_tokens,
         output_tokens=usage.output_tokens,
         cache_creation_input_tokens=cache_creation,
         cache_write_input_tokens=cache_write,
         cache_read_input_tokens=(
-            details.cached_tokens if details is not None else None
-        ),
-        audio_input_tokens=(
-            getattr(details, "audio_tokens", None)
+            getattr(details, "cached_tokens", None)
             if details is not None
-            else None
-        ),
-        audio_output_tokens=(
-            getattr(output_details, "audio_tokens", None)
-            if output_details is not None
             else None
         ),
     )
@@ -678,10 +669,6 @@ def set_invocation_response_attributes(
     invocation.output_tokens = tokens.output_tokens
     invocation.cache_write_input_tokens = tokens.cache_write_input_tokens
     invocation.cache_read_input_tokens = tokens.cache_read_input_tokens
-    if tokens.audio_input_tokens is not None:
-        invocation.audio_input_tokens = tokens.audio_input_tokens
-    if tokens.audio_output_tokens is not None:
-        invocation.audio_output_tokens = tokens.audio_output_tokens
 
     finish_reasons = extract_finish_reasons(response)
     if finish_reasons:

--- a/instrumentation/opentelemetry-instrumentation-genai-openai/src/opentelemetry/instrumentation/genai/openai/response_extractors.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-openai/src/opentelemetry/instrumentation/genai/openai/response_extractors.py
@@ -108,6 +108,9 @@ class UsageTokens:
     output_tokens: int | None = None
     cache_creation_input_tokens: int | None = None
     cache_read_input_tokens: int | None = None
+    cache_write_input_tokens: int | None = None
+    audio_input_tokens: int | None = None
+    audio_output_tokens: int | None = None
 
 
 def _get_field(value: object, field_name: str) -> object | None:
@@ -586,20 +589,35 @@ def extract_usage_tokens(usage: ResponseUsage | None) -> UsageTokens:
         return UsageTokens()
 
     details = usage.input_tokens_details
+    cache_creation = (
+        details.cache_creation_input_tokens
+        if details is not None
+        and hasattr(details, "cache_creation_input_tokens")
+        else None
+    )
+    cache_write = (
+        getattr(details, "cache_write_input_tokens", None)
+        if details is not None
+        else None
+    ) or cache_creation
+    output_details = getattr(usage, "output_tokens_details", None)
     return UsageTokens(
         input_tokens=usage.input_tokens,
         output_tokens=usage.output_tokens,
-        # `cache_creation_input_tokens` is not present on every SDK version's
-        # input token details model, so keep this attribute access guarded for
-        # compatibility across the supported OpenAI range.
-        cache_creation_input_tokens=(
-            details.cache_creation_input_tokens
-            if details is not None
-            and hasattr(details, "cache_creation_input_tokens")
-            else None
-        ),
+        cache_creation_input_tokens=cache_creation,
+        cache_write_input_tokens=cache_write,
         cache_read_input_tokens=(
             details.cached_tokens if details is not None else None
+        ),
+        audio_input_tokens=(
+            getattr(details, "audio_tokens", None)
+            if details is not None
+            else None
+        ),
+        audio_output_tokens=(
+            getattr(output_details, "audio_tokens", None)
+            if output_details is not None
+            else None
         ),
     )
 
@@ -658,8 +676,12 @@ def set_invocation_response_attributes(
     tokens = extract_usage_tokens(response.usage)
     invocation.input_tokens = tokens.input_tokens
     invocation.output_tokens = tokens.output_tokens
-    invocation.cache_creation_input_tokens = tokens.cache_creation_input_tokens
+    invocation.cache_write_input_tokens = tokens.cache_write_input_tokens
     invocation.cache_read_input_tokens = tokens.cache_read_input_tokens
+    if tokens.audio_input_tokens is not None:
+        invocation.audio_input_tokens = tokens.audio_input_tokens
+    if tokens.audio_output_tokens is not None:
+        invocation.audio_output_tokens = tokens.audio_output_tokens
 
     finish_reasons = extract_finish_reasons(response)
     if finish_reasons:

--- a/instrumentation/opentelemetry-instrumentation-genai-openai/tests/test_response_extractors.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-openai/tests/test_response_extractors.py
@@ -572,10 +572,35 @@ def test_set_invocation_response_attributes_populates_usage_and_metadata(
     assert invocation.input_tokens == 11
     assert invocation.output_tokens == 7
     assert invocation.cache_read_input_tokens == 3
-    assert invocation.cache_creation_input_tokens == 5
+    assert invocation.cache_write_input_tokens == 0
     assert invocation.attributes == {
         OpenAIAttributes.OPENAI_RESPONSE_SERVICE_TIER: "scale",
     }
+
+
+def test_set_invocation_response_attributes_falls_back_to_cache_creation(
+    loaded_module,
+):
+    invocation = LLMInvocation(request_model="gpt-4o-mini")
+    usage = loaded_module.ResponseUsage.model_construct(
+        input_tokens=11,
+        output_tokens=7,
+        input_tokens_details=SimpleNamespace(cache_creation_input_tokens=5),
+        output_tokens_details=None,
+    )
+    result = loaded_module.Response.model_construct(
+        id="resp_123",
+        model="gpt-4.1",
+        usage=usage,
+        output=[],
+        service_tier=None,
+    )
+
+    loaded_module.set_invocation_response_attributes(
+        invocation, result, capture_content=False
+    )
+
+    assert invocation.cache_write_input_tokens == 5
 
 
 def test_set_invocation_response_attributes_prefers_raw_served_model_header(

--- a/instrumentation/opentelemetry-instrumentation-genai-openai/tests/test_utils.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-openai/tests/test_utils.py
@@ -562,7 +562,7 @@ def assert_cache_attributes(span, usage):
     assert details is not None
 
     cached_tokens = getattr(details, "cached_tokens", None)
-    if cached_tokens is None:
+    if not cached_tokens:
         assert GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS not in span.attributes
     else:
         assert (
@@ -571,7 +571,7 @@ def assert_cache_attributes(span, usage):
         )
 
     cache_creation = getattr(details, "cache_creation_input_tokens", None)
-    if cache_creation is None:
+    if not cache_creation:
         assert GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS not in span.attributes
     else:
         assert (

--- a/instrumentation/opentelemetry-instrumentation-google-genai/.changelog/613.added
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/.changelog/613.added
@@ -1,0 +1,1 @@
+Record modality token usage breakdown (`input_tokens_by_modality` and `output_tokens_by_modality`).

--- a/instrumentation/opentelemetry-instrumentation-google-genai/.changelog/613.added
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/.changelog/613.added
@@ -1,1 +1,1 @@
-Record modality token usage breakdown (`input_tokens_by_modality` and `output_tokens_by_modality`).
+Record modality token usage breakdown attributes (text, image, audio) for interactions.

--- a/instrumentation/opentelemetry-instrumentation-google-genai/src/opentelemetry/instrumentation/google_genai/interactions.py
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/src/opentelemetry/instrumentation/google_genai/interactions.py
@@ -151,33 +151,43 @@ def _apply_interaction_response_attributes(
 
     if isinstance(invocation, InferenceInvocation):
         invocation.thinking_tokens = usage.total_thought_tokens
-        input_by_modality = _get_field(usage, "input_tokens_by_modality") or []
-        for entry in input_by_modality:
-            modality = _get_field(entry, "modality")
-            tokens = _get_field(entry, "tokens")
-            if modality and tokens is not None:
-                m = str(modality).lower()
-                if m == "text":
-                    invocation.text_input_tokens = tokens
-                elif m == "image":
-                    invocation.image_input_tokens = tokens
-                elif m == "audio":
-                    invocation.audio_input_tokens = tokens
 
-        output_by_modality = (
-            _get_field(usage, "output_tokens_by_modality") or []
+        def _set_modality_tokens(
+            entries: Any,
+            text_attr: str,
+            image_attr: str,
+            audio_attr: str,
+        ) -> None:
+            for entry in entries or []:
+                modality = _get_field(entry, "modality")
+                tokens = _get_field(entry, "tokens")
+                if modality and tokens is not None:
+                    m = str(modality).lower()
+                    if m == "text":
+                        setattr(invocation, text_attr, tokens)
+                    elif m == "image":
+                        setattr(invocation, image_attr, tokens)
+                    elif m == "audio":
+                        setattr(invocation, audio_attr, tokens)
+
+        _set_modality_tokens(
+            _get_field(usage, "input_tokens_by_modality"),
+            "text_input_tokens",
+            "image_input_tokens",
+            "audio_input_tokens",
         )
-        for entry in output_by_modality:
-            modality = _get_field(entry, "modality")
-            tokens = _get_field(entry, "tokens")
-            if modality and tokens is not None:
-                m = str(modality).lower()
-                if m == "text":
-                    invocation.text_output_tokens = tokens
-                elif m == "image":
-                    invocation.image_output_tokens = tokens
-                elif m == "audio":
-                    invocation.audio_output_tokens = tokens
+        _set_modality_tokens(
+            _get_field(usage, "output_tokens_by_modality"),
+            "text_output_tokens",
+            "image_output_tokens",
+            "audio_output_tokens",
+        )
+        _set_modality_tokens(
+            _get_field(usage, "cached_tokens_by_modality"),
+            "text_cache_read_input_tokens",
+            "image_cache_read_input_tokens",
+            "audio_cache_read_input_tokens",
+        )
 
     if telemetry_handler.should_capture_content():
         invocation.output_messages = _interactions_response_to_messages(

--- a/instrumentation/opentelemetry-instrumentation-google-genai/src/opentelemetry/instrumentation/google_genai/interactions.py
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/src/opentelemetry/instrumentation/google_genai/interactions.py
@@ -147,9 +147,37 @@ def _apply_interaction_response_attributes(
 
     invocation.input_tokens = usage.total_input_tokens
     invocation.output_tokens = usage.total_output_tokens
+    invocation.cache_read_input_tokens = usage.total_cached_tokens
+
     if isinstance(invocation, InferenceInvocation):
         invocation.thinking_tokens = usage.total_thought_tokens
-    invocation.cache_read_input_tokens = usage.total_cached_tokens
+        input_by_modality = _get_field(usage, "input_tokens_by_modality") or []
+        for entry in input_by_modality:
+            modality = _get_field(entry, "modality")
+            tokens = _get_field(entry, "tokens")
+            if modality and tokens is not None:
+                m = str(modality).lower()
+                if m == "text":
+                    invocation.text_input_tokens = tokens
+                elif m == "image":
+                    invocation.image_input_tokens = tokens
+                elif m == "audio":
+                    invocation.audio_input_tokens = tokens
+
+        output_by_modality = (
+            _get_field(usage, "output_tokens_by_modality") or []
+        )
+        for entry in output_by_modality:
+            modality = _get_field(entry, "modality")
+            tokens = _get_field(entry, "tokens")
+            if modality and tokens is not None:
+                m = str(modality).lower()
+                if m == "text":
+                    invocation.text_output_tokens = tokens
+                elif m == "image":
+                    invocation.image_output_tokens = tokens
+                elif m == "audio":
+                    invocation.audio_output_tokens = tokens
 
     if telemetry_handler.should_capture_content():
         invocation.output_messages = _interactions_response_to_messages(

--- a/instrumentation/opentelemetry-instrumentation-google-genai/tests/interactions/base.py
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/tests/interactions/base.py
@@ -248,6 +248,38 @@ class TestCase(CommonTestCaseBase):
         self.assertEqual(span.attributes["gen_ai.usage.input_tokens"], 15)
         self.assertEqual(span.attributes["gen_ai.usage.output_tokens"], 25)
 
+    def test_generated_span_counts_modality_tokens(self) -> None:
+        self.configure_valid_interaction(
+            input_tokens=15,
+            output_tokens=25,
+            input_tokens_by_modality=[
+                {"modality": "text", "tokens": 10},
+                {"modality": "image", "tokens": 5},
+            ],
+            output_tokens_by_modality=[
+                {"modality": "text", "tokens": 20},
+                {"modality": "audio", "tokens": 5},
+            ],
+            cached_tokens_by_modality=[
+                {"modality": "text", "tokens": 3},
+            ],
+        )
+        self.run_interaction(model="gemini-2.5-flash", input="Some input")
+        span = self.otel.get_span_named("interactions.create gemini-2.5-flash")
+        self.assertEqual(span.attributes["gen_ai.usage.input_tokens"], 15)
+        self.assertEqual(span.attributes["gen_ai.usage.output_tokens"], 25)
+        self.assertEqual(span.attributes["gen_ai.usage.text.input_tokens"], 10)
+        self.assertEqual(span.attributes["gen_ai.usage.image.input_tokens"], 5)
+        self.assertEqual(
+            span.attributes["gen_ai.usage.text.output_tokens"], 20
+        )
+        self.assertEqual(
+            span.attributes["gen_ai.usage.audio.output_tokens"], 5
+        )
+        self.assertEqual(
+            span.attributes["gen_ai.usage.text.cache_read.input_tokens"], 3
+        )
+
     @patch.dict(
         "os.environ",
         {"OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT": "SPAN_ONLY"},

--- a/instrumentation/opentelemetry-instrumentation-google-genai/tests/interactions/util.py
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/tests/interactions/util.py
@@ -14,12 +14,18 @@ def create_mock_interaction(
     output_text: str = "model output",
     input_tokens: int = 10,
     output_tokens: int = 20,
+    input_tokens_by_modality: list[Any] | None = None,
+    output_tokens_by_modality: list[Any] | None = None,
+    cached_tokens_by_modality: list[Any] | None = None,
 ) -> Any:
     mock_usage = unittest.mock.MagicMock()
     mock_usage.total_input_tokens = input_tokens
     mock_usage.total_output_tokens = output_tokens
     mock_usage.total_thought_tokens = 0
     mock_usage.total_cached_tokens = 0
+    mock_usage.input_tokens_by_modality = input_tokens_by_modality
+    mock_usage.output_tokens_by_modality = output_tokens_by_modality
+    mock_usage.cached_tokens_by_modality = cached_tokens_by_modality
 
     mock_user_step = unittest.mock.MagicMock()
     mock_user_step.type = "user_input"

--- a/util/opentelemetry-util-genai/.changelog/613.added
+++ b/util/opentelemetry-util-genai/.changelog/613.added
@@ -1,0 +1,1 @@
+Add `cache_write_input_tokens` and modality token breakdown attributes (`text_*`, `image_*`, `audio_*`) to invocations.

--- a/util/opentelemetry-util-genai/.changelog/613.deprecated
+++ b/util/opentelemetry-util-genai/.changelog/613.deprecated
@@ -1,0 +1,1 @@
+Deprecate `cache_creation_input_tokens` in favor of `cache_write_input_tokens`.

--- a/util/opentelemetry-util-genai/README.rst
+++ b/util/opentelemetry-util-genai/README.rst
@@ -81,6 +81,8 @@ This package sets the following span attributes on LLM invocations:
 - ``gen_ai.response.id``: Str(chatcmpl-Bz8yrvPnydD9pObv625n2CGBPHS13)
 - ``gen_ai.usage.input_tokens``: Int(24)
 - ``gen_ai.usage.output_tokens``: Int(7)
+- ``gen_ai.usage.cache_write.input_tokens``: Int(10)
+- ``gen_ai.usage.cache_read.input_tokens``: Int(5)
 
 **Request parameter attributes (when provided):**
 

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_agent_invocation.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_agent_invocation.py
@@ -3,8 +3,6 @@
 
 from __future__ import annotations
 
-from typing import Final
-
 from opentelemetry._logs import Logger
 from opentelemetry.semconv._incubating.attributes import (
     gen_ai_attributes as GenAI,
@@ -27,10 +25,6 @@ from opentelemetry.util.genai.types import (
 )
 from opentelemetry.util.genai.utils import ContentCapturingMode
 from opentelemetry.util.types import AttributeValue
-
-_GEN_AI_USAGE_CACHE_WRITE_INPUT_TOKENS: Final = (
-    "gen_ai.usage.cache_write.input_tokens"
-)
 
 
 class AgentInvocation(GenAIInvocation):
@@ -101,7 +95,7 @@ class AgentInvocation(GenAIInvocation):
         self.input_tokens: int | None = None
         self.output_tokens: int | None = None
         self._cache_write_input_tokens: int | None = None
-        self.cache_read_input_tokens: int | None = None
+        self._cache_read_input_tokens: int | None = None
 
         self.input_messages: list[InputMessage] = []
         self.output_messages: list[OutputMessage] = []
@@ -115,7 +109,11 @@ class AgentInvocation(GenAIInvocation):
 
     @property
     def cache_write_input_tokens(self) -> int | None:
-        """The number of cache write input tokens."""
+        """The number of cache write input tokens.
+
+        .. deprecated:: 1.3b0
+            Cache tokens are not reported on internal agent spans per semantic conventions.
+        """
         return self._cache_write_input_tokens
 
     @cache_write_input_tokens.setter
@@ -127,13 +125,26 @@ class AgentInvocation(GenAIInvocation):
         """The number of cache creation input tokens.
 
         .. deprecated:: 1.3b0
-            Use :attr:`cache_write_input_tokens` instead.
+            Cache tokens are not reported on internal agent spans per semantic conventions.
         """
         return self._cache_write_input_tokens
 
     @cache_creation_input_tokens.setter
     def cache_creation_input_tokens(self, value: int | None) -> None:
         self._cache_write_input_tokens = value
+
+    @property
+    def cache_read_input_tokens(self) -> int | None:
+        """The number of cache read input tokens.
+
+        .. deprecated:: 1.3b0
+            Cache tokens are not reported on internal agent spans per semantic conventions.
+        """
+        return self._cache_read_input_tokens
+
+    @cache_read_input_tokens.setter
+    def cache_read_input_tokens(self, value: int | None) -> None:
+        self._cache_read_input_tokens = value
 
     @property
     def agent_name(self) -> str | None:
@@ -188,14 +199,6 @@ class AgentInvocation(GenAIInvocation):
         optional_attrs = (
             (GenAI.GEN_AI_USAGE_INPUT_TOKENS, self.input_tokens),
             (GenAI.GEN_AI_USAGE_OUTPUT_TOKENS, self.output_tokens),
-            (
-                _GEN_AI_USAGE_CACHE_WRITE_INPUT_TOKENS,
-                self.cache_write_input_tokens or None,
-            ),
-            (
-                GenAI.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS,
-                self.cache_read_input_tokens or None,
-            ),
         )
         return {k: v for k, v in optional_attrs if v is not None}
 

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_agent_invocation.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_agent_invocation.py
@@ -190,11 +190,11 @@ class AgentInvocation(GenAIInvocation):
             (GenAI.GEN_AI_USAGE_OUTPUT_TOKENS, self.output_tokens),
             (
                 _GEN_AI_USAGE_CACHE_WRITE_INPUT_TOKENS,
-                self.cache_write_input_tokens,
+                self.cache_write_input_tokens or None,
             ),
             (
                 GenAI.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS,
-                self.cache_read_input_tokens,
+                self.cache_read_input_tokens or None,
             ),
         )
         return {k: v for k, v in optional_attrs if v is not None}

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_agent_invocation.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_agent_invocation.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+from typing import Final
+
 from opentelemetry._logs import Logger
 from opentelemetry.semconv._incubating.attributes import (
     gen_ai_attributes as GenAI,
@@ -25,6 +27,10 @@ from opentelemetry.util.genai.types import (
 )
 from opentelemetry.util.genai.utils import ContentCapturingMode
 from opentelemetry.util.types import AttributeValue
+
+_GEN_AI_USAGE_CACHE_WRITE_INPUT_TOKENS: Final = (
+    "gen_ai.usage.cache_write.input_tokens"
+)
 
 
 class AgentInvocation(GenAIInvocation):
@@ -94,7 +100,7 @@ class AgentInvocation(GenAIInvocation):
 
         self.input_tokens: int | None = None
         self.output_tokens: int | None = None
-        self.cache_creation_input_tokens: int | None = None
+        self._cache_write_input_tokens: int | None = None
         self.cache_read_input_tokens: int | None = None
 
         self.input_messages: list[InputMessage] = []
@@ -106,6 +112,28 @@ class AgentInvocation(GenAIInvocation):
         self.tool_definitions: list[ToolDefinition] | None = None
 
         self._start(self._get_start_attributes())
+
+    @property
+    def cache_write_input_tokens(self) -> int | None:
+        """The number of cache write input tokens."""
+        return self._cache_write_input_tokens
+
+    @cache_write_input_tokens.setter
+    def cache_write_input_tokens(self, value: int | None) -> None:
+        self._cache_write_input_tokens = value
+
+    @property
+    def cache_creation_input_tokens(self) -> int | None:
+        """The number of cache creation input tokens.
+
+        .. deprecated:: 1.3b0
+            Use :attr:`cache_write_input_tokens` instead.
+        """
+        return self._cache_write_input_tokens
+
+    @cache_creation_input_tokens.setter
+    def cache_creation_input_tokens(self, value: int | None) -> None:
+        self._cache_write_input_tokens = value
 
     @property
     def agent_name(self) -> str | None:
@@ -161,8 +189,8 @@ class AgentInvocation(GenAIInvocation):
             (GenAI.GEN_AI_USAGE_INPUT_TOKENS, self.input_tokens),
             (GenAI.GEN_AI_USAGE_OUTPUT_TOKENS, self.output_tokens),
             (
-                GenAI.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS,
-                self.cache_creation_input_tokens,
+                _GEN_AI_USAGE_CACHE_WRITE_INPUT_TOKENS,
+                self.cache_write_input_tokens,
             ),
             (
                 GenAI.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS,

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_inference_invocation.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_inference_invocation.py
@@ -216,51 +216,51 @@ class InferenceInvocation(GenAIInvocation):
             (GenAI.GEN_AI_OUTPUT_TYPE, self.output_type),
             (
                 _GEN_AI_USAGE_CACHE_WRITE_INPUT_TOKENS,
-                self.cache_write_input_tokens,
+                self.cache_write_input_tokens or None,
             ),
             (
                 GenAI.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS,
-                self.cache_read_input_tokens,
+                self.cache_read_input_tokens or None,
             ),
             (
                 GenAI.GEN_AI_USAGE_REASONING_OUTPUT_TOKENS,
-                self.thinking_tokens,
+                self.thinking_tokens or None,
             ),
             (
                 _GEN_AI_USAGE_TEXT_INPUT_TOKENS,
-                self.text_input_tokens,
+                self.text_input_tokens or None,
             ),
             (
                 _GEN_AI_USAGE_IMAGE_INPUT_TOKENS,
-                self.image_input_tokens,
+                self.image_input_tokens or None,
             ),
             (
                 _GEN_AI_USAGE_AUDIO_INPUT_TOKENS,
-                self.audio_input_tokens,
+                self.audio_input_tokens or None,
             ),
             (
                 _GEN_AI_USAGE_TEXT_OUTPUT_TOKENS,
-                self.text_output_tokens,
+                self.text_output_tokens or None,
             ),
             (
                 _GEN_AI_USAGE_IMAGE_OUTPUT_TOKENS,
-                self.image_output_tokens,
+                self.image_output_tokens or None,
             ),
             (
                 _GEN_AI_USAGE_AUDIO_OUTPUT_TOKENS,
-                self.audio_output_tokens,
+                self.audio_output_tokens or None,
             ),
             (
                 _GEN_AI_USAGE_TEXT_CACHE_READ_INPUT_TOKENS,
-                self.text_cache_read_input_tokens,
+                self.text_cache_read_input_tokens or None,
             ),
             (
                 _GEN_AI_USAGE_IMAGE_CACHE_READ_INPUT_TOKENS,
-                self.image_cache_read_input_tokens,
+                self.image_cache_read_input_tokens or None,
             ),
             (
                 _GEN_AI_USAGE_AUDIO_CACHE_READ_INPUT_TOKENS,
-                self.audio_cache_read_input_tokens,
+                self.audio_cache_read_input_tokens or None,
             ),
             (
                 GenAI.GEN_AI_RESPONSE_TIME_TO_FIRST_CHUNK,

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_inference_invocation.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_inference_invocation.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from typing import Final
 
 from opentelemetry._logs import Logger, LogRecord
 from opentelemetry.semconv._incubating.attributes import (
@@ -31,6 +32,25 @@ from opentelemetry.util.genai.utils import (
     should_emit_event,
 )
 from opentelemetry.util.types import AttributeValue
+
+_GEN_AI_USAGE_CACHE_WRITE_INPUT_TOKENS: Final = (
+    "gen_ai.usage.cache_write.input_tokens"
+)
+_GEN_AI_USAGE_TEXT_INPUT_TOKENS: Final = "gen_ai.usage.text.input_tokens"
+_GEN_AI_USAGE_IMAGE_INPUT_TOKENS: Final = "gen_ai.usage.image.input_tokens"
+_GEN_AI_USAGE_AUDIO_INPUT_TOKENS: Final = "gen_ai.usage.audio.input_tokens"
+_GEN_AI_USAGE_TEXT_OUTPUT_TOKENS: Final = "gen_ai.usage.text.output_tokens"
+_GEN_AI_USAGE_IMAGE_OUTPUT_TOKENS: Final = "gen_ai.usage.image.output_tokens"
+_GEN_AI_USAGE_AUDIO_OUTPUT_TOKENS: Final = "gen_ai.usage.audio.output_tokens"
+_GEN_AI_USAGE_TEXT_CACHE_READ_INPUT_TOKENS: Final = (
+    "gen_ai.usage.text.cache_read.input_tokens"
+)
+_GEN_AI_USAGE_IMAGE_CACHE_READ_INPUT_TOKENS: Final = (
+    "gen_ai.usage.image.cache_read.input_tokens"
+)
+_GEN_AI_USAGE_AUDIO_CACHE_READ_INPUT_TOKENS: Final = (
+    "gen_ai.usage.audio.cache_read.input_tokens"
+)
 
 
 class InferenceInvocation(GenAIInvocation):
@@ -96,8 +116,17 @@ class InferenceInvocation(GenAIInvocation):
         self.max_tokens: int | None = None
         self.stop_sequences: list[str] | None = None
         self.seed: int | None = None
-        self.cache_creation_input_tokens: int | None = None
+        self.cache_write_input_tokens: int | None = None
         self.cache_read_input_tokens: int | None = None
+        self.text_input_tokens: int | None = None
+        self.image_input_tokens: int | None = None
+        self.audio_input_tokens: int | None = None
+        self.text_output_tokens: int | None = None
+        self.image_output_tokens: int | None = None
+        self.audio_output_tokens: int | None = None
+        self.text_cache_read_input_tokens: int | None = None
+        self.image_cache_read_input_tokens: int | None = None
+        self.audio_cache_read_input_tokens: int | None = None
         self.tool_definitions: list[ToolDefinition] | None = None
         self.top_k: float | None = None
         self.request_choice_count: int | None = None
@@ -106,6 +135,18 @@ class InferenceInvocation(GenAIInvocation):
         # _invalidate_metric_attributes whenever an input changes.
         self._cached_metric_attributes: dict[str, AttributeValue] | None = None
         self._start(self._get_start_attributes())
+
+    @property
+    def cache_creation_input_tokens(self) -> int | None:
+        """
+        .. deprecated:: 1.3b0
+            Use :attr:`cache_write_input_tokens` instead.
+        """
+        return self.cache_write_input_tokens
+
+    @cache_creation_input_tokens.setter
+    def cache_creation_input_tokens(self, value: int | None) -> None:
+        self.cache_write_input_tokens = value
 
     @property
     def response_model_name(self) -> str | None:
@@ -174,8 +215,8 @@ class InferenceInvocation(GenAIInvocation):
             (GenAI.GEN_AI_REQUEST_CHOICE_COUNT, self.request_choice_count),
             (GenAI.GEN_AI_OUTPUT_TYPE, self.output_type),
             (
-                GenAI.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS,
-                self.cache_creation_input_tokens,
+                _GEN_AI_USAGE_CACHE_WRITE_INPUT_TOKENS,
+                self.cache_write_input_tokens,
             ),
             (
                 GenAI.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS,
@@ -184,6 +225,42 @@ class InferenceInvocation(GenAIInvocation):
             (
                 GenAI.GEN_AI_USAGE_REASONING_OUTPUT_TOKENS,
                 self.thinking_tokens,
+            ),
+            (
+                _GEN_AI_USAGE_TEXT_INPUT_TOKENS,
+                self.text_input_tokens,
+            ),
+            (
+                _GEN_AI_USAGE_IMAGE_INPUT_TOKENS,
+                self.image_input_tokens,
+            ),
+            (
+                _GEN_AI_USAGE_AUDIO_INPUT_TOKENS,
+                self.audio_input_tokens,
+            ),
+            (
+                _GEN_AI_USAGE_TEXT_OUTPUT_TOKENS,
+                self.text_output_tokens,
+            ),
+            (
+                _GEN_AI_USAGE_IMAGE_OUTPUT_TOKENS,
+                self.image_output_tokens,
+            ),
+            (
+                _GEN_AI_USAGE_AUDIO_OUTPUT_TOKENS,
+                self.audio_output_tokens,
+            ),
+            (
+                _GEN_AI_USAGE_TEXT_CACHE_READ_INPUT_TOKENS,
+                self.text_cache_read_input_tokens,
+            ),
+            (
+                _GEN_AI_USAGE_IMAGE_CACHE_READ_INPUT_TOKENS,
+                self.image_cache_read_input_tokens,
+            ),
+            (
+                _GEN_AI_USAGE_AUDIO_CACHE_READ_INPUT_TOKENS,
+                self.audio_cache_read_input_tokens,
             ),
             (
                 GenAI.GEN_AI_RESPONSE_TIME_TO_FIRST_CHUNK,
@@ -286,6 +363,17 @@ class LLMInvocation:
     finish_reasons: list[str] | None = None
     input_tokens: int | None = None
     output_tokens: int | None = None
+    cache_write_input_tokens: int | None = None
+    cache_read_input_tokens: int | None = None
+    text_input_tokens: int | None = None
+    image_input_tokens: int | None = None
+    audio_input_tokens: int | None = None
+    text_output_tokens: int | None = None
+    image_output_tokens: int | None = None
+    audio_output_tokens: int | None = None
+    text_cache_read_input_tokens: int | None = None
+    image_cache_read_input_tokens: int | None = None
+    audio_cache_read_input_tokens: int | None = None
     attributes: dict[str, AttributeValue] = field(default_factory=dict)  # pyright: ignore[reportUnknownVariableType]
     """Additional attributes to set on spans and/or events. Not set on metrics."""
     metric_attributes: dict[str, AttributeValue] = field(default_factory=dict)  # pyright: ignore[reportUnknownVariableType]
@@ -303,6 +391,18 @@ class LLMInvocation:
     _inference_invocation: InferenceInvocation | None = field(
         default=None, init=False, repr=False
     )
+
+    @property
+    def cache_creation_input_tokens(self) -> int | None:
+        """
+        .. deprecated:: 1.3b0
+            Use :attr:`cache_write_input_tokens` instead.
+        """
+        return self.cache_write_input_tokens
+
+    @cache_creation_input_tokens.setter
+    def cache_creation_input_tokens(self, value: int | None) -> None:
+        self.cache_write_input_tokens = value
 
     def _start_with_handler(
         self,
@@ -333,6 +433,17 @@ class LLMInvocation:
         inv.finish_reasons = self.finish_reasons
         inv.input_tokens = self.input_tokens
         inv.output_tokens = self.output_tokens
+        inv.cache_write_input_tokens = self.cache_write_input_tokens
+        inv.cache_read_input_tokens = self.cache_read_input_tokens
+        inv.text_input_tokens = self.text_input_tokens
+        inv.image_input_tokens = self.image_input_tokens
+        inv.audio_input_tokens = self.audio_input_tokens
+        inv.text_output_tokens = self.text_output_tokens
+        inv.image_output_tokens = self.image_output_tokens
+        inv.audio_output_tokens = self.audio_output_tokens
+        inv.text_cache_read_input_tokens = self.text_cache_read_input_tokens
+        inv.image_cache_read_input_tokens = self.image_cache_read_input_tokens
+        inv.audio_cache_read_input_tokens = self.audio_cache_read_input_tokens
         inv.temperature = self.temperature
         inv.top_p = self.top_p
         inv.frequency_penalty = self.frequency_penalty
@@ -358,6 +469,17 @@ class LLMInvocation:
         inv.finish_reasons = self.finish_reasons
         inv.input_tokens = self.input_tokens
         inv.output_tokens = self.output_tokens
+        inv.cache_write_input_tokens = self.cache_write_input_tokens
+        inv.cache_read_input_tokens = self.cache_read_input_tokens
+        inv.text_input_tokens = self.text_input_tokens
+        inv.image_input_tokens = self.image_input_tokens
+        inv.audio_input_tokens = self.audio_input_tokens
+        inv.text_output_tokens = self.text_output_tokens
+        inv.image_output_tokens = self.image_output_tokens
+        inv.audio_output_tokens = self.audio_output_tokens
+        inv.text_cache_read_input_tokens = self.text_cache_read_input_tokens
+        inv.image_cache_read_input_tokens = self.image_cache_read_input_tokens
+        inv.audio_cache_read_input_tokens = self.audio_cache_read_input_tokens
         inv.temperature = self.temperature
         inv.top_p = self.top_p
         inv.frequency_penalty = self.frequency_penalty

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_inference_invocation.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_inference_invocation.py
@@ -363,17 +363,6 @@ class LLMInvocation:
     finish_reasons: list[str] | None = None
     input_tokens: int | None = None
     output_tokens: int | None = None
-    cache_write_input_tokens: int | None = None
-    cache_read_input_tokens: int | None = None
-    text_input_tokens: int | None = None
-    image_input_tokens: int | None = None
-    audio_input_tokens: int | None = None
-    text_output_tokens: int | None = None
-    image_output_tokens: int | None = None
-    audio_output_tokens: int | None = None
-    text_cache_read_input_tokens: int | None = None
-    image_cache_read_input_tokens: int | None = None
-    audio_cache_read_input_tokens: int | None = None
     attributes: dict[str, AttributeValue] = field(default_factory=dict)  # pyright: ignore[reportUnknownVariableType]
     """Additional attributes to set on spans and/or events. Not set on metrics."""
     metric_attributes: dict[str, AttributeValue] = field(default_factory=dict)  # pyright: ignore[reportUnknownVariableType]
@@ -391,18 +380,6 @@ class LLMInvocation:
     _inference_invocation: InferenceInvocation | None = field(
         default=None, init=False, repr=False
     )
-
-    @property
-    def cache_creation_input_tokens(self) -> int | None:
-        """
-        .. deprecated:: 1.3b0
-            Use :attr:`cache_write_input_tokens` instead.
-        """
-        return self.cache_write_input_tokens
-
-    @cache_creation_input_tokens.setter
-    def cache_creation_input_tokens(self, value: int | None) -> None:
-        self.cache_write_input_tokens = value
 
     def _start_with_handler(
         self,
@@ -433,17 +410,6 @@ class LLMInvocation:
         inv.finish_reasons = self.finish_reasons
         inv.input_tokens = self.input_tokens
         inv.output_tokens = self.output_tokens
-        inv.cache_write_input_tokens = self.cache_write_input_tokens
-        inv.cache_read_input_tokens = self.cache_read_input_tokens
-        inv.text_input_tokens = self.text_input_tokens
-        inv.image_input_tokens = self.image_input_tokens
-        inv.audio_input_tokens = self.audio_input_tokens
-        inv.text_output_tokens = self.text_output_tokens
-        inv.image_output_tokens = self.image_output_tokens
-        inv.audio_output_tokens = self.audio_output_tokens
-        inv.text_cache_read_input_tokens = self.text_cache_read_input_tokens
-        inv.image_cache_read_input_tokens = self.image_cache_read_input_tokens
-        inv.audio_cache_read_input_tokens = self.audio_cache_read_input_tokens
         inv.temperature = self.temperature
         inv.top_p = self.top_p
         inv.frequency_penalty = self.frequency_penalty
@@ -469,17 +435,6 @@ class LLMInvocation:
         inv.finish_reasons = self.finish_reasons
         inv.input_tokens = self.input_tokens
         inv.output_tokens = self.output_tokens
-        inv.cache_write_input_tokens = self.cache_write_input_tokens
-        inv.cache_read_input_tokens = self.cache_read_input_tokens
-        inv.text_input_tokens = self.text_input_tokens
-        inv.image_input_tokens = self.image_input_tokens
-        inv.audio_input_tokens = self.audio_input_tokens
-        inv.text_output_tokens = self.text_output_tokens
-        inv.image_output_tokens = self.image_output_tokens
-        inv.audio_output_tokens = self.audio_output_tokens
-        inv.text_cache_read_input_tokens = self.text_cache_read_input_tokens
-        inv.image_cache_read_input_tokens = self.image_cache_read_input_tokens
-        inv.audio_cache_read_input_tokens = self.audio_cache_read_input_tokens
         inv.temperature = self.temperature
         inv.top_p = self.top_p
         inv.frequency_penalty = self.frequency_penalty

--- a/util/opentelemetry-util-genai/tests/test_handler_agent.py
+++ b/util/opentelemetry-util-genai/tests/test_handler_agent.py
@@ -162,7 +162,7 @@ class TestLocalAgentInvocation(unittest.TestCase):  # pylint: disable=too-many-p
 
         attrs = self.span_exporter.get_finished_spans()[0].attributes
         assert attrs[GenAI.GEN_AI_USAGE_INPUT_TOKENS] == 100
-        assert attrs[GenAI.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS] == 25
+        assert attrs["gen_ai.usage.cache_write.input_tokens"] == 25
         assert attrs[GenAI.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS] == 50
 
     def test_fail_sets_error_status(self):

--- a/util/opentelemetry-util-genai/tests/test_handler_agent.py
+++ b/util/opentelemetry-util-genai/tests/test_handler_agent.py
@@ -162,8 +162,9 @@ class TestLocalAgentInvocation(unittest.TestCase):  # pylint: disable=too-many-p
 
         attrs = self.span_exporter.get_finished_spans()[0].attributes
         assert attrs[GenAI.GEN_AI_USAGE_INPUT_TOKENS] == 100
-        assert attrs["gen_ai.usage.cache_write.input_tokens"] == 25
-        assert attrs[GenAI.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS] == 50
+        assert "gen_ai.usage.cache_write.input_tokens" not in attrs
+        assert "gen_ai.usage.cache_creation.input_tokens" not in attrs
+        assert GenAI.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS not in attrs
 
     def test_fail_sets_error_status(self):
         invocation = self.handler.invoke_local_agent()

--- a/util/opentelemetry-util-genai/tests/test_utils.py
+++ b/util/opentelemetry-util-genai/tests/test_utils.py
@@ -1134,6 +1134,41 @@ class TestTelemetryHandler(unittest.TestCase):
         assert attrs["gen_ai.usage.image.cache_read.input_tokens"] == 6
         assert attrs["gen_ai.usage.audio.cache_read.input_tokens"] == 7
 
+    def test_inference_modality_and_cache_tokens_omitted_when_zero(self):
+        invocation = self.telemetry_handler.inference(
+            "test-provider", request_model="test-model"
+        )
+        invocation.cache_write_input_tokens = 0
+        invocation.cache_read_input_tokens = 0
+        invocation.thinking_tokens = 0
+        invocation.text_input_tokens = 0
+        invocation.image_input_tokens = 0
+        invocation.audio_input_tokens = 0
+        invocation.text_output_tokens = 0
+        invocation.image_output_tokens = 0
+        invocation.audio_output_tokens = 0
+        invocation.text_cache_read_input_tokens = 0
+        invocation.image_cache_read_input_tokens = 0
+        invocation.audio_cache_read_input_tokens = 0
+        invocation.stop()
+
+        attrs = self.span_exporter.get_finished_spans()[0].attributes
+        for key in (
+            "gen_ai.usage.cache_write.input_tokens",
+            "gen_ai.usage.cache_read.input_tokens",
+            "gen_ai.usage.reasoning.output_tokens",
+            "gen_ai.usage.text.input_tokens",
+            "gen_ai.usage.image.input_tokens",
+            "gen_ai.usage.audio.input_tokens",
+            "gen_ai.usage.text.output_tokens",
+            "gen_ai.usage.image.output_tokens",
+            "gen_ai.usage.audio.output_tokens",
+            "gen_ai.usage.text.cache_read.input_tokens",
+            "gen_ai.usage.image.cache_read.input_tokens",
+            "gen_ai.usage.audio.cache_read.input_tokens",
+        ):
+            assert key not in attrs
+
 
 class AnyNonNone:
     def __eq__(self, other):

--- a/util/opentelemetry-util-genai/tests/test_utils.py
+++ b/util/opentelemetry-util-genai/tests/test_utils.py
@@ -1084,6 +1084,56 @@ class TestTelemetryHandler(unittest.TestCase):
                     self.assertNotEqual(key, server_attributes.SERVER_ADDRESS)
                     self.assertNotEqual(key, server_attributes.SERVER_PORT)
 
+    def test_inference_cache_write_input_tokens(self):
+        invocation = self.telemetry_handler.inference(
+            "test-provider", request_model="test-model"
+        )
+        invocation.cache_write_input_tokens = 42
+        invocation.stop()
+
+        attrs = self.span_exporter.get_finished_spans()[0].attributes
+        assert attrs["gen_ai.usage.cache_write.input_tokens"] == 42
+
+    def test_inference_cache_creation_input_tokens_backward_compatibility(
+        self,
+    ):
+        invocation = self.telemetry_handler.inference(
+            "test-provider", request_model="test-model"
+        )
+        invocation.cache_creation_input_tokens = 42
+        assert invocation.cache_write_input_tokens == 42
+        assert invocation.cache_creation_input_tokens == 42
+        invocation.stop()
+
+        attrs = self.span_exporter.get_finished_spans()[0].attributes
+        assert attrs["gen_ai.usage.cache_write.input_tokens"] == 42
+
+    def test_inference_modality_tokens(self):
+        invocation = self.telemetry_handler.inference(
+            "test-provider", request_model="test-model"
+        )
+        invocation.text_input_tokens = 10
+        invocation.image_input_tokens = 20
+        invocation.audio_input_tokens = 30
+        invocation.text_output_tokens = 40
+        invocation.image_output_tokens = 50
+        invocation.audio_output_tokens = 60
+        invocation.text_cache_read_input_tokens = 5
+        invocation.image_cache_read_input_tokens = 6
+        invocation.audio_cache_read_input_tokens = 7
+        invocation.stop()
+
+        attrs = self.span_exporter.get_finished_spans()[0].attributes
+        assert attrs["gen_ai.usage.text.input_tokens"] == 10
+        assert attrs["gen_ai.usage.image.input_tokens"] == 20
+        assert attrs["gen_ai.usage.audio.input_tokens"] == 30
+        assert attrs["gen_ai.usage.text.output_tokens"] == 40
+        assert attrs["gen_ai.usage.image.output_tokens"] == 50
+        assert attrs["gen_ai.usage.audio.output_tokens"] == 60
+        assert attrs["gen_ai.usage.text.cache_read.input_tokens"] == 5
+        assert attrs["gen_ai.usage.image.cache_read.input_tokens"] == 6
+        assert attrs["gen_ai.usage.audio.cache_read.input_tokens"] == 7
+
 
 class AnyNonNone:
     def __eq__(self, other):


### PR DESCRIPTION
## What does this change do?

Adds `cache_write_input_tokens` (deprecating `cache_creation_input_tokens`) and modality token breakdown attributes to invocations in `opentelemetry-util-genai`, updating `openai`, `google-genai`, `bedrock`, and `langchain` to record them where available.

**Deprecated attribute:**
- `gen_ai.usage.cache_creation.input_tokens` (replaced by `gen_ai.usage.cache_write.input_tokens`)

**New attributes:**
- `gen_ai.usage.cache_write.input_tokens`
- `gen_ai.usage.text.input_tokens`
- `gen_ai.usage.image.input_tokens`
- `gen_ai.usage.audio.input_tokens`
- `gen_ai.usage.text.output_tokens`
- `gen_ai.usage.image.output_tokens`
- `gen_ai.usage.audio.output_tokens`
- `gen_ai.usage.text.cache_read.input_tokens`
- `gen_ai.usage.image.cache_read.input_tokens`
- `gen_ai.usage.audio.cache_read.input_tokens`

## Why?

Aligns token usage attributes with GenAI semantic conventions ([spans spec](https://github.com/open-telemetry/semantic-conventions-genai/blob/main/docs/gen-ai/gen-ai-spans.md)).