### PR TITLE
[opentelemetry-instrumentation-genai-anthropic] Record cache token usage via the shared invocation fields

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/src/opentelemetry/instrumentation/genai/anthropic/messages_extractors.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/src/opentelemetry/instrumentation/genai/anthropic/messages_extractors.py
@@ -65,12 +65,6 @@ class MessageRequestParams:
     system: str | Iterable[TextBlockParam] | None = None
 
 
-GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS = (
-    "gen_ai.usage.cache_creation.input_tokens"
-)
-GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS = "gen_ai.usage.cache_read.input_tokens"
-
-
 @dataclass
 class UsageTokens:
     input_tokens: int | None = None
@@ -173,14 +167,8 @@ def set_invocation_response_attributes(
     tokens = extract_usage_tokens(message.usage)
     invocation.input_tokens = tokens.input_tokens
     invocation.output_tokens = tokens.output_tokens
-    if tokens.cache_creation_input_tokens is not None:
-        invocation.attributes[GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS] = (
-            tokens.cache_creation_input_tokens
-        )
-    if tokens.cache_read_input_tokens is not None:
-        invocation.attributes[GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS] = (
-            tokens.cache_read_input_tokens
-        )
+    invocation.cache_creation_input_tokens = tokens.cache_creation_input_tokens
+    invocation.cache_read_input_tokens = tokens.cache_read_input_tokens
 
     if capture_content:
         invocation.output_messages = get_output_messages_from_message(message)

--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/test_async_messages.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/test_async_messages.py
@@ -30,10 +30,6 @@ from opentelemetry.instrumentation.genai.anthropic import (
 from opentelemetry.instrumentation.genai.anthropic._raw_response import (
     RawResponseProxy,
 )
-from opentelemetry.instrumentation.genai.anthropic.messages_extractors import (
-    GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS,
-    GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS,
-)
 from opentelemetry.instrumentation.genai.anthropic.wrappers import (
     AsyncMessagesStreamWrapper,
 )
@@ -882,8 +878,13 @@ async def test_async_messages_create_aggregates_cache_tokens(
     assert len(spans) == 1
     span = spans[0]
 
-    assert GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS in span.attributes
-    assert GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS in span.attributes
+    assert (
+        GenAIAttributes.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS
+        in span.attributes
+    )
+    assert (
+        GenAIAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS in span.attributes
+    )
     assert span.attributes[
         GenAIAttributes.GEN_AI_USAGE_INPUT_TOKENS
     ] == expected_input_tokens(response.usage)
@@ -894,10 +895,15 @@ async def test_async_messages_create_aggregates_cache_tokens(
     cache_creation = getattr(response.usage, "cache_creation_input_tokens", 0)
     cache_read = getattr(response.usage, "cache_read_input_tokens", 0)
     assert (
-        span.attributes[GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS]
+        span.attributes[
+            GenAIAttributes.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS
+        ]
         == cache_creation
     )
-    assert span.attributes[GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS] == cache_read
+    assert (
+        span.attributes[GenAIAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS]
+        == cache_read
+    )
 
 
 @pytest.mark.asyncio
@@ -936,8 +942,13 @@ async def test_async_messages_create_streaming_aggregates_cache_tokens(
     assert len(spans) == 1
     span = spans[0]
 
-    assert GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS in span.attributes
-    assert GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS in span.attributes
+    assert (
+        GenAIAttributes.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS
+        in span.attributes
+    )
+    assert (
+        GenAIAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS in span.attributes
+    )
     assert (
         span.attributes[GenAIAttributes.GEN_AI_USAGE_INPUT_TOKENS]
         == input_tokens
@@ -947,10 +958,15 @@ async def test_async_messages_create_streaming_aggregates_cache_tokens(
         == output_tokens
     )
     assert (
-        span.attributes[GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS]
+        span.attributes[
+            GenAIAttributes.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS
+        ]
         == cache_creation
     )
-    assert span.attributes[GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS] == cache_read
+    assert (
+        span.attributes[GenAIAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS]
+        == cache_read
+    )
 
 
 @pytest.mark.asyncio

--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/test_sync_messages.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/test_sync_messages.py
@@ -40,8 +40,6 @@ from opentelemetry.instrumentation.genai.anthropic._raw_response import (
     RawResponseProxy,
 )
 from opentelemetry.instrumentation.genai.anthropic.messages_extractors import (
-    GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS,
-    GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS,
     get_server_address_and_port,
 )
 from opentelemetry.semconv._incubating.attributes import (
@@ -1219,8 +1217,13 @@ def test_sync_messages_create_aggregates_cache_tokens(
     assert len(spans) == 1
     span = spans[0]
 
-    assert GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS in span.attributes
-    assert GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS in span.attributes
+    assert (
+        GenAIAttributes.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS
+        in span.attributes
+    )
+    assert (
+        GenAIAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS in span.attributes
+    )
     assert span.attributes[
         GenAIAttributes.GEN_AI_USAGE_INPUT_TOKENS
     ] == expected_input_tokens(response.usage)
@@ -1231,10 +1234,15 @@ def test_sync_messages_create_aggregates_cache_tokens(
     cache_creation = getattr(response.usage, "cache_creation_input_tokens", 0)
     cache_read = getattr(response.usage, "cache_read_input_tokens", 0)
     assert (
-        span.attributes[GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS]
+        span.attributes[
+            GenAIAttributes.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS
+        ]
         == cache_creation
     )
-    assert span.attributes[GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS] == cache_read
+    assert (
+        span.attributes[GenAIAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS]
+        == cache_read
+    )
 
 
 @pytest.mark.vcr()
@@ -1273,8 +1281,13 @@ def test_sync_messages_create_streaming_aggregates_cache_tokens(
     assert len(spans) == 1
     span = spans[0]
 
-    assert GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS in span.attributes
-    assert GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS in span.attributes
+    assert (
+        GenAIAttributes.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS
+        in span.attributes
+    )
+    assert (
+        GenAIAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS in span.attributes
+    )
     assert (
         span.attributes[GenAIAttributes.GEN_AI_USAGE_INPUT_TOKENS]
         == input_tokens
@@ -1284,10 +1297,15 @@ def test_sync_messages_create_streaming_aggregates_cache_tokens(
         == output_tokens
     )
     assert (
-        span.attributes[GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS]
+        span.attributes[
+            GenAIAttributes.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS
+        ]
         == cache_creation
     )
-    assert span.attributes[GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS] == cache_read
+    assert (
+        span.attributes[GenAIAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS]
+        == cache_read
+    )
 
 
 @pytest.mark.vcr()


### PR DESCRIPTION
# Description

`messages_extractors` defined its own `gen_ai.usage.cache_creation.input_tokens` and `gen_ai.usage.cache_read.input_tokens` string constants and wrote them straight into `invocation.attributes`, so the attribute names were pinned in this package rather than tracking the semantic conventions. `InferenceInvocation` already carries `cache_creation_input_tokens` and `cache_read_input_tokens` fields for exactly this, and openai uses them (`response_extractors.py:661`).

This sets those fields instead and drops the two local constants. The emitted attributes are unchanged.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

The existing cache token tests now assert against the semconv constants rather than the removed local ones.

- [x] `anthropic` suite: 178 passed (latest), 171 passed with 7 skipped (oldest)
- [x] `anthropic` conformance: 5 passed
- [x] `tox -e precommit` and `tox -e typecheck` clean

# Checklist

- [x] Followed the style guidelines of this project
- [x] Changelog updated if the change requires an entry
- [x] Unit tests updated
