### PR TITLE
Rename the cache write usage attribute to gen_ai.usage.cache_write.input_tokens

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/conformance/inference.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/conformance/inference.py
@@ -16,7 +16,6 @@ from opentelemetry.sdk._logs import LoggerProvider
 from opentelemetry.sdk.metrics import MeterProvider
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.test_util_genai.conformance import (
-    ExpectedViolation,
     Scenario,
 )
 from opentelemetry.test_util_genai.instrumentor import instrument
@@ -27,12 +26,6 @@ class InferenceScenario(Scenario):
     expected_metrics = (
         "gen_ai.client.operation.duration",
         "gen_ai.client.token.usage",
-    )
-    expected_violations = (
-        ExpectedViolation(
-            advice_id="missing_attribute",
-            message_substring="gen_ai.usage.cache_creation.input_tokens",
-        ),
     )
 
     def run(

--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/conformance/inference_raw_response.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/conformance/inference_raw_response.py
@@ -23,7 +23,6 @@ from opentelemetry.sdk._logs import LoggerProvider
 from opentelemetry.sdk.metrics import MeterProvider
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.test_util_genai.conformance import (
-    ExpectedViolation,
     Scenario,
 )
 from opentelemetry.test_util_genai.instrumentor import instrument
@@ -40,12 +39,6 @@ class InferenceRawResponseScenario(Scenario):
     expected_metrics = (
         "gen_ai.client.operation.duration",
         "gen_ai.client.token.usage",
-    )
-    expected_violations = (
-        ExpectedViolation(
-            advice_id="missing_attribute",
-            message_substring="gen_ai.usage.cache_creation.input_tokens",
-        ),
     )
 
     def run(
@@ -89,12 +82,6 @@ class InferenceRawResponseStreamingScenario(Scenario):
         "gen_ai.client.token.usage",
         "gen_ai.client.operation.time_to_first_chunk",
         "gen_ai.client.operation.time_per_output_chunk",
-    )
-    expected_violations = (
-        ExpectedViolation(
-            advice_id="missing_attribute",
-            message_substring="gen_ai.usage.cache_creation.input_tokens",
-        ),
     )
 
     def run(

--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/conformance/inference_streaming.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/conformance/inference_streaming.py
@@ -22,7 +22,6 @@ from opentelemetry.sdk.metrics import MeterProvider
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.test.weaver_live_check import LiveCheckReport
 from opentelemetry.test_util_genai.conformance import (
-    ExpectedViolation,
     Scenario,
 )
 from opentelemetry.test_util_genai.instrumentor import instrument
@@ -35,12 +34,6 @@ class InferenceStreamingScenario(Scenario):
         "gen_ai.client.token.usage",
         "gen_ai.client.operation.time_to_first_chunk",
         "gen_ai.client.operation.time_per_output_chunk",
-    )
-    expected_violations = (
-        ExpectedViolation(
-            advice_id="missing_attribute",
-            message_substring="gen_ai.usage.cache_creation.input_tokens",
-        ),
     )
 
     def validate(self, report: LiveCheckReport) -> None:

--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/conformance/tool_calling.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/conformance/tool_calling.py
@@ -16,7 +16,6 @@ from opentelemetry.sdk._logs import LoggerProvider
 from opentelemetry.sdk.metrics import MeterProvider
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.test_util_genai.conformance import (
-    ExpectedViolation,
     Scenario,
 )
 from opentelemetry.test_util_genai.instrumentor import instrument
@@ -27,12 +26,6 @@ class ToolCallingScenario(Scenario):
     expected_metrics = (
         "gen_ai.client.operation.duration",
         "gen_ai.client.token.usage",
-    )
-    expected_violations = (
-        ExpectedViolation(
-            advice_id="missing_attribute",
-            message_substring="gen_ai.usage.cache_creation.input_tokens",
-        ),
     )
 
     def run(

--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/test_async_messages.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/test_async_messages.py
@@ -44,6 +44,12 @@ from opentelemetry.semconv._incubating.attributes import (
 )
 from opentelemetry.semconv._incubating.metrics import gen_ai_metrics
 
+# TODO: use the semconv constant once this attribute is released in
+# opentelemetry-semantic-conventions. Renamed from
+# gen_ai.usage.cache_creation.input_tokens in
+# https://github.com/open-telemetry/semantic-conventions-genai/pull/440.
+GEN_AI_USAGE_CACHE_WRITE_INPUT_TOKENS = "gen_ai.usage.cache_write.input_tokens"
+
 _create_params = set(inspect.signature(_AsyncMessages.create).parameters)
 _has_tools_param = "tools" in _create_params
 _has_thinking_param = "thinking" in _create_params
@@ -878,10 +884,7 @@ async def test_async_messages_create_aggregates_cache_tokens(
     assert len(spans) == 1
     span = spans[0]
 
-    assert (
-        GenAIAttributes.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS
-        in span.attributes
-    )
+    assert GEN_AI_USAGE_CACHE_WRITE_INPUT_TOKENS in span.attributes
     assert (
         GenAIAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS in span.attributes
     )
@@ -895,9 +898,7 @@ async def test_async_messages_create_aggregates_cache_tokens(
     cache_creation = getattr(response.usage, "cache_creation_input_tokens", 0)
     cache_read = getattr(response.usage, "cache_read_input_tokens", 0)
     assert (
-        span.attributes[
-            GenAIAttributes.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS
-        ]
+        span.attributes[GEN_AI_USAGE_CACHE_WRITE_INPUT_TOKENS]
         == cache_creation
     )
     assert (
@@ -942,10 +943,7 @@ async def test_async_messages_create_streaming_aggregates_cache_tokens(
     assert len(spans) == 1
     span = spans[0]
 
-    assert (
-        GenAIAttributes.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS
-        in span.attributes
-    )
+    assert GEN_AI_USAGE_CACHE_WRITE_INPUT_TOKENS in span.attributes
     assert (
         GenAIAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS in span.attributes
     )
@@ -958,9 +956,7 @@ async def test_async_messages_create_streaming_aggregates_cache_tokens(
         == output_tokens
     )
     assert (
-        span.attributes[
-            GenAIAttributes.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS
-        ]
+        span.attributes[GEN_AI_USAGE_CACHE_WRITE_INPUT_TOKENS]
         == cache_creation
     )
     assert (

--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/test_sync_messages.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/test_sync_messages.py
@@ -53,6 +53,12 @@ from opentelemetry.semconv._incubating.attributes import (
 )
 from opentelemetry.semconv._incubating.metrics import gen_ai_metrics
 
+# TODO: use the semconv constant once this attribute is released in
+# opentelemetry-semantic-conventions. Renamed from
+# gen_ai.usage.cache_creation.input_tokens in
+# https://github.com/open-telemetry/semantic-conventions-genai/pull/440.
+GEN_AI_USAGE_CACHE_WRITE_INPUT_TOKENS = "gen_ai.usage.cache_write.input_tokens"
+
 # Detect whether the installed anthropic SDK supports tools / thinking params.
 # Older SDK versions (e.g. 0.16.0) do not accept these keyword arguments.
 _create_params = set(inspect.signature(_Messages.create).parameters)
@@ -1217,10 +1223,7 @@ def test_sync_messages_create_aggregates_cache_tokens(
     assert len(spans) == 1
     span = spans[0]
 
-    assert (
-        GenAIAttributes.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS
-        in span.attributes
-    )
+    assert GEN_AI_USAGE_CACHE_WRITE_INPUT_TOKENS in span.attributes
     assert (
         GenAIAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS in span.attributes
     )
@@ -1234,9 +1237,7 @@ def test_sync_messages_create_aggregates_cache_tokens(
     cache_creation = getattr(response.usage, "cache_creation_input_tokens", 0)
     cache_read = getattr(response.usage, "cache_read_input_tokens", 0)
     assert (
-        span.attributes[
-            GenAIAttributes.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS
-        ]
+        span.attributes[GEN_AI_USAGE_CACHE_WRITE_INPUT_TOKENS]
         == cache_creation
     )
     assert (
@@ -1281,10 +1282,7 @@ def test_sync_messages_create_streaming_aggregates_cache_tokens(
     assert len(spans) == 1
     span = spans[0]
 
-    assert (
-        GenAIAttributes.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS
-        in span.attributes
-    )
+    assert GEN_AI_USAGE_CACHE_WRITE_INPUT_TOKENS in span.attributes
     assert (
         GenAIAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS in span.attributes
     )
@@ -1297,9 +1295,7 @@ def test_sync_messages_create_streaming_aggregates_cache_tokens(
         == output_tokens
     )
     assert (
-        span.attributes[
-            GenAIAttributes.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS
-        ]
+        span.attributes[GEN_AI_USAGE_CACHE_WRITE_INPUT_TOKENS]
         == cache_creation
     )
     assert (

--- a/instrumentation/opentelemetry-instrumentation-genai-bedrock/tests/test_invoke_model.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-bedrock/tests/test_invoke_model.py
@@ -32,6 +32,12 @@ from opentelemetry.semconv.attributes import (
 from opentelemetry.trace import StatusCode
 from opentelemetry.util.genai.handler import TelemetryHandler
 
+# TODO: use the semconv constant once this attribute is released in
+# opentelemetry-semantic-conventions. Renamed from
+# gen_ai.usage.cache_creation.input_tokens in
+# https://github.com/open-telemetry/semantic-conventions-genai/pull/440.
+GEN_AI_USAGE_CACHE_WRITE_INPUT_TOKENS = "gen_ai.usage.cache_write.input_tokens"
+
 
 def test_invoke_model_anthropic_messages(
     bedrock_client,
@@ -115,12 +121,7 @@ def test_invoke_model_anthropic_messages(
     )
     assert span.attributes[GenAIAttributes.GEN_AI_USAGE_INPUT_TOKENS] == 12
     assert span.attributes[GenAIAttributes.GEN_AI_USAGE_OUTPUT_TOKENS] == 8
-    assert (
-        span.attributes[
-            GenAIAttributes.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS
-        ]
-        == 2
-    )
+    assert span.attributes[GEN_AI_USAGE_CACHE_WRITE_INPUT_TOKENS] == 2
     assert (
         span.attributes[GenAIAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS]
         == 4

--- a/instrumentation/opentelemetry-instrumentation-genai-bedrock/tests/test_invoke_model_stream.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-bedrock/tests/test_invoke_model_stream.py
@@ -29,6 +29,12 @@ from opentelemetry.semconv.attributes import (
 from opentelemetry.trace import StatusCode
 from opentelemetry.util.genai.handler import TelemetryHandler
 
+# TODO: use the semconv constant once this attribute is released in
+# opentelemetry-semantic-conventions. Renamed from
+# gen_ai.usage.cache_creation.input_tokens in
+# https://github.com/open-telemetry/semantic-conventions-genai/pull/440.
+GEN_AI_USAGE_CACHE_WRITE_INPUT_TOKENS = "gen_ai.usage.cache_write.input_tokens"
+
 
 def test_stream_wrapper_anthropic_messages(
     tracer_provider,
@@ -461,12 +467,7 @@ def test_stream_wrapper_anthropic_with_cache_tokens(
         span.attributes[GenAIAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS]
         == 30
     )
-    assert (
-        span.attributes[
-            GenAIAttributes.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS
-        ]
-        == 10
-    )
+    assert span.attributes[GEN_AI_USAGE_CACHE_WRITE_INPUT_TOKENS] == 10
     assert span.attributes[GenAIAttributes.GEN_AI_RESPONSE_FINISH_REASONS] == (
         "stop",
     )

--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/tests/test_llm_call.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/tests/test_llm_call.py
@@ -40,6 +40,12 @@ from opentelemetry.semconv.attributes import error_attributes
 from opentelemetry.test_util_genai.instrumentor import instrument
 from opentelemetry.util.genai.types import TextPart
 
+# TODO: use the semconv constant once this attribute is released in
+# opentelemetry-semantic-conventions. Renamed from
+# gen_ai.usage.cache_creation.input_tokens in
+# https://github.com/open-telemetry/semantic-conventions-genai/pull/440.
+GEN_AI_USAGE_CACHE_WRITE_INPUT_TOKENS = "gen_ai.usage.cache_write.input_tokens"
+
 
 def _openai_cassette_name(model, base: str) -> str:
     # Newer langchain-openai renders ``max_completion_tokens`` on the request
@@ -1378,12 +1384,7 @@ def test_chat_anthropic_claude_sonnet_cache_token_details(
     assert len(spans) == 1
     span = spans[0]
 
-    assert (
-        span.attributes.get(
-            gen_ai_attributes.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS
-        )
-        == 5
-    )
+    assert span.attributes.get(GEN_AI_USAGE_CACHE_WRITE_INPUT_TOKENS) == 5
 
     assert (
         span.attributes.get(

--- a/instrumentation/opentelemetry-instrumentation-genai-openai/tests/test_utils.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-openai/tests/test_utils.py
@@ -26,9 +26,7 @@ FETCH_RESPONSE_OPERATION_NAME = "fetch_response"
 # in https://github.com/open-telemetry/semantic-conventions-genai/pull/353.
 GEN_AI_REQUEST_STREAM_CURSOR = "gen_ai.request.stream_cursor"
 GEN_AI_RESPONSE_STATUS = "gen_ai.response.status"
-GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS = (
-    "gen_ai.usage.cache_creation.input_tokens"
-)
+GEN_AI_USAGE_CACHE_WRITE_INPUT_TOKENS = "gen_ai.usage.cache_write.input_tokens"
 GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS = "gen_ai.usage.cache_read.input_tokens"
 USER_ONLY_PROMPT = [{"role": "user", "content": "Say this is a test"}]
 USER_ONLY_EXPECTED_INPUT_MESSAGES = [
@@ -370,10 +368,10 @@ def assert_cache_attributes(span, usage):
 
     cache_creation = getattr(details, "cache_creation_input_tokens", None)
     if cache_creation is None:
-        assert GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS not in span.attributes
+        assert GEN_AI_USAGE_CACHE_WRITE_INPUT_TOKENS not in span.attributes
     else:
         assert (
-            span.attributes[GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS]
+            span.attributes[GEN_AI_USAGE_CACHE_WRITE_INPUT_TOKENS]
             == cache_creation
         )
 

--- a/util/opentelemetry-util-genai/.changelog/660.changed
+++ b/util/opentelemetry-util-genai/.changelog/660.changed
@@ -1,0 +1,1 @@
+report cache write input tokens as `gen_ai.usage.cache_write.input_tokens`, renamed from `gen_ai.usage.cache_creation.input_tokens` in the GenAI semantic conventions

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_agent_invocation.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_agent_invocation.py
@@ -10,6 +10,7 @@ from opentelemetry.semconv._incubating.attributes import (
 from opentelemetry.semconv.attributes import server_attributes
 from opentelemetry.trace import SpanKind, Tracer
 from opentelemetry.util.genai._invocation import (
+    GEN_AI_USAGE_CACHE_WRITE_INPUT_TOKENS,
     Error,
     GenAIInvocation,
     get_content_attributes,
@@ -161,7 +162,7 @@ class AgentInvocation(GenAIInvocation):
             (GenAI.GEN_AI_USAGE_INPUT_TOKENS, self.input_tokens),
             (GenAI.GEN_AI_USAGE_OUTPUT_TOKENS, self.output_tokens),
             (
-                GenAI.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS,
+                GEN_AI_USAGE_CACHE_WRITE_INPUT_TOKENS,
                 self.cache_creation_input_tokens,
             ),
             (

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_inference_invocation.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_inference_invocation.py
@@ -12,6 +12,7 @@ from opentelemetry.semconv._incubating.attributes import (
 from opentelemetry.semconv.attributes import server_attributes
 from opentelemetry.trace import INVALID_SPAN, Span, SpanKind, Tracer
 from opentelemetry.util.genai._invocation import (
+    GEN_AI_USAGE_CACHE_WRITE_INPUT_TOKENS,
     Error,
     GenAIInvocation,
     get_content_attributes,
@@ -174,7 +175,7 @@ class InferenceInvocation(GenAIInvocation):
             (GenAI.GEN_AI_REQUEST_CHOICE_COUNT, self.request_choice_count),
             (GenAI.GEN_AI_OUTPUT_TYPE, self.output_type),
             (
-                GenAI.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS,
+                GEN_AI_USAGE_CACHE_WRITE_INPUT_TOKENS,
                 self.cache_creation_input_tokens,
             ),
             (

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_invocation.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_invocation.py
@@ -10,7 +10,7 @@ from contextlib import AbstractContextManager
 from contextvars import Token
 from dataclasses import asdict
 from types import TracebackType
-from typing import TYPE_CHECKING, Any, TypeAlias, cast
+from typing import TYPE_CHECKING, Any, Final, TypeAlias, cast
 
 from typing_extensions import Self
 
@@ -42,6 +42,13 @@ from opentelemetry.util.genai.utils import (
     get_content_capturing_mode,
 )
 from opentelemetry.util.types import AttributeValue
+
+# TODO: Migrate to a gen_ai_attributes constant once available in the semconv
+# package. Renamed from gen_ai.usage.cache_creation.input_tokens in
+# https://github.com/open-telemetry/semantic-conventions-genai/pull/440.
+GEN_AI_USAGE_CACHE_WRITE_INPUT_TOKENS: Final = (
+    "gen_ai.usage.cache_write.input_tokens"
+)
 
 if TYPE_CHECKING:
     from opentelemetry.util.genai.metrics import InvocationMetricsRecorder

--- a/util/opentelemetry-util-genai/tests/test_handler_agent.py
+++ b/util/opentelemetry-util-genai/tests/test_handler_agent.py
@@ -32,6 +32,12 @@ from opentelemetry.util.genai.types import (
     TextPart,
 )
 
+# TODO: use the semconv constant once this attribute is released in
+# opentelemetry-semantic-conventions. Renamed from
+# gen_ai.usage.cache_creation.input_tokens in
+# https://github.com/open-telemetry/semantic-conventions-genai/pull/440.
+GEN_AI_USAGE_CACHE_WRITE_INPUT_TOKENS = "gen_ai.usage.cache_write.input_tokens"
+
 
 class TestLocalAgentInvocation(unittest.TestCase):  # pylint: disable=too-many-public-methods
     def setUp(self):
@@ -162,7 +168,7 @@ class TestLocalAgentInvocation(unittest.TestCase):  # pylint: disable=too-many-p
 
         attrs = self.span_exporter.get_finished_spans()[0].attributes
         assert attrs[GenAI.GEN_AI_USAGE_INPUT_TOKENS] == 100
-        assert attrs[GenAI.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS] == 25
+        assert attrs[GEN_AI_USAGE_CACHE_WRITE_INPUT_TOKENS] == 25
         assert attrs[GenAI.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS] == 50
 
     def test_fail_sets_error_status(self):

--- a/util/opentelemetry-util-genai/tests/test_utils.py
+++ b/util/opentelemetry-util-genai/tests/test_utils.py
@@ -64,6 +64,12 @@ from opentelemetry.util.genai.utils import (
     should_emit_event,
 )
 
+# TODO: use the semconv constant once this attribute is released in
+# opentelemetry-semantic-conventions. Renamed from
+# gen_ai.usage.cache_creation.input_tokens in
+# https://github.com/open-telemetry/semantic-conventions-genai/pull/440.
+GEN_AI_USAGE_CACHE_WRITE_INPUT_TOKENS = "gen_ai.usage.cache_write.input_tokens"
+
 
 def _create_input_message(
     content: str = "hello world", role: str = "Human"
@@ -593,6 +599,34 @@ class TestTelemetryHandler(unittest.TestCase):
 
         attrs = self.span_exporter.get_finished_spans()[0].attributes
         assert GenAI.GEN_AI_CONVERSATION_ID not in attrs
+
+    def test_inference_cache_token_attributes(self):
+        invocation = self.telemetry_handler.inference(
+            "test-provider", request_model="test-model"
+        )
+        invocation.input_tokens = 100
+        invocation.cache_creation_input_tokens = 25
+        invocation.cache_read_input_tokens = 50
+        invocation.stop()
+
+        attrs = self.span_exporter.get_finished_spans()[0].attributes
+        assert attrs[GenAI.GEN_AI_USAGE_INPUT_TOKENS] == 100
+        assert attrs[GEN_AI_USAGE_CACHE_WRITE_INPUT_TOKENS] == 25
+        assert isinstance(attrs[GEN_AI_USAGE_CACHE_WRITE_INPUT_TOKENS], int)
+        assert attrs[GenAI.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS] == 50
+        assert isinstance(
+            attrs[GenAI.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS], int
+        )
+
+    def test_inference_omits_cache_token_attributes_when_not_set(self):
+        invocation = self.telemetry_handler.inference(
+            "test-provider", request_model="test-model"
+        )
+        invocation.stop()
+
+        attrs = self.span_exporter.get_finished_spans()[0].attributes
+        assert GEN_AI_USAGE_CACHE_WRITE_INPUT_TOKENS not in attrs
+        assert GenAI.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS not in attrs
 
     def test_start_inference_sampler_can_drop_span_based_on_attributes(self):
         """Verify that a sampler can reject spans based on attributes passed at creation time."""


### PR DESCRIPTION
# Description

`gen_ai.usage.cache_creation.input_tokens` was renamed to `gen_ai.usage.cache_write.input_tokens` in open-telemetry/semantic-conventions-genai#440, which is inside the registry SHA this repo already pins as `SEMCONV_GENAI_REF`. Inference and agent spans still emit the old name, and the anthropic conformance scenarios carry a declared `expected_violations` entry recording that gap.

This emits the new name and drops those declarations. `opentelemetry-semantic-conventions` does not export a constant for it yet, so the name is defined locally with a TODO, following `_fetch_response_invocation.py`.

Fixes #554

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How has this been tested?

Adds util coverage for the cache attributes on the inference span, which had none. The emitted name changes for anthropic, openai, bedrock and langchain, so their assertions move with it. Happy to split further if you would rather land the util rename separately.

- [x] `util-genai`: 400 passed
- [x] `anthropic` 178 (latest) / 171 (oldest), `openai` 271, `bedrock` 56, `langchain` 384
- [x] conformance: `anthropic` 5, `bedrock` 5, `langchain` 12, `openai` 9
- [x] `tox -e precommit` and `tox -e typecheck` clean

# Checklist

- [x] Followed the style guidelines of this project
- [x] Changelog updated if the change requires an entry
- [x] Unit tests updated
