### PR TITLE
Add Bedrock, dspy, LlamaIndex to release pipelines

### DIFF
--- a/.github/workflows/prepare-backport-patch.yml
+++ b/.github/workflows/prepare-backport-patch.yml
@@ -7,12 +7,16 @@ on:
         options:
         - opentelemetry-instrumentation-genai-agno
         - opentelemetry-instrumentation-genai-anthropic
+        - opentelemetry-instrumentation-genai-bedrock
+        - opentelemetry-instrumentation-genai-dspy
         - opentelemetry-instrumentation-google-genai
         - opentelemetry-instrumentation-genai-langchain
+        - opentelemetry-instrumentation-genai-llama-index
         - opentelemetry-instrumentation-genai-openai-agents
         - opentelemetry-instrumentation-genai-openai
         - opentelemetry-instrumentation-genai-portkey
         - opentelemetry-instrumentation-genai-qwen-agent
+        - opentelemetry-instrumentation-genai-smolagents
         - opentelemetry-util-genai
         description: 'Package to prepare for patch release'
         required: true

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -8,12 +8,16 @@ on:
         - ''
         - opentelemetry-instrumentation-genai-agno
         - opentelemetry-instrumentation-genai-anthropic
+        - opentelemetry-instrumentation-genai-bedrock
+        - opentelemetry-instrumentation-genai-dspy
         - opentelemetry-instrumentation-google-genai
         - opentelemetry-instrumentation-genai-langchain
+        - opentelemetry-instrumentation-genai-llama-index
         - opentelemetry-instrumentation-genai-openai-agents
         - opentelemetry-instrumentation-genai-openai
         - opentelemetry-instrumentation-genai-portkey
         - opentelemetry-instrumentation-genai-qwen-agent
+        - opentelemetry-instrumentation-genai-smolagents
         - opentelemetry-util-genai
         description: >
           Restrict to a single package. Leave empty to prepare every package

--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -7,8 +7,11 @@ on:
         options:
         - opentelemetry-instrumentation-genai-agno
         - opentelemetry-instrumentation-genai-anthropic
+        - opentelemetry-instrumentation-genai-bedrock
+        - opentelemetry-instrumentation-genai-dspy
         - opentelemetry-instrumentation-google-genai
         - opentelemetry-instrumentation-genai-langchain
+        - opentelemetry-instrumentation-genai-llama-index
         - opentelemetry-instrumentation-genai-openai-agents
         - opentelemetry-instrumentation-genai-openai
         - opentelemetry-instrumentation-genai-portkey

--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ All instrumentations use [opentelemetry-util-genai](./util/opentelemetry-util-ge
 
 | Instrumentation | Supported Package | Version | Status |
 | --------------- | ----------------- | ------- | ------ |
-| [opentelemetry-instrumentation-genai-bedrock](./instrumentation/opentelemetry-instrumentation-genai-bedrock) | boto3 >= 1.40.46, < 2 | 1.2b0.dev | skeleton |
+| [opentelemetry-instrumentation-genai-bedrock](./instrumentation/opentelemetry-instrumentation-genai-bedrock) | boto3 >= 1.40.46, < 2 | 1.2b0.dev | to be released |
 | [opentelemetry-instrumentation-genai-claude-agent-sdk](./instrumentation/opentelemetry-instrumentation-genai-claude-agent-sdk) | claude-agent-sdk >= 0.1.14, < 1 | 1.2b0.dev | skeleton |
 | [opentelemetry-instrumentation-genai-crewai](./instrumentation/opentelemetry-instrumentation-genai-crewai) | crewai >= 1.10.1, < 2 | 1.2b0.dev | skeleton |
-| [opentelemetry-instrumentation-genai-dspy](./instrumentation/opentelemetry-instrumentation-genai-dspy) | dspy >= 3.3.0, < 4 | 1.2b0.dev | skeleton |
-| [opentelemetry-instrumentation-genai-llama-index](./instrumentation/opentelemetry-instrumentation-genai-llama-index) | llama-index-core >= 0.14.19, < 1 | 1.2b0.dev | skeleton |
+| [opentelemetry-instrumentation-genai-dspy](./instrumentation/opentelemetry-instrumentation-genai-dspy) | dspy >= 3.3.0, < 4 | 1.2b0.dev | to be released |
+| [opentelemetry-instrumentation-genai-llama-index](./instrumentation/opentelemetry-instrumentation-genai-llama-index) | llama-index-core >= 0.14.19, < 1 | 1.2b0.dev | to be released |
 | [opentelemetry-instrumentation-genai-portkey](./instrumentation/opentelemetry-instrumentation-genai-portkey) | portkey-ai >= 1.0.0, < 3 | 1.2b0.dev | to be released |
 | [opentelemetry-instrumentation-genai-weaviate-client](./instrumentation/opentelemetry-instrumentation-genai-weaviate-client) | weaviate-client >= 3.0.0, <5.0.0 | 1.2b0.dev | skeleton |
 <!-- end -->

--- a/eachdist.ini
+++ b/eachdist.ini
@@ -18,8 +18,11 @@ packages=
 packages=
     opentelemetry-instrumentation-genai-agno
     opentelemetry-instrumentation-genai-anthropic
+    opentelemetry-instrumentation-genai-bedrock
+    opentelemetry-instrumentation-genai-dspy
     opentelemetry-instrumentation-google-genai
     opentelemetry-instrumentation-genai-langchain
+    opentelemetry-instrumentation-genai-llama-index
     opentelemetry-instrumentation-genai-openai
     opentelemetry-instrumentation-genai-openai-agents
     opentelemetry-instrumentation-genai-portkey


### PR DESCRIPTION
Adds `opentelemetry-instrumentation-genai-bedrock`, `opentelemetry-instrumentation-genai-dspy`, and `opentelemetry-instrumentation-genai-llama-index` to the release pipelines and `eachdist.ini`, and updates their status in the README to "to be released". Also adds `opentelemetry-instrumentation-genai-smolagents` to `prepare-release.yml` and `prepare-backport-patch.yml` options.

Bedrock, DSPy, and LlamaIndex packages contain real instrumentation code, but were still marked as skeletons and excluded from release workflows.