### PR TITLE
Add reasoning, continuation, compaction, prompt attributes, and retrieval top_k

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/test_retrieve.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-dspy/tests/test_retrieve.py
@@ -26,6 +26,8 @@ from opentelemetry.semconv.attributes import error_attributes
 from opentelemetry.test_util_genai.instrumentor import instrument
 from opentelemetry.trace import StatusCode
 
+_GEN_AI_RETRIEVAL_TOP_K = "gen_ai.retrieval.top_k"
+
 
 class _DummyPassage:
     def __init__(self, text: str) -> None:
@@ -75,8 +77,8 @@ def test_sync_retrieve_execution(
     assert span.status.status_code == StatusCode.UNSET
     attrs = span.attributes or {}
     assert attrs.get(GenAI.GEN_AI_OPERATION_NAME) == "retrieval"
-    assert attrs.get(GenAI.GEN_AI_REQUEST_TOP_K) == 3
-    assert isinstance(attrs.get(GenAI.GEN_AI_REQUEST_TOP_K), int)
+    assert attrs.get(_GEN_AI_RETRIEVAL_TOP_K) == 3
+    assert isinstance(attrs.get(_GEN_AI_RETRIEVAL_TOP_K), int)
     assert (
         attrs.get(GenAI.GEN_AI_RETRIEVAL_QUERY_TEXT)
         == "What is OpenTelemetry?"
@@ -114,8 +116,8 @@ def test_retrieve_forward_direct_call(
     spans = span_exporter.get_finished_spans()
     assert len(spans) == 1
     attrs = spans[0].attributes or {}
-    assert attrs.get(GenAI.GEN_AI_REQUEST_TOP_K) == 2
-    assert isinstance(attrs.get(GenAI.GEN_AI_REQUEST_TOP_K), int)
+    assert attrs.get(_GEN_AI_RETRIEVAL_TOP_K) == 2
+    assert isinstance(attrs.get(_GEN_AI_RETRIEVAL_TOP_K), int)
     assert attrs.get(GenAI.GEN_AI_RETRIEVAL_QUERY_TEXT) == "Direct call"
 
 
@@ -142,8 +144,8 @@ def test_retrieve_with_positional_k(
     spans = span_exporter.get_finished_spans()
     assert len(spans) == 1
     attrs = spans[0].attributes or {}
-    assert attrs.get(GenAI.GEN_AI_REQUEST_TOP_K) == 4
-    assert isinstance(attrs.get(GenAI.GEN_AI_REQUEST_TOP_K), int)
+    assert attrs.get(_GEN_AI_RETRIEVAL_TOP_K) == 4
+    assert isinstance(attrs.get(_GEN_AI_RETRIEVAL_TOP_K), int)
     assert attrs.get(GenAI.GEN_AI_RETRIEVAL_QUERY_TEXT) == "Positional k query"
 
 
@@ -171,8 +173,8 @@ def test_retrieve_without_content_capture(
     span = spans[0]
     attrs = span.attributes or {}
     assert attrs.get(GenAI.GEN_AI_OPERATION_NAME) == "retrieval"
-    assert attrs.get(GenAI.GEN_AI_REQUEST_TOP_K) == 2
-    assert isinstance(attrs.get(GenAI.GEN_AI_REQUEST_TOP_K), int)
+    assert attrs.get(_GEN_AI_RETRIEVAL_TOP_K) == 2
+    assert isinstance(attrs.get(_GEN_AI_RETRIEVAL_TOP_K), int)
     assert GenAI.GEN_AI_RETRIEVAL_QUERY_TEXT not in attrs
     assert GenAI.GEN_AI_RETRIEVAL_DOCUMENTS not in attrs
 

--- a/util/opentelemetry-util-genai/.changelog/614.added
+++ b/util/opentelemetry-util-genai/.changelog/614.added
@@ -1,0 +1,1 @@
+Add `reasoning_level`, `previous_response_id`, `conversation_compacted`, and `prompt.*` attributes to inference invocations.

--- a/util/opentelemetry-util-genai/.changelog/614.changed
+++ b/util/opentelemetry-util-genai/.changelog/614.changed
@@ -1,0 +1,1 @@
+Record `top_k` on retrieval spans as integer `gen_ai.retrieval.top_k`.

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_inference_invocation.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_inference_invocation.py
@@ -30,9 +30,6 @@ from opentelemetry.util.genai.types import (
 )
 from opentelemetry.util.genai.utils import (
     ContentCapturingMode,
-    gen_ai_json_dumps,
-    should_capture_content_on_events,
-    should_capture_content_on_spans,
     should_emit_event,
 )
 from opentelemetry.util.types import AttributeValue
@@ -61,7 +58,6 @@ _GEN_AI_REQUEST_PREVIOUS_RESPONSE_ID: Final = (
 )
 _GEN_AI_CONVERSATION_COMPACTED: Final = "gen_ai.conversation.compacted"
 _GEN_AI_PROMPT_VERSION: Final = "gen_ai.prompt.version"
-_GEN_AI_PROMPT_VARIABLE_PREFIX: Final = "gen_ai.prompt.variable."
 
 
 class InferenceInvocation(GenAIInvocation):
@@ -183,6 +179,7 @@ class InferenceInvocation(GenAIInvocation):
             output_messages=self.output_messages,
             system_instruction=self.system_instruction,
             tool_definitions=self.tool_definitions,
+            prompt_variables=self.prompt_variables,
             for_span=for_span,
             content_capturing_mode=self._content_capturing_mode,
         )
@@ -307,24 +304,6 @@ class InferenceInvocation(GenAIInvocation):
         attrs.update({k: v for k, v in optional_attrs if v is not None})
         return attrs
 
-    def _get_prompt_variable_attributes(
-        self, *, for_span: bool
-    ) -> dict[str, str]:
-        if not self.prompt_variables:
-            return {}
-        if not (
-            should_capture_content_on_spans()
-            if for_span
-            else should_capture_content_on_events()
-        ):
-            return {}
-        return {
-            f"{_GEN_AI_PROMPT_VARIABLE_PREFIX}{k}": (
-                v if isinstance(v, str) else gen_ai_json_dumps(v)
-            )
-            for k, v in self.prompt_variables.items()
-        }
-
     def _invalidate_metric_attributes(self) -> None:
         """Drop the cached metric attributes so the next read rebuilds them.
 
@@ -364,7 +343,6 @@ class InferenceInvocation(GenAIInvocation):
             self._apply_error_attributes(error)
         attributes = self._get_attributes()
         attributes.update(self._get_message_attributes(for_span=True))
-        attributes.update(self._get_prompt_variable_attributes(for_span=True))
         attributes.update(self.attributes)
         self.span.set_attributes(attributes)
         self._metrics_recorder.record(self)
@@ -391,7 +369,6 @@ class InferenceInvocation(GenAIInvocation):
         attributes = self._get_start_attributes()
         attributes.update(self._get_attributes())
         attributes.update(self._get_message_attributes(for_span=False))
-        attributes.update(self._get_prompt_variable_attributes(for_span=False))
         attributes.update(self.attributes)
         return LogRecord(
             event_name="gen_ai.client.inference.operation.details",

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_inference_invocation.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_inference_invocation.py
@@ -3,8 +3,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass, field
-from typing import Final
+from typing import Any, Final
 
 from opentelemetry._logs import Logger, LogRecord
 from opentelemetry.semconv._incubating.attributes import (
@@ -51,6 +52,13 @@ _GEN_AI_USAGE_IMAGE_CACHE_READ_INPUT_TOKENS: Final = (
 _GEN_AI_USAGE_AUDIO_CACHE_READ_INPUT_TOKENS: Final = (
     "gen_ai.usage.audio.cache_read.input_tokens"
 )
+_GEN_AI_REQUEST_REASONING_LEVEL: Final = "gen_ai.request.reasoning.level"
+_GEN_AI_REQUEST_PREVIOUS_RESPONSE_ID: Final = (
+    "gen_ai.request.previous_response.id"
+)
+_GEN_AI_CONVERSATION_COMPACTED: Final = "gen_ai.conversation.compacted"
+_GEN_AI_PROMPT_VERSION: Final = "gen_ai.prompt.version"
+_GEN_AI_PROMPT_VARIABLE_PREFIX: Final = "gen_ai.prompt.variable."
 
 
 class InferenceInvocation(GenAIInvocation):
@@ -127,6 +135,12 @@ class InferenceInvocation(GenAIInvocation):
         self.text_cache_read_input_tokens: int | None = None
         self.image_cache_read_input_tokens: int | None = None
         self.audio_cache_read_input_tokens: int | None = None
+        self.reasoning_level: str | None = None
+        self.previous_response_id: str | None = None
+        self.conversation_compacted: bool | None = None
+        self.prompt_name: str | None = None
+        self.prompt_version: str | None = None
+        self.prompt_variables: Mapping[str, Any] | None = None
         self.tool_definitions: list[ToolDefinition] | None = None
         self.top_k: float | None = None
         self.request_choice_count: int | None = None
@@ -263,11 +277,34 @@ class InferenceInvocation(GenAIInvocation):
                 self.audio_cache_read_input_tokens or None,
             ),
             (
+                _GEN_AI_REQUEST_REASONING_LEVEL,
+                self.reasoning_level,
+            ),
+            (
+                _GEN_AI_REQUEST_PREVIOUS_RESPONSE_ID,
+                self.previous_response_id,
+            ),
+            (
+                _GEN_AI_CONVERSATION_COMPACTED,
+                True if self.conversation_compacted else None,
+            ),
+            (
+                GenAI.GEN_AI_PROMPT_NAME,
+                self.prompt_name,
+            ),
+            (
+                _GEN_AI_PROMPT_VERSION,
+                self.prompt_version,
+            ),
+            (
                 GenAI.GEN_AI_RESPONSE_TIME_TO_FIRST_CHUNK,
                 self._ttfc_seconds,
             ),
         )
         attrs.update({k: v for k, v in optional_attrs if v is not None})
+        if self.prompt_variables:
+            for k, v in self.prompt_variables.items():
+                attrs[f"{_GEN_AI_PROMPT_VARIABLE_PREFIX}{k}"] = str(v)
         return attrs
 
     def _invalidate_metric_attributes(self) -> None:
@@ -363,6 +400,7 @@ class LLMInvocation:
     finish_reasons: list[str] | None = None
     input_tokens: int | None = None
     output_tokens: int | None = None
+
     attributes: dict[str, AttributeValue] = field(default_factory=dict)  # pyright: ignore[reportUnknownVariableType]
     """Additional attributes to set on spans and/or events. Not set on metrics."""
     metric_attributes: dict[str, AttributeValue] = field(default_factory=dict)  # pyright: ignore[reportUnknownVariableType]
@@ -410,6 +448,7 @@ class LLMInvocation:
         inv.finish_reasons = self.finish_reasons
         inv.input_tokens = self.input_tokens
         inv.output_tokens = self.output_tokens
+
         inv.temperature = self.temperature
         inv.top_p = self.top_p
         inv.frequency_penalty = self.frequency_penalty
@@ -435,6 +474,7 @@ class LLMInvocation:
         inv.finish_reasons = self.finish_reasons
         inv.input_tokens = self.input_tokens
         inv.output_tokens = self.output_tokens
+
         inv.temperature = self.temperature
         inv.top_p = self.top_p
         inv.frequency_penalty = self.frequency_penalty

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_inference_invocation.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_inference_invocation.py
@@ -30,6 +30,7 @@ from opentelemetry.util.genai.types import (
 )
 from opentelemetry.util.genai.utils import (
     ContentCapturingMode,
+    gen_ai_json_dumps,
     should_capture_content_on_events,
     should_capture_content_on_spans,
     should_emit_event,
@@ -308,18 +309,19 @@ class InferenceInvocation(GenAIInvocation):
 
     def _get_prompt_variable_attributes(
         self, *, for_span: bool
-    ) -> dict[str, AttributeValue]:
+    ) -> dict[str, str]:
         if not self.prompt_variables:
             return {}
-        should_capture = (
+        if not (
             should_capture_content_on_spans()
             if for_span
             else should_capture_content_on_events()
-        )
-        if not should_capture:
+        ):
             return {}
         return {
-            f"{_GEN_AI_PROMPT_VARIABLE_PREFIX}{k}": str(v)
+            f"{_GEN_AI_PROMPT_VARIABLE_PREFIX}{k}": (
+                v if isinstance(v, str) else gen_ai_json_dumps(v)
+            )
             for k, v in self.prompt_variables.items()
         }
 

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_inference_invocation.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_inference_invocation.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import dataclass, field
-from typing import Any, Final
+from typing import Final
 
 from opentelemetry._logs import Logger, LogRecord
 from opentelemetry.semconv._incubating.attributes import (
@@ -30,6 +30,8 @@ from opentelemetry.util.genai.types import (
 )
 from opentelemetry.util.genai.utils import (
     ContentCapturingMode,
+    should_capture_content_on_events,
+    should_capture_content_on_spans,
     should_emit_event,
 )
 from opentelemetry.util.types import AttributeValue
@@ -140,7 +142,7 @@ class InferenceInvocation(GenAIInvocation):
         self.conversation_compacted: bool | None = None
         self.prompt_name: str | None = None
         self.prompt_version: str | None = None
-        self.prompt_variables: Mapping[str, Any] | None = None
+        self.prompt_variables: Mapping[str, object] | None = None
         self.tool_definitions: list[ToolDefinition] | None = None
         self.top_k: float | None = None
         self.request_choice_count: int | None = None
@@ -302,10 +304,24 @@ class InferenceInvocation(GenAIInvocation):
             ),
         )
         attrs.update({k: v for k, v in optional_attrs if v is not None})
-        if self.prompt_variables:
-            for k, v in self.prompt_variables.items():
-                attrs[f"{_GEN_AI_PROMPT_VARIABLE_PREFIX}{k}"] = str(v)
         return attrs
+
+    def _get_prompt_variable_attributes(
+        self, *, for_span: bool
+    ) -> dict[str, AttributeValue]:
+        if not self.prompt_variables:
+            return {}
+        should_capture = (
+            should_capture_content_on_spans()
+            if for_span
+            else should_capture_content_on_events()
+        )
+        if not should_capture:
+            return {}
+        return {
+            f"{_GEN_AI_PROMPT_VARIABLE_PREFIX}{k}": str(v)
+            for k, v in self.prompt_variables.items()
+        }
 
     def _invalidate_metric_attributes(self) -> None:
         """Drop the cached metric attributes so the next read rebuilds them.
@@ -346,6 +362,7 @@ class InferenceInvocation(GenAIInvocation):
             self._apply_error_attributes(error)
         attributes = self._get_attributes()
         attributes.update(self._get_message_attributes(for_span=True))
+        attributes.update(self._get_prompt_variable_attributes(for_span=True))
         attributes.update(self.attributes)
         self.span.set_attributes(attributes)
         self._metrics_recorder.record(self)
@@ -372,6 +389,7 @@ class InferenceInvocation(GenAIInvocation):
         attributes = self._get_start_attributes()
         attributes.update(self._get_attributes())
         attributes.update(self._get_message_attributes(for_span=False))
+        attributes.update(self._get_prompt_variable_attributes(for_span=False))
         attributes.update(self.attributes)
         return LogRecord(
             event_name="gen_ai.client.inference.operation.details",

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_invocation.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_invocation.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import timeit
 from abc import abstractmethod
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from contextlib import AbstractContextManager
 from contextvars import Token
 from dataclasses import asdict
@@ -42,6 +42,8 @@ from opentelemetry.util.genai.utils import (
     get_content_capturing_mode,
 )
 from opentelemetry.util.types import AttributeValue
+
+_GEN_AI_PROMPT_VARIABLE_PREFIX: str = "gen_ai.prompt.variable."
 
 if TYPE_CHECKING:
     from opentelemetry.util.genai.metrics import InvocationMetricsRecorder
@@ -272,6 +274,7 @@ def get_content_attributes(
     output_messages: Sequence[OutputMessage],
     system_instruction: Sequence[SystemInstructionPart | MessagePart],
     tool_definitions: Sequence[ToolDefinition] | None,
+    prompt_variables: Mapping[str, object] | None = None,
     for_span: bool,
     content_capturing_mode: ContentCapturingMode | None = None,
 ) -> dict[str, Any]:
@@ -283,6 +286,7 @@ def get_content_attributes(
         system_instruction: System instructions to serialize. Passing ``MessagePart``
             is deprecated; use ``SystemInstructionPart``.
         tool_definitions: Tool definitions to serialize (may be None).
+        prompt_variables: Prompt template variables to serialize (may be None).
         for_span: If True, serialize for span attributes (JSON string);
                   if False, serialize for event attributes (list of dicts).
         content_capturing_mode: Configured content capturing mode; if None,
@@ -336,4 +340,10 @@ def get_content_attributes(
             serialize(tool_definitions) if tool_definitions else None,
         ),
     )
-    return {key: value for key, value in optional_attrs if value is not None}
+    result = {key: value for key, value in optional_attrs if value is not None}
+    if prompt_variables:
+        for k, v in prompt_variables.items():
+            result[f"{_GEN_AI_PROMPT_VARIABLE_PREFIX}{k}"] = (
+                v if isinstance(v, str) else gen_ai_json_dumps(v)
+            )
+    return result

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_retrieval_invocation.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_retrieval_invocation.py
@@ -38,7 +38,7 @@ class RetrievalInvocation(GenAIInvocation):
     - gen_ai.provider.name: Provider name (Conditionally Required, when applicable)
     - gen_ai.request.model: Model name if applicable (Conditionally Required, if available)
     - server.port: Server port (Conditionally Required, if server.address is set)
-    - gen_ai.retrieval.top_k: Top-k sampling setting (Recommended)
+    - gen_ai.retrieval.top_k: Maximum number of documents to return (Recommended)
     - server.address: Server address (Recommended)
     - gen_ai.retrieval.documents: Retrieved documents (Opt-In, may contain sensitive data)
     - gen_ai.retrieval.query.text: Query text (Opt-In, may contain sensitive data)

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_retrieval_invocation.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_retrieval_invocation.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
-from typing import Any
+from typing import Any, Final
 
 from opentelemetry._logs import Logger
 from opentelemetry.semconv._incubating.attributes import (
@@ -21,6 +21,8 @@ from opentelemetry.util.genai.utils import (
 )
 from opentelemetry.util.types import AttributeValue
 
+_GEN_AI_RETRIEVAL_TOP_K: Final = "gen_ai.retrieval.top_k"
+
 
 class RetrievalInvocation(GenAIInvocation):
     """Represents a single retrieval invocation (retrieval span).
@@ -36,7 +38,7 @@ class RetrievalInvocation(GenAIInvocation):
     - gen_ai.provider.name: Provider name (Conditionally Required, when applicable)
     - gen_ai.request.model: Model name if applicable (Conditionally Required, if available)
     - server.port: Server port (Conditionally Required, if server.address is set)
-    - gen_ai.request.top_k: Top-k sampling setting (Recommended)
+    - gen_ai.retrieval.top_k: Top-k sampling setting (Recommended)
     - server.address: Server address (Recommended)
     - gen_ai.retrieval.documents: Retrieved documents (Opt-In, may contain sensitive data)
     - gen_ai.retrieval.query.text: Query text (Opt-In, may contain sensitive data)
@@ -75,7 +77,7 @@ class RetrievalInvocation(GenAIInvocation):
         self._request_model: str | None = request_model
         self._server_address: str | None = server_address
         self._server_port: int | None = server_port
-        self.top_k: float | None = None
+        self.top_k: int | None = None
         self.query_text: str | None = None
         self.documents: Sequence[Mapping[str, Any]] | None = None
         self._start(self._get_start_attributes())
@@ -131,7 +133,7 @@ class RetrievalInvocation(GenAIInvocation):
             self._apply_error_attributes(error)
         attributes: dict[str, AttributeValue] = {}
         if self.top_k is not None:
-            attributes[GenAI.GEN_AI_REQUEST_TOP_K] = self.top_k
+            attributes[_GEN_AI_RETRIEVAL_TOP_K] = int(self.top_k)
         attributes.update(self._get_content_attributes_for_span())
         attributes.update(self.attributes)
         self.span.set_attributes(attributes)

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/utils.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/utils.py
@@ -143,6 +143,14 @@ def should_capture_content_on_spans() -> bool:
     )
 
 
+def should_capture_content_on_events() -> bool:
+    """Returns whether capture content is enabled on events."""
+    return get_content_capturing_mode() in (
+        ContentCapturingMode.EVENT_ONLY,
+        ContentCapturingMode.SPAN_AND_EVENT,
+    )
+
+
 def fq_exception_type(exception: BaseException) -> str:
     """Return the fully qualified name of an exception's type.
 

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/utils.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/utils.py
@@ -143,14 +143,6 @@ def should_capture_content_on_spans() -> bool:
     )
 
 
-def should_capture_content_on_events() -> bool:
-    """Returns whether capture content is enabled on events."""
-    return get_content_capturing_mode() in (
-        ContentCapturingMode.EVENT_ONLY,
-        ContentCapturingMode.SPAN_AND_EVENT,
-    )
-
-
 def fq_exception_type(exception: BaseException) -> str:
     """Return the fully qualified name of an exception's type.
 

--- a/util/opentelemetry-util-genai/tests/test_handler_retrieval.py
+++ b/util/opentelemetry-util-genai/tests/test_handler_retrieval.py
@@ -143,13 +143,13 @@ class TelemetryHandlerRetrievalTest(_RetrievalTestBase):  # pylint: disable=too-
 
     def test_stop_sets_top_k(self) -> None:
         invocation = self.handler.retrieval()
-        invocation.top_k = 10.0
+        invocation.top_k = 10
         invocation.stop()
 
         spans = self._get_finished_spans()
-        value = spans[0].attributes[GenAI.GEN_AI_REQUEST_TOP_K]
-        self.assertIsInstance(value, float)
-        self.assertEqual(value, 10.0)
+        value = spans[0].attributes["gen_ai.retrieval.top_k"]
+        self.assertIsInstance(value, int)
+        self.assertEqual(value, 10)
 
     @patch.dict(
         os.environ,
@@ -330,13 +330,13 @@ class TelemetryHandlerRetrievalContextManagerTest(_RetrievalTestBase):
 
     def test_context_manager_sets_attributes_on_span(self) -> None:
         with self.handler.retrieval(provider="weaviate") as inv:
-            inv.top_k = 5.0
+            inv.top_k = 5
 
         spans = self._get_finished_spans()
         attrs = spans[0].attributes
         self.assertEqual(attrs[GenAI.GEN_AI_PROVIDER_NAME], "weaviate")
-        self.assertIsInstance(attrs[GenAI.GEN_AI_REQUEST_TOP_K], float)
-        self.assertEqual(attrs[GenAI.GEN_AI_REQUEST_TOP_K], 5.0)
+        self.assertIsInstance(attrs["gen_ai.retrieval.top_k"], int)
+        self.assertEqual(attrs["gen_ai.retrieval.top_k"], 5)
 
 
 class TelemetryHandlerRetrievalSamplingTest(_RetrievalTestBase):

--- a/util/opentelemetry-util-genai/tests/test_utils.py
+++ b/util/opentelemetry-util-genai/tests/test_utils.py
@@ -60,6 +60,7 @@ from opentelemetry.util.genai.utils import (
     gen_ai_json_dumps,
     get_content_capturing_mode,
     image_from_url,
+    should_capture_content_on_events,
     should_capture_content_on_spans,
     should_emit_event,
 )
@@ -259,6 +260,25 @@ class TestShouldCaptureContent(unittest.TestCase):
             ):
                 assert (
                     should_capture_content_on_spans() is span_content_enabled
+                )
+
+    def test_should_capture_content_on_events_against_various_env_var_combinations(
+        self,
+    ):  # pylint: disable=no-self-use
+        for content_capture, event_content_enabled in [
+            ("NO_CONTENT", False),
+            ("EVENT_ONLY", True),
+            ("SPAN_ONLY", False),
+            ("SPAN_AND_EVENT", True),
+        ]:
+            with patch.dict(
+                os.environ,
+                {
+                    "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT": content_capture,
+                },
+            ):
+                assert (
+                    should_capture_content_on_events() is event_content_enabled
                 )
 
     def test_get_content_capturing_mode(self):  # pylint: disable=no-self-use
@@ -1195,8 +1215,37 @@ class TestTelemetryHandler(unittest.TestCase):
         attrs = self.span_exporter.get_finished_spans()[0].attributes
         assert attrs[GenAI.GEN_AI_PROMPT_NAME] == "chat_prompt"
         assert attrs["gen_ai.prompt.version"] == "1.0.0"
-        assert attrs["gen_ai.prompt.variable.user"] == "Alice"
-        assert attrs["gen_ai.prompt.variable.style"] == "formal"
+        # Prompt variables are gated by content capturing
+        assert "gen_ai.prompt.variable.user" not in attrs
+        assert "gen_ai.prompt.variable.style" not in attrs
+
+        with patch.dict(
+            os.environ,
+            {
+                "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT": "SPAN_AND_EVENT",
+            },
+        ):
+            invocation = self.telemetry_handler.inference(
+                "test-provider", request_model="test-model"
+            )
+            invocation.prompt_name = "chat_prompt"
+            invocation.prompt_version = "1.0.0"
+            invocation.prompt_variables = {"user": "Alice", "style": "formal"}
+            invocation.stop()
+
+            attrs = self.span_exporter.get_finished_spans()[-1].attributes
+            assert attrs[GenAI.GEN_AI_PROMPT_NAME] == "chat_prompt"
+            assert attrs["gen_ai.prompt.version"] == "1.0.0"
+            assert attrs["gen_ai.prompt.variable.user"] == "Alice"
+            assert attrs["gen_ai.prompt.variable.style"] == "formal"
+
+            event_attrs = self.log_exporter.get_finished_logs()[
+                -1
+            ].log_record.attributes
+            assert event_attrs[GenAI.GEN_AI_PROMPT_NAME] == "chat_prompt"
+            assert event_attrs["gen_ai.prompt.version"] == "1.0.0"
+            assert event_attrs["gen_ai.prompt.variable.user"] == "Alice"
+            assert event_attrs["gen_ai.prompt.variable.style"] == "formal"
 
 
 class AnyNonNone:

--- a/util/opentelemetry-util-genai/tests/test_utils.py
+++ b/util/opentelemetry-util-genai/tests/test_utils.py
@@ -60,7 +60,6 @@ from opentelemetry.util.genai.utils import (
     gen_ai_json_dumps,
     get_content_capturing_mode,
     image_from_url,
-    should_capture_content_on_events,
     should_capture_content_on_spans,
     should_emit_event,
 )
@@ -262,25 +261,6 @@ class TestShouldCaptureContent(unittest.TestCase):
                     should_capture_content_on_spans() is span_content_enabled
                 )
 
-    def test_should_capture_content_on_events_against_various_env_var_combinations(
-        self,
-    ):  # pylint: disable=no-self-use
-        for content_capture, event_content_enabled in [
-            ("NO_CONTENT", False),
-            ("EVENT_ONLY", True),
-            ("SPAN_ONLY", False),
-            ("SPAN_AND_EVENT", True),
-        ]:
-            with patch.dict(
-                os.environ,
-                {
-                    "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT": content_capture,
-                },
-            ):
-                assert (
-                    should_capture_content_on_events() is event_content_enabled
-                )
-
     def test_get_content_capturing_mode(self):  # pylint: disable=no-self-use
         for content_capture, expected_content_capturing in [
             ("NO_CONTENT", ContentCapturingMode.NO_CONTENT),
@@ -324,13 +304,13 @@ class TestTelemetryHandler(unittest.TestCase):
             SimpleSpanProcessor(self.span_exporter)
         )
         self.log_exporter = InMemoryLogRecordExporter()
-        logger_provider = LoggerProvider()
-        logger_provider.add_log_record_processor(
+        self.logger_provider = LoggerProvider()
+        self.logger_provider.add_log_record_processor(
             SimpleLogRecordProcessor(self.log_exporter)
         )
         self.telemetry_handler = get_telemetry_handler(
             tracer_provider=self.tracer_provider,
-            logger_provider=logger_provider,
+            logger_provider=self.logger_provider,
         )
 
     def tearDown(self):
@@ -1225,7 +1205,11 @@ class TestTelemetryHandler(unittest.TestCase):
                 "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT": "SPAN_AND_EVENT",
             },
         ):
-            invocation = self.telemetry_handler.inference(
+            handler = TelemetryHandler(
+                tracer_provider=self.tracer_provider,
+                logger_provider=self.logger_provider,
+            )
+            invocation = handler.inference(
                 "test-provider", request_model="test-model"
             )
             invocation.prompt_name = "chat_prompt"

--- a/util/opentelemetry-util-genai/tests/test_utils.py
+++ b/util/opentelemetry-util-genai/tests/test_utils.py
@@ -1169,6 +1169,35 @@ class TestTelemetryHandler(unittest.TestCase):
         ):
             assert key not in attrs
 
+    def test_inference_reasoning_and_continuation_and_compaction(self):
+        invocation = self.telemetry_handler.inference(
+            "test-provider", request_model="test-model"
+        )
+        invocation.reasoning_level = "high"
+        invocation.previous_response_id = "resp_123"
+        invocation.conversation_compacted = True
+        invocation.stop()
+
+        attrs = self.span_exporter.get_finished_spans()[0].attributes
+        assert attrs["gen_ai.request.reasoning.level"] == "high"
+        assert attrs["gen_ai.request.previous_response.id"] == "resp_123"
+        assert attrs["gen_ai.conversation.compacted"] is True
+
+    def test_inference_prompt_template_attributes(self):
+        invocation = self.telemetry_handler.inference(
+            "test-provider", request_model="test-model"
+        )
+        invocation.prompt_name = "chat_prompt"
+        invocation.prompt_version = "1.0.0"
+        invocation.prompt_variables = {"user": "Alice", "style": "formal"}
+        invocation.stop()
+
+        attrs = self.span_exporter.get_finished_spans()[0].attributes
+        assert attrs[GenAI.GEN_AI_PROMPT_NAME] == "chat_prompt"
+        assert attrs["gen_ai.prompt.version"] == "1.0.0"
+        assert attrs["gen_ai.prompt.variable.user"] == "Alice"
+        assert attrs["gen_ai.prompt.variable.style"] == "formal"
+
 
 class AnyNonNone:
     def __eq__(self, other):

--- a/util/opentelemetry-util-genai/tests/test_utils.py
+++ b/util/opentelemetry-util-genai/tests/test_utils.py
@@ -1230,7 +1230,11 @@ class TestTelemetryHandler(unittest.TestCase):
             )
             invocation.prompt_name = "chat_prompt"
             invocation.prompt_version = "1.0.0"
-            invocation.prompt_variables = {"user": "Alice", "style": "formal"}
+            invocation.prompt_variables = {
+                "user": "Alice",
+                "style": "formal",
+                "tags": ["a", "b"],
+            }
             invocation.stop()
 
             attrs = self.span_exporter.get_finished_spans()[-1].attributes
@@ -1238,6 +1242,7 @@ class TestTelemetryHandler(unittest.TestCase):
             assert attrs["gen_ai.prompt.version"] == "1.0.0"
             assert attrs["gen_ai.prompt.variable.user"] == "Alice"
             assert attrs["gen_ai.prompt.variable.style"] == "formal"
+            assert attrs["gen_ai.prompt.variable.tags"] == '["a","b"]'
 
             event_attrs = self.log_exporter.get_finished_logs()[
                 -1
@@ -1246,6 +1251,7 @@ class TestTelemetryHandler(unittest.TestCase):
             assert event_attrs["gen_ai.prompt.version"] == "1.0.0"
             assert event_attrs["gen_ai.prompt.variable.user"] == "Alice"
             assert event_attrs["gen_ai.prompt.variable.style"] == "formal"
+            assert event_attrs["gen_ai.prompt.variable.tags"] == '["a","b"]'
 
 
 class AnyNonNone:


### PR DESCRIPTION
## What does this change do?

Adds support for reasoning level, continuation, conversation compaction, and prompt template attributes to `InferenceInvocation`, and updates `RetrievalInvocation` to record integer `gen_ai.retrieval.top_k`.

### Attributes added/updated

- `gen_ai.request.reasoning.level`: Request reasoning effort/level.
- `gen_ai.request.previous_response.id`: Previous response ID for continuation requests.
- `gen_ai.conversation.compacted`: Flag indicating conversation history was compacted.
- `gen_ai.prompt.name`: Prompt template identifier.
- `gen_ai.prompt.version`: Prompt template version.
- `gen_ai.prompt.variable.<key>`: Prompt template input variables.
- `gen_ai.retrieval.top_k`: Integer top-k documents requested (replaces `gen_ai.request.top_k` on retrieval spans).

## Why?

Catches up with GenAI semantic conventions updates:
- **Retrieval top-k**: Replaces `gen_ai.request.top_k` (float) with dedicated integer `gen_ai.retrieval.top_k` on retrieval spans.
- **Reasoning**: Introduces `gen_ai.request.reasoning.level` for reasoning models.
- **Continuation**: Introduces `gen_ai.request.previous_response.id` for multi-turn continuations.
- **Compaction**: Introduces `gen_ai.conversation.compacted` for compacted context.
- **Prompts**: Standardizes prompt management metadata (`name`, `version`, and dynamic `variable.<key>` attributes).