### PR TITLE
[google-genai] Do not unconditionally set OTEL_INSTRUMENTATION_GENAI_EMIT_EVENT during instrumentation

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-google-genai/.changelog/619.fixed
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/.changelog/619.fixed
@@ -1,0 +1,1 @@
+Do not unconditionally set OTEL_INSTRUMENTATION_GENAI_EMIT_EVENT during instrumentation.

--- a/instrumentation/opentelemetry-instrumentation-google-genai/src/opentelemetry/instrumentation/google_genai/generate_content.py
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/src/opentelemetry/instrumentation/google_genai/generate_content.py
@@ -842,7 +842,6 @@ def instrument_generate_content(
     telemetry_handler: TelemetryHandler,
     generate_content_config_key_allowlist: AllowList,
 ) -> object:
-    os.environ["OTEL_INSTRUMENTATION_GENAI_EMIT_EVENT"] = "true"
     snapshot = _MethodsSnapshot()
     wrapped = wrap_function_wrapper(
         "google.genai.models",

--- a/instrumentation/opentelemetry-instrumentation-google-genai/tests/test_instrumentor.py
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/tests/test_instrumentor.py
@@ -3,6 +3,8 @@
 
 """Tests for GoogleGenAiSdkInstrumentor."""
 
+import os
+
 from google.genai.models import AsyncModels, Models
 
 from opentelemetry.instrumentation.google_genai import (
@@ -14,6 +16,9 @@ from opentelemetry.instrumentation.google_genai.interactions import (
     InteractionsResource,
 )
 from opentelemetry.test_util_genai.instrumentor import instrument
+from opentelemetry.util.genai.environment_variables import (
+    OTEL_INSTRUMENTATION_GENAI_EMIT_EVENT,
+)
 
 
 def test_co_filename_on_wrapped_functions(
@@ -58,3 +63,29 @@ def test_co_filename_on_wrapped_functions(
         ), (
             f"Expected opentelemetry/instrumentation/google_genai removed from {co_filename} upon uninstrument"
         )
+
+
+def test_instrument_does_not_mutate_emit_event_env(
+    monkeypatch, tracer_provider, logger_provider, meter_provider
+):
+    monkeypatch.delenv(OTEL_INSTRUMENTATION_GENAI_EMIT_EVENT, raising=False)
+    with instrument(
+        GoogleGenAiSdkInstrumentor(),
+        tracer_provider=tracer_provider,
+        logger_provider=logger_provider,
+        meter_provider=meter_provider,
+    ):
+        assert OTEL_INSTRUMENTATION_GENAI_EMIT_EVENT not in os.environ
+
+
+def test_instrument_preserves_explicit_emit_event_env(
+    monkeypatch, tracer_provider, logger_provider, meter_provider
+):
+    monkeypatch.setenv(OTEL_INSTRUMENTATION_GENAI_EMIT_EVENT, "false")
+    with instrument(
+        GoogleGenAiSdkInstrumentor(),
+        tracer_provider=tracer_provider,
+        logger_provider=logger_provider,
+        meter_provider=meter_provider,
+    ):
+        assert os.environ.get(OTEL_INSTRUMENTATION_GENAI_EMIT_EVENT) == "false"


### PR DESCRIPTION
# Description

Fixes #619

In `instrumentation/opentelemetry-instrumentation-google-genai/src/opentelemetry/instrumentation/google_genai/generate_content.py`, `instrument_generate_content()` unconditionally mutated the global environment via:
```python
os.environ["OTEL_INSTRUMENTATION_GENAI_EMIT_EVENT"] = "true"
```

This overrides explicit user settings (such as `OTEL_INSTRUMENTATION_GENAI_EMIT_EVENT="false"`) as well as the default resolution logic from `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` implemented in `opentelemetry.util.genai.utils.should_emit_event()`, while polluting `os.environ` for any other code running in the process.

This PR removes the unconditional assignment so `should_emit_event()` properly evaluates user configuration and capturing modes.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

- Added `test_instrument_does_not_mutate_emit_event_env` and `test_instrument_preserves_explicit_emit_event_env` in `instrumentation/opentelemetry-instrumentation-google-genai/tests/test_instrumentor.py`.
- Verified test suite passes: `pytest instrumentation/opentelemetry-instrumentation-google-genai/tests/test_instrumentor.py`.
- Formatted and linted via `ruff check` and `ruff format`.

# Checklist

- [x] Followed the style guidelines of this project
- [x] Changelog updated if the change requires an entry
- [x] Unit tests added
- [ ] Documentation updated