### PR TITLE
Fix cancelled GenAI wrapper finalization

### DIFF
--- a/.github/instructions/instrumentation.instructions.md
+++ b/.github/instructions/instrumentation.instructions.md
@@ -93,6 +93,8 @@ Flag, with a link to the rule:
 
 - When catching exceptions from the underlying library to record telemetry, always re-raise the
   original exception unmodified.
+- Flag telemetry-finalizing handlers that catch `Exception` instead of `BaseException`; cancellation
+  raises `asyncio.CancelledError`, which would otherwise leave spans open.
 - Do not raise **new** exceptions in instrumentation/telemetry code.
 
 ## 6. Tests

--- a/.github/instructions/instrumentation.instructions.md
+++ b/.github/instructions/instrumentation.instructions.md
@@ -93,8 +93,7 @@ Flag, with a link to the rule:
 
 - When catching exceptions from the underlying library to record telemetry, always re-raise the
   original exception unmodified.
-- Flag telemetry-finalizing handlers that catch `Exception` instead of `BaseException`; cancellation
-  raises `asyncio.CancelledError`, which would otherwise leave spans open.
+- Flag telemetry-finalizing handlers that catch `Exception` instead of `BaseException` to catch  `asyncio.CancelledError` and such.
 - Do not raise **new** exceptions in instrumentation/telemetry code.
 
 ## 6. Tests

--- a/instrumentation/AGENTS.md
+++ b/instrumentation/AGENTS.md
@@ -65,3 +65,9 @@ Before emitting an inference (`chat`) or `embeddings` span, ask:
 - **Yes** → emit an `invoke_workflow` span around the library API that runs the workflow.
 - **No** → don't emit a workflow span. A single agent run or a plain chain of calls is not an AI
   workflow.
+
+## Exception handling
+
+- When catching exceptions from an underlying library after starting telemetry,
+  catch `BaseException`, not `Exception`, so cancellation and interrupts
+  finalize the invocation before the original exception is re-raised.

--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/.changelog/656.fixed
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/.changelog/656.fixed
@@ -1,0 +1,1 @@
+Record failed Anthropic invocations when cancellation raises a `BaseException`.

