### PR TITLE
fix(google-genai): respect event emission configuration

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-google-genai/.changelog/648.fixed
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/.changelog/648.fixed
@@ -1,0 +1,1 @@
+Respect the `OTEL_INSTRUMENTATION_GENAI_EMIT_EVENT` setting in Google GenAI instrumentation.

--- a/instrumentation/opentelemetry-instrumentation-google-genai/src/opentelemetry/instrumentation/google_genai/generate_content.py
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/src/opentelemetry/instrumentation/google_genai/generate_content.py
@@ -842,7 +842,6 @@ def instrument_generate_content(
     telemetry_handler: TelemetryHandler,
     generate_content_config_key_allowlist: AllowList,
 ) -> object:
-    os.environ["OTEL_INSTRUMENTATION_GENAI_EMIT_EVENT"] = "true"
     snapshot = _MethodsSnapshot()
     wrapped = wrap_function_wrapper(
         "google.genai.models",

--- a/instrumentation/opentelemetry-instrumentation-google-genai/tests/generate_content/nonstreaming_base.py
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/tests/generate_content/nonstreaming_base.py
@@ -359,6 +359,7 @@ class NonStreamingTestCase(TestCase):
         {
             "OTEL_GOOGLE_GENAI_GENERATE_CONTENT_CONFIG_INCLUDES": "gcp.gen_ai.operation.config.response_schema",
             "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT": "NO_CONTENT",
+            "OTEL_INSTRUMENTATION_GENAI_EMIT_EVENT": "true",
         },
     )
     def test_log_event_no_content_capture(self):
@@ -427,6 +428,19 @@ class NonStreamingTestCase(TestCase):
                 event.attributes[GEN_AI_TOOL_DEFINITIONS],
                 self.base_tools_definition,
             )
+
+    @patch.dict(
+        "os.environ",
+        {
+            "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT": "NO_CONTENT",
+        },
+    )
+    def test_no_log_event_by_default_without_content_capture(self):
+        self.configure_valid_response(text="Some response content")
+        self.generate_content(model="gemini-2.0-flash", contents="Some input")
+        self.otel.assert_does_not_have_event_named(
+            "gen_ai.client.inference.operation.details"
+        )
 
     @patch.dict(
         "os.environ",

--- a/instrumentation/opentelemetry-instrumentation-google-genai/tests/generate_content/test_e2e.py
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/tests/generate_content/test_e2e.py
@@ -40,6 +40,7 @@ from opentelemetry.instrumentation.google_genai import (
 )
 from opentelemetry.util.genai.environment_variables import (
     OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT,
+    OTEL_INSTRUMENTATION_GENAI_EMIT_EVENT,
     OTEL_INSTRUMENTATION_GENAI_UPLOAD_BASE_PATH,
 )
 
@@ -314,7 +315,9 @@ def fixture_enable_completion_hook(request):
 
 
 @pytest.fixture(name="internal_instrumentation_setup", autouse=True)
-def fixture_setup_instrumentation(instrumentor, enable_completion_hook):
+def fixture_setup_instrumentation(
+    instrumentor, enable_completion_hook, monkeypatch
+):
     if enable_completion_hook == "enable_completion_hook":
         os.environ.update(
             {
@@ -322,6 +325,7 @@ def fixture_setup_instrumentation(instrumentor, enable_completion_hook):
                 "OTEL_INSTRUMENTATION_GENAI_COMPLETION_HOOK": "upload",
             }
         )
+        monkeypatch.setenv(OTEL_INSTRUMENTATION_GENAI_EMIT_EVENT, "true")
     instrumentor.instrument()
     yield
     instrumentor.uninstrument()

--- a/instrumentation/opentelemetry-instrumentation-google-genai/tests/test_instrumentor.py
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/tests/test_instrumentor.py
@@ -3,6 +3,9 @@
 
 """Tests for GoogleGenAiSdkInstrumentor."""
 
+import os
+
+import pytest
 from google.genai.models import AsyncModels, Models
 
 from opentelemetry.instrumentation.google_genai import (
@@ -14,6 +17,38 @@ from opentelemetry.instrumentation.google_genai.interactions import (
     InteractionsResource,
 )
 from opentelemetry.test_util_genai.instrumentor import instrument
+from opentelemetry.util.genai.environment_variables import (
+    OTEL_INSTRUMENTATION_GENAI_EMIT_EVENT,
+)
+
+
+@pytest.mark.parametrize("configured_value", [None, "false"])
+def test_instrumentation_preserves_emit_event_configuration(
+    configured_value,
+    monkeypatch,
+    tracer_provider,
+    logger_provider,
+    meter_provider,
+):
+    if configured_value is None:
+        monkeypatch.delenv(
+            OTEL_INSTRUMENTATION_GENAI_EMIT_EVENT, raising=False
+        )
+    else:
+        monkeypatch.setenv(
+            OTEL_INSTRUMENTATION_GENAI_EMIT_EVENT, configured_value
+        )
+
+    with instrument(
+        GoogleGenAiSdkInstrumentor(),
+        tracer_provider=tracer_provider,
+        logger_provider=logger_provider,
+        meter_provider=meter_provider,
+    ):
+        assert (
+            os.environ.get(OTEL_INSTRUMENTATION_GENAI_EMIT_EVENT)
+            == configured_value
+        )
 
 
 def test_co_filename_on_wrapped_functions(


### PR DESCRIPTION
## Why

Google GenAI instrumentation unconditionally set `OTEL_INSTRUMENTATION_GENAI_EMIT_EVENT=true` during instrumentation. That overwrote an explicit `false`, changed the shared default, and mutated process-global configuration. Fixes #619.

## What

Remove the Google-specific environment mutation. Add regression coverage for preserving unset and explicit-false configuration, default no-event behavior when content capture is disabled, and explicit event opt-in where tests require events.

## Why the approach

`opentelemetry-util-genai` already owns event-selection policy through `should_emit_event()`. Deferring to that shared path avoids duplicate configuration logic, preserves the public interface, and limits production code to a one-line removal.

## Validation

- Google GenAI latest: 212 passed, 118 skipped
- Google GenAI oldest: 163 passed, 167 skipped
- Google GenAI conformance: 4 passed
- `tox -e typecheck`: 0 errors
- `tox -e precommit`: passed
- `tox -e changelog-preview`: passed