--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/src/opentelemetry/instrumentation/genai/anthropic/patch.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/src/opentelemetry/instrumentation/genai/anthropic/patch.py
@@ -138,7 +138,7 @@ def messages_create(
             # this returns a response object that ``create``'s annotations do
             # not describe, so the checks below cannot be narrowed away.
             result: Any = wrapped(*args, **kwargs)
-        except Exception as exc:
+        except BaseException as exc:
             invocation.fail(exc)
             raise
 
@@ -194,7 +194,7 @@ def async_messages_create(
         try:
             # See ``messages_create`` on why this is Any.
             result: Any = await wrapped(*args, **kwargs)
-        except Exception as exc:
+        except BaseException as exc:
             invocation.fail(exc)
             raise
 

--- a/instrumentation/opentelemetry-instrumentation-genai-bedrock/.changelog/656.fixed
+++ b/instrumentation/opentelemetry-instrumentation-genai-bedrock/.changelog/656.fixed
@@ -1,0 +1,1 @@
+Record failed Bedrock invocations when cancellation raises a `BaseException`.

--- a/instrumentation/opentelemetry-instrumentation-genai-bedrock/src/opentelemetry/instrumentation/genai/bedrock/patch.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-bedrock/src/opentelemetry/instrumentation/genai/bedrock/patch.py
@@ -65,7 +65,7 @@ def _handle_converse(
     )
     try:
         response: Any = wrapped(*args, **kwargs)
-    except Exception as exc:
+    except BaseException as exc:
         invocation.fail(exc)
         raise
 
@@ -117,7 +117,7 @@ def _handle_invoke_model(
     )
     try:
         response: Any = wrapped(*args, **kwargs)
-    except Exception as exc:
+    except BaseException as exc:
         invocation.fail(exc)
         raise
 

--- a/instrumentation/opentelemetry-instrumentation-genai-bedrock/tests/test_patch.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-bedrock/tests/test_patch.py
@@ -1,0 +1,85 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from opentelemetry.instrumentation.genai.bedrock.patch import (
+    _handle_converse,
+    _handle_invoke_model,
+)
+from opentelemetry.semconv._incubating.attributes import (
+    error_attributes as ErrorAttributes,
+)
+from opentelemetry.util.genai.handler import TelemetryHandler
+
+
+def _bedrock_client() -> Any:
+    return SimpleNamespace(
+        meta=SimpleNamespace(
+            endpoint_url="https://bedrock-runtime.us-east-1.amazonaws.com"
+        )
+    )
+
+
+def _cancelled_call(*_args: Any, **_kwargs: Any) -> Any:
+    raise asyncio.CancelledError()
+
+
+def test_converse_records_cancelled_error(
+    tracer_provider,
+    span_exporter,
+) -> None:
+    handler = TelemetryHandler(tracer_provider=tracer_provider)
+
+    with pytest.raises(asyncio.CancelledError):
+        _handle_converse(
+            _cancelled_call,
+            _bedrock_client(),
+            (),
+            {},
+            {
+                "modelId": "amazon.nova-micro-v1:0",
+                "messages": [],
+            },
+            handler,
+        )
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert (
+        spans[0].attributes[ErrorAttributes.ERROR_TYPE]
+        == "asyncio.exceptions.CancelledError"
+    )
+
+
+def test_invoke_model_records_cancelled_error(
+    tracer_provider,
+    span_exporter,
+) -> None:
+    handler = TelemetryHandler(tracer_provider=tracer_provider)
+
+    with pytest.raises(asyncio.CancelledError):
+        _handle_invoke_model(
+            _cancelled_call,
+            _bedrock_client(),
+            (),
+            {},
+            {
+                "modelId": "anthropic.claude-v2",
+                "body": "{}",
+            },
+            handler,
+        )
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert (
+        spans[0].attributes[ErrorAttributes.ERROR_TYPE]
+        == "asyncio.exceptions.CancelledError"
+    )

--- a/instrumentation/opentelemetry-instrumentation-genai-openai/.changelog/656.fixed
+++ b/instrumentation/opentelemetry-instrumentation-genai-openai/.changelog/656.fixed
@@ -1,0 +1,1 @@
+Record failed OpenAI invocations when cancellation raises a `BaseException`.

--- a/instrumentation/opentelemetry-instrumentation-genai-openai/src/opentelemetry/instrumentation/genai/openai/patch.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-openai/src/opentelemetry/instrumentation/genai/openai/patch.py
@@ -82,7 +82,7 @@ def chat_completions_create_v_new(
             _set_response_properties(chat_invocation, result, capture_content)
             chat_invocation.stop()
             return result
-        except Exception as error:
+        except BaseException as error:
             chat_invocation.fail(error)
             raise
 
@@ -114,7 +114,7 @@ def async_chat_completions_create_v_new(
             chat_invocation.stop()
             return result
 
-        except Exception as error:
+        except BaseException as error:
             chat_invocation.fail(error)
             raise
 
@@ -129,7 +129,7 @@ def embeddings_create(handler: TelemetryHandler):
 
         try:
             result = wrapped(*args, **kwargs)
-        except Exception as error:
+        except BaseException as error:
             invocation.fail(error)
             raise
 
@@ -148,7 +148,7 @@ def async_embeddings_create(handler: TelemetryHandler):
 
         try:
             result = await wrapped(*args, **kwargs)
-        except Exception as error:
+        except BaseException as error:
             invocation.fail(error)
             raise
 

--- a/instrumentation/opentelemetry-instrumentation-genai-openai/src/opentelemetry/instrumentation/genai/openai/patch_responses.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-openai/src/opentelemetry/instrumentation/genai/openai/patch_responses.py
@@ -108,7 +108,7 @@ def responses_create(
             else:
                 invocation.stop()
             return result
-        except Exception as error:
+        except BaseException as error:
             invocation.fail(error)
             raise
 
@@ -181,7 +181,7 @@ def async_responses_create(
             else:
                 invocation.stop()
             return result
-        except Exception as error:
+        except BaseException as error:
             invocation.fail(error)
             raise
 
@@ -286,7 +286,7 @@ def responses_retrieve(
             )
             invocation.stop()
             return result
-        except Exception as error:
+        except BaseException as error:
             invocation.fail(error)
             raise
 
@@ -356,7 +356,7 @@ def async_responses_retrieve(
             )
             invocation.stop()
             return result
-        except Exception as error:
+        except BaseException as error:
             invocation.fail(error)
             raise
 

--- a/instrumentation/opentelemetry-instrumentation-genai-openai/tests/test_embedding_invocation_unit.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-openai/tests/test_embedding_invocation_unit.py
@@ -11,6 +11,7 @@ that targeted the removed ``get_llm_request_attributes`` /
 
 from __future__ import annotations
 
+import asyncio
 from types import SimpleNamespace
 from typing import Any
 
@@ -25,6 +26,7 @@ from opentelemetry.instrumentation.genai.openai.patch import (
     _create_embedding_invocation as create_embedding_invocation,
 )
 from opentelemetry.instrumentation.genai.openai.patch import (
+    async_embeddings_create,
     embeddings_create,
 )
 from opentelemetry.semconv._incubating.attributes import (
@@ -278,3 +280,38 @@ def test_wrapped_call_exception_is_recorded_and_reraised(
     assert len(spans) == 1
     span = spans[0]
     assert span.attributes["error.type"] == "ValueError"
+
+
+def test_wrapped_call_base_exception_is_recorded_and_reraised(
+    handler, span_exporter
+):
+    def wrapped(*_args, **_kwargs):
+        raise asyncio.CancelledError()
+
+    traced = embeddings_create(handler)
+    with pytest.raises(asyncio.CancelledError):
+        traced(wrapped, _make_client(), (), {"model": "m"})
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.attributes["error.type"] == "asyncio.exceptions.CancelledError"
+
+
+def test_async_wrapped_call_base_exception_is_recorded_and_reraised(
+    handler, span_exporter
+):
+    async def exercise():
+        async def wrapped(*_args, **_kwargs):
+            raise asyncio.CancelledError()
+
+        traced = async_embeddings_create(handler)
+        with pytest.raises(asyncio.CancelledError):
+            await traced(wrapped, _make_client(), (), {"model": "m"})
+
+    asyncio.run(exercise())
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.attributes["error.type"] == "asyncio.exceptions.CancelledError"

--- a/instrumentation/opentelemetry-instrumentation-genai-portkey/.changelog/656.fixed
+++ b/instrumentation/opentelemetry-instrumentation-genai-portkey/.changelog/656.fixed
@@ -1,0 +1,1 @@
+Record failed Portkey invocations when cancellation raises a `BaseException`.

--- a/instrumentation/opentelemetry-instrumentation-genai-portkey/src/opentelemetry/instrumentation/genai/portkey/patch.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-portkey/src/opentelemetry/instrumentation/genai/portkey/patch.py
@@ -111,7 +111,7 @@ def _sync_completions_create(
             set_response_properties(invocation, result, capture_content)
             invocation.stop()
             return result
-        except Exception as error:
+        except BaseException as error:
             invocation.fail(error)
             raise
 
@@ -144,7 +144,7 @@ def _async_completions_create(
             set_response_properties(invocation, result, capture_content)
             invocation.stop()
             return result
-        except Exception as error:
+        except BaseException as error:
             invocation.fail(error)
             raise
 

--- a/instrumentation/opentelemetry-instrumentation-genai-qwen-agent/.changelog/656.fixed
+++ b/instrumentation/opentelemetry-instrumentation-genai-qwen-agent/.changelog/656.fixed
@@ -1,0 +1,1 @@
+Record failed Qwen Agent tool invocations when cancellation raises a `BaseException`.

--- a/instrumentation/opentelemetry-instrumentation-genai-qwen-agent/src/opentelemetry/instrumentation/genai/qwen_agent/patch.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-qwen-agent/src/opentelemetry/instrumentation/genai/qwen_agent/patch.py
@@ -108,7 +108,7 @@ def wrap_agent_call_tool(
 
     try:
         result = wrapped(*args, **kwargs)
-    except Exception as error:
+    except BaseException as error:
         invocation.fail(error)
         raise
 

--- a/instrumentation/opentelemetry-instrumentation-genai-smolagents/.changelog/656.fixed
+++ b/instrumentation/opentelemetry-instrumentation-genai-smolagents/.changelog/656.fixed
@@ -1,1 +1,0 @@
-Record failed Smolagents streamed model invocations when cancellation raises a `BaseException`.

--- a/instrumentation/opentelemetry-instrumentation-genai-smolagents/.changelog/656.fixed
+++ b/instrumentation/opentelemetry-instrumentation-genai-smolagents/.changelog/656.fixed
@@ -1,0 +1,1 @@
+Record failed Smolagents streamed model invocations when cancellation raises a `BaseException`.

--- a/instrumentation/opentelemetry-instrumentation-google-genai/.changelog/656.fixed
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/.changelog/656.fixed
@@ -1,0 +1,1 @@
+Record failed Google GenAI interaction invocations when cancellation raises a `BaseException`.

--- a/instrumentation/opentelemetry-instrumentation-google-genai/src/opentelemetry/instrumentation/google_genai/interactions.py
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/src/opentelemetry/instrumentation/google_genai/interactions.py
@@ -452,7 +452,7 @@ def _create_instrumented_interactions_create(
             )
             invocation.stop()
             return response
-        except Exception as exc:
+        except BaseException as exc:
             invocation.fail(exc)
             raise
 
@@ -496,7 +496,7 @@ def _create_instrumented_async_interactions_create(
             )
             invocation.stop()
             return response
-        except Exception as exc:
+        except BaseException as exc:
             invocation.fail(exc)
             raise
 

--- a/instrumentation/opentelemetry-instrumentation-google-genai/tests/interactions/base.py
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/tests/interactions/base.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import unittest
 import unittest.mock
 from typing import Any
@@ -69,10 +70,12 @@ class TestCase(CommonTestCaseBase):
         interaction = create_mock_interaction(**kwargs)
         self._interactions.append(interaction)
 
-    def configure_exception(self, e: Exception) -> None:
+    def configure_exception(self, e: BaseException) -> None:
         self._create_and_install_mocks(e)
 
-    def _create_and_install_mocks(self, e: Exception | None = None) -> None:
+    def _create_and_install_mocks(
+        self, e: BaseException | None = None
+    ) -> None:
         if self._create_mock is not None:
             return
         self.reset_client()
@@ -81,7 +84,7 @@ class TestCase(CommonTestCaseBase):
         self._install_mocks()
 
     def _create_mock_impl(
-        self, e: Exception | None = None
+        self, e: BaseException | None = None
     ) -> unittest.mock.MagicMock:
         mock = unittest.mock.MagicMock()
 
@@ -227,6 +230,54 @@ class TestCase(CommonTestCaseBase):
         )
         self.assertEqual(span.attributes["error.type"], "ValueError")
         self.assertEqual(event.attributes["error.type"], "ValueError")
+
+    def test_cancelled_request_records_error(self) -> None:
+        self.configure_exception(asyncio.CancelledError())
+        with self.assertRaises(asyncio.CancelledError):
+            self.run_interaction(
+                model="gemini-2.5-flash", input="Does this work?"
+            )
+        self.otel.assert_has_span_named("interactions.create gemini-2.5-flash")
+        span = self.otel.get_span_named("interactions.create gemini-2.5-flash")
+        self.otel.assert_has_event_named(
+            "gen_ai.client.inference.operation.details"
+        )
+        event = self.otel.get_event_named(
+            "gen_ai.client.inference.operation.details"
+        )
+        self.assertEqual(
+            span.attributes["error.type"],
+            "asyncio.exceptions.CancelledError",
+        )
+        self.assertEqual(
+            event.attributes["error.type"],
+            "asyncio.exceptions.CancelledError",
+        )
+
+    def test_cancelled_streaming_request_records_error(self) -> None:
+        self.configure_exception(asyncio.CancelledError())
+        with self.assertRaises(asyncio.CancelledError):
+            self.run_streaming_interaction(
+                model="gemini-2.5-flash",
+                input="Does this work?",
+                stream=True,
+            )
+        self.otel.assert_has_span_named("interactions.create gemini-2.5-flash")
+        span = self.otel.get_span_named("interactions.create gemini-2.5-flash")
+        self.otel.assert_has_event_named(
+            "gen_ai.client.inference.operation.details"
+        )
+        event = self.otel.get_event_named(
+            "gen_ai.client.inference.operation.details"
+        )
+        self.assertEqual(
+            span.attributes["error.type"],
+            "asyncio.exceptions.CancelledError",
+        )
+        self.assertEqual(
+            event.attributes["error.type"],
+            "asyncio.exceptions.CancelledError",
+        )
 
     def test_generated_span_has_vertex_ai_system_when_configured(self) -> None:
         self.set_use_vertex(True)

--- a/util/opentelemetry-util-genai/.changelog/656.fixed
+++ b/util/opentelemetry-util-genai/.changelog/656.fixed
@@ -1,0 +1,1 @@
+Finalize stream telemetry when stream iteration, close, or manager entry/exit is cancelled.

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/stream.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/stream.py
@@ -170,7 +170,7 @@ class SyncStreamWrapper(
     def close(self) -> None:
         try:
             self._self_stream.close()
-        except Exception as error:
+        except BaseException as error:
             self._finalize_failure(error)
             raise
         self._finalize_success()
@@ -187,7 +187,7 @@ class SyncStreamWrapper(
         except StopIteration:
             self._finalize_success()
             raise
-        except Exception as error:
+        except BaseException as error:
             self._finalize_failure(error)
             raise
         invocation = self._self_invocation
@@ -299,7 +299,7 @@ class AsyncStreamWrapper(
         """
         try:
             await self._close_stream()
-        except Exception as error:
+        except BaseException as error:
             self._finalize_failure(error)
             _logger.debug(
                 "GenAI stream close error during close",
@@ -346,7 +346,7 @@ class AsyncStreamWrapper(
         except StopAsyncIteration:
             self._finalize_success()
             raise
-        except Exception as error:
+        except BaseException as error:
             self._finalize_failure(error)
             raise
 
@@ -449,7 +449,7 @@ class SyncStreamManagerWrapper(
         self._self_invocation = invocation
         try:
             stream = self._enter_manager(invocation)
-        except Exception as error:
+        except BaseException as error:
             invocation.fail(error)
             raise
         stream_wrapper = self._wrap_stream(stream, invocation)
@@ -466,7 +466,7 @@ class SyncStreamManagerWrapper(
         self._self_stream_wrapper = None
         try:
             suppressed = self.__wrapped__.__exit__(exc_type, exc_val, exc_tb)
-        except Exception as error:
+        except BaseException as error:
             if stream_wrapper is not None:
                 stream_wrapper.__exit__(
                     type(error), error, error.__traceback__
@@ -516,7 +516,7 @@ class AsyncStreamManagerWrapper(
         self._self_invocation = invocation
         try:
             stream = await self._enter_manager(invocation)
-        except Exception as error:
+        except BaseException as error:
             invocation.fail(error)
             raise
         stream_wrapper = self._wrap_stream(stream, invocation)
@@ -535,7 +535,7 @@ class AsyncStreamManagerWrapper(
             suppressed = await self.__wrapped__.__aexit__(
                 exc_type, exc_val, exc_tb
             )
-        except Exception as error:
+        except BaseException as error:
             if stream_wrapper is not None:
                 await stream_wrapper.__aexit__(
                     type(error), error, error.__traceback__

--- a/util/opentelemetry-util-genai/tests/test_stream.py
+++ b/util/opentelemetry-util-genai/tests/test_stream.py
@@ -133,6 +133,16 @@ def test_sync_stream_wrapper_fails_stream_errors():
     assert wrapper._self_failures == [error]
 
 
+def test_sync_stream_wrapper_fails_base_exception_stream_errors():
+    error = asyncio.CancelledError()
+    wrapper = _TestSyncStreamWrapper(_FakeSyncStream(error=error))
+
+    with pytest.raises(asyncio.CancelledError):
+        next(wrapper)
+
+    assert wrapper._self_failures == [error]
+
+
 def test_sync_stream_wrapper_close_stops_once():
     stream = _FakeSyncStream(chunks=["chunk"])
     wrapper = _TestSyncStreamWrapper(stream)
@@ -152,6 +162,19 @@ def test_sync_stream_wrapper_close_fails_with_close_error():
     )
 
     with pytest.raises(RuntimeError, match="close failure"):
+        wrapper.close()
+
+    assert wrapper._self_failures == [error]
+    assert wrapper._self_stop_count == 0
+
+
+def test_sync_stream_wrapper_close_fails_with_base_exception():
+    error = asyncio.CancelledError()
+    wrapper = _TestSyncStreamWrapper(
+        _FakeSyncStream(chunks=["chunk"], close_error=error)
+    )
+
+    with pytest.raises(asyncio.CancelledError):
         wrapper.close()
 
     assert wrapper._self_failures == [error]
@@ -306,6 +329,19 @@ def test_async_stream_wrapper_fails_stream_errors():
     asyncio.run(exercise())
 
 
+def test_async_stream_wrapper_fails_base_exception_stream_errors():
+    async def exercise():
+        error = asyncio.CancelledError()
+        wrapper = _TestAsyncStreamWrapper(_FakeAsyncStream(error=error))
+
+        with pytest.raises(asyncio.CancelledError):
+            await anext(wrapper)
+
+        assert wrapper._self_failures == [error]
+
+    asyncio.run(exercise())
+
+
 def test_async_stream_wrapper_close_stops_once():
     async def exercise():
         stream = _FakeAsyncStream(chunks=["chunk"])
@@ -329,6 +365,22 @@ def test_async_stream_wrapper_close_fails_with_close_error():
         )
 
         with pytest.raises(RuntimeError, match="close failure"):
+            await wrapper.close()
+
+        assert wrapper._self_failures == [error]
+        assert wrapper._self_stop_count == 0
+
+    asyncio.run(exercise())
+
+
+def test_async_stream_wrapper_close_fails_with_base_exception():
+    async def exercise():
+        error = asyncio.CancelledError()
+        wrapper = _TestAsyncStreamWrapper(
+            _FakeAsyncStream(chunks=["chunk"], close_error=error)
+        )
+
+        with pytest.raises(asyncio.CancelledError):
             await wrapper.close()
 
         assert wrapper._self_failures == [error]
@@ -810,6 +862,21 @@ def test_sync_manager_wrapper_fails_invocation_when_enter_raises():
     assert invocation.failures == [error]
 
 
+def test_sync_manager_wrapper_fails_invocation_when_enter_is_cancelled():
+    error = asyncio.CancelledError()
+    invocation = _FakeInvocation()
+    wrapper = _TestSyncManagerWrapper(
+        _FakeSyncManager(_FakeSyncStream(), enter_error=error),
+        lambda: invocation,
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        with wrapper:
+            pass
+
+    assert invocation.failures == [error]
+
+
 def test_sync_manager_wrapper_forwards_caller_error_to_stream_wrapper():
     manager = _FakeSyncManager(_FakeSyncStream())
     wrapper = _TestSyncManagerWrapper(manager, _FakeInvocation)
@@ -841,6 +908,18 @@ def test_sync_manager_wrapper_finalizes_stream_when_exit_raises():
 
     stream_wrapper = wrapper.__enter__()
     with pytest.raises(RuntimeError, match="manager failure"):
+        wrapper.__exit__(None, None, None)
+
+    assert stream_wrapper._self_failures == [manager_error]
+
+
+def test_sync_manager_wrapper_finalizes_stream_when_exit_is_cancelled():
+    manager_error = asyncio.CancelledError()
+    manager = _FakeSyncManager(_FakeSyncStream(), exit_error=manager_error)
+    wrapper = _TestSyncManagerWrapper(manager, _FakeInvocation)
+
+    stream_wrapper = wrapper.__enter__()
+    with pytest.raises(asyncio.CancelledError):
         wrapper.__exit__(None, None, None)
 
     assert stream_wrapper._self_failures == [manager_error]
@@ -894,6 +973,24 @@ def test_async_manager_wrapper_fails_invocation_when_enter_raises():
     asyncio.run(exercise())
 
 
+def test_async_manager_wrapper_fails_invocation_when_enter_is_cancelled():
+    async def exercise():
+        error = asyncio.CancelledError()
+        invocation = _FakeInvocation()
+        wrapper = _TestAsyncManagerWrapper(
+            _FakeAsyncManager(_FakeAsyncStream(), enter_error=error),
+            lambda: invocation,
+        )
+
+        with pytest.raises(asyncio.CancelledError):
+            async with wrapper:
+                pass
+
+        assert invocation.failures == [error]
+
+    asyncio.run(exercise())
+
+
 def test_async_manager_wrapper_forwards_caller_error_to_stream_wrapper():
     async def exercise():
         manager = _FakeAsyncManager(_FakeAsyncStream())
@@ -934,6 +1031,23 @@ def test_async_manager_wrapper_finalizes_stream_when_exit_raises():
 
         stream_wrapper = await wrapper.__aenter__()
         with pytest.raises(RuntimeError, match="manager failure"):
+            await wrapper.__aexit__(None, None, None)
+
+        assert stream_wrapper._self_failures == [manager_error]
+
+    asyncio.run(exercise())
+
+
+def test_async_manager_wrapper_finalizes_stream_when_exit_is_cancelled():
+    async def exercise():
+        manager_error = asyncio.CancelledError()
+        manager = _FakeAsyncManager(
+            _FakeAsyncStream(), exit_error=manager_error
+        )
+        wrapper = _TestAsyncManagerWrapper(manager, _FakeInvocation)
+
+        stream_wrapper = await wrapper.__aenter__()
+        with pytest.raises(asyncio.CancelledError):
             await wrapper.__aexit__(None, None, None)
 
         assert stream_wrapper._self_failures == [manager_error]


### PR DESCRIPTION
Fixes #646.

This widens telemetry-finalizing wrapper handlers from `Exception` to `BaseException` so cancellations such as `asyncio.CancelledError` fail and end invocations before being re-raised. It covers shared stream wrappers/managers plus OpenAI, Anthropic, Bedrock, Portkey, Qwen Agent, and Google GenAI hand-written wrapper paths.

Also updates instrumentation reviewer instructions to flag telemetry-finalizing `except Exception` handlers.

Known gaps: none.