### PR TITLE
genai-openai: report gen_ai.usage.cache_read.input_tokens on chat completion spans

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-genai-openai/.changelog/670.fixed
+++ b/instrumentation/opentelemetry-instrumentation-genai-openai/.changelog/670.fixed
@@ -1,0 +1,4 @@
+Report `gen_ai.usage.cache_read.input_tokens` on chat completion spans from
+`usage.prompt_tokens_details.cached_tokens`, for both streaming and
+non-streaming `chat.completions.create` calls, matching what the Responses
+API instrumentation already emits.

--- a/instrumentation/opentelemetry-instrumentation-genai-openai/src/opentelemetry/instrumentation/genai/openai/chat_wrappers.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-openai/src/opentelemetry/instrumentation/genai/openai/chat_wrappers.py
@@ -40,6 +40,7 @@ class _ChatStreamMixin:
     _self_service_tier: str | None
     _self_prompt_tokens: int | None
     _self_completion_tokens: int | None
+    _self_cache_read_input_tokens: int | None
 
     def _set_response_model(self, chunk: ChatCompletionChunk) -> None:
         # Set eagerly so the per-chunk streaming timing metrics carry
@@ -97,6 +98,11 @@ class _ChatStreamMixin:
         if usage:
             self._self_completion_tokens = usage.completion_tokens
             self._self_prompt_tokens = usage.prompt_tokens
+            prompt_tokens_details = getattr(usage, "prompt_tokens_details", None)
+            if prompt_tokens_details is not None:
+                self._self_cache_read_input_tokens = getattr(
+                    prompt_tokens_details, "cached_tokens", None
+                )
 
     def _process_chunk(self, chunk: ChatCompletionChunk) -> None:
         if not isinstance(chunk, ChatCompletionChunk):
@@ -158,6 +164,7 @@ class _ChatStreamMixin:
         self._self_invocation.response_id = self._self_response_id
         self._self_invocation.input_tokens = self._self_prompt_tokens
         self._self_invocation.output_tokens = self._self_completion_tokens
+        self._self_invocation.cache_read_input_tokens = self._self_cache_read_input_tokens
         finish_reasons = [
             choice.finish_reason
             for choice in self._self_choice_buffers
@@ -198,6 +205,7 @@ class ChatStreamWrapper(
         self._self_service_tier = None
         self._self_prompt_tokens = None
         self._self_completion_tokens = None
+        self._self_cache_read_input_tokens = None
 
 
 class AsyncChatStreamWrapper(
@@ -218,6 +226,7 @@ class AsyncChatStreamWrapper(
         self._self_service_tier = None
         self._self_prompt_tokens = None
         self._self_completion_tokens = None
+        self._self_cache_read_input_tokens = None
 
 
 __all__ = [

--- a/instrumentation/opentelemetry-instrumentation-genai-openai/src/opentelemetry/instrumentation/genai/openai/patch.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-openai/src/opentelemetry/instrumentation/genai/openai/patch.py
@@ -200,6 +200,11 @@ def _set_response_properties(
     if getattr(result, "usage", None):
         chat_invocation.input_tokens = result.usage.prompt_tokens
         chat_invocation.output_tokens = result.usage.completion_tokens
+        prompt_tokens_details = getattr(result.usage, "prompt_tokens_details", None)
+        if prompt_tokens_details is not None:
+            chat_invocation.cache_read_input_tokens = getattr(
+                prompt_tokens_details, "cached_tokens", None
+            )
 
     if getattr(result, "system_fingerprint", None):
         chat_invocation.attributes.update(

--- a/instrumentation/opentelemetry-instrumentation-genai-openai/tests/cassettes/test_chat_completion_reports_cached_tokens.yaml
+++ b/instrumentation/opentelemetry-instrumentation-genai-openai/tests/cassettes/test_chat_completion_reports_cached_tokens.yaml
@@ -1,0 +1,134 @@
+interactions:
+- request:
+    body: |-
+      {
+        "messages": [
+          {
+            "role": "user",
+            "content": "Say this is a test"
+          }
+        ],
+        "model": "gpt-4o-mini",
+        "stream": false
+      }
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - Bearer test_openai_api_key
+      connection:
+      - keep-alive
+      content-length:
+      - '106'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      user-agent:
+      - OpenAI/Python 1.54.3
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 1.54.3
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.12.6
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: |-
+        {
+          "id": "chatcmpl-ASYMQRl3A3DXL9FWCK9tnGRcKIO7q",
+          "object": "chat.completion",
+          "created": 1731368630,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "role": "assistant",
+                "content": "This is a test.",
+                "refusal": null
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 12,
+            "completion_tokens": 5,
+            "total_tokens": 17,
+            "prompt_tokens_details": {
+              "cached_tokens": 9,
+              "audio_tokens": 0
+            },
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "audio_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0
+            }
+          },
+          "system_fingerprint": "fp_0ba0d124f1"
+        }
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 8e122593ff368bc8-SIN
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 11 Nov 2024 23:43:50 GMT
+      Server:
+      - cloudflare
+      Set-Cookie: test_set_cookie
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      access-control-expose-headers:
+      - X-Request-ID
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-length:
+      - '765'
+      openai-organization: test_openai_org_id
+      openai-processing-ms:
+      - '287'
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      x-ratelimit-limit-requests:
+      - '10000'
+      x-ratelimit-limit-tokens:
+      - '200000'
+      x-ratelimit-remaining-requests:
+      - '9999'
+      x-ratelimit-remaining-tokens:
+      - '199977'
+      x-ratelimit-reset-requests:
+      - 8.64s
+      x-ratelimit-reset-tokens:
+      - 6ms
+      x-request-id:
+      - req_58cff97afd0e7c0bba910ccf0b044a6f
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/instrumentation/opentelemetry-instrumentation-genai-openai/tests/cassettes/test_chat_completion_streaming_reports_cached_tokens.yaml
+++ b/instrumentation/opentelemetry-instrumentation-genai-openai/tests/cassettes/test_chat_completion_streaming_reports_cached_tokens.yaml
@@ -1,0 +1,143 @@
+interactions:
+- request:
+    body: |-
+      {
+        "messages": [
+          {
+            "role": "user",
+            "content": "Say this is a test"
+          }
+        ],
+        "model": "gpt-4o-mini",
+        "stream": true,
+        "stream_options": {
+          "include_usage": true
+        }
+      }
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '148'
+      Content-Type:
+      - application/json
+      Host:
+      - api.openai.com
+      User-Agent:
+      - AsyncOpenAI/Python 1.109.1
+      X-Stainless-Arch:
+      - x64
+      X-Stainless-Async:
+      - async:asyncio
+      X-Stainless-Lang:
+      - python
+      X-Stainless-OS:
+      - Linux
+      X-Stainless-Package-Version:
+      - 1.109.1
+      X-Stainless-Raw-Response:
+      - 'true'
+      X-Stainless-Runtime:
+      - CPython
+      X-Stainless-Runtime-Version:
+      - 3.12.12
+      authorization:
+      - Bearer test_openai_api_key
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: |+
+        data: {"id":"chatcmpl-CnMM0oFYQitzT43PYAvCrmNt6GIKs","object":"chat.completion.chunk","created":1765880036,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_644f11dd4d","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"v3JkrR4kf"}
+
+        data: {"id":"chatcmpl-CnMM0oFYQitzT43PYAvCrmNt6GIKs","object":"chat.completion.chunk","created":1765880036,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_644f11dd4d","choices":[{"index":0,"delta":{"content":"This"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"c2Yj6Tq"}
+
+        data: {"id":"chatcmpl-CnMM0oFYQitzT43PYAvCrmNt6GIKs","object":"chat.completion.chunk","created":1765880036,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_644f11dd4d","choices":[{"index":0,"delta":{"content":" is"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"vYP94Gjb"}
+
+        data: {"id":"chatcmpl-CnMM0oFYQitzT43PYAvCrmNt6GIKs","object":"chat.completion.chunk","created":1765880036,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_644f11dd4d","choices":[{"index":0,"delta":{"content":" a"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"axQhTg4rR"}
+
+        data: {"id":"chatcmpl-CnMM0oFYQitzT43PYAvCrmNt6GIKs","object":"chat.completion.chunk","created":1765880036,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_644f11dd4d","choices":[{"index":0,"delta":{"content":" test"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"Sd4wYC"}
+
+        data: {"id":"chatcmpl-CnMM0oFYQitzT43PYAvCrmNt6GIKs","object":"chat.completion.chunk","created":1765880036,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_644f11dd4d","choices":[{"index":0,"delta":{"content":"."},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"ZufRh78gtk"}
+
+        data: {"id":"chatcmpl-CnMM0oFYQitzT43PYAvCrmNt6GIKs","object":"chat.completion.chunk","created":1765880036,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_644f11dd4d","choices":[{"index":0,"delta":{"content":" How"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"Si8PiPK"}
+
+        data: {"id":"chatcmpl-CnMM0oFYQitzT43PYAvCrmNt6GIKs","object":"chat.completion.chunk","created":1765880036,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_644f11dd4d","choices":[{"index":0,"delta":{"content":" can"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"DtALgOW"}
+
+        data: {"id":"chatcmpl-CnMM0oFYQitzT43PYAvCrmNt6GIKs","object":"chat.completion.chunk","created":1765880036,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_644f11dd4d","choices":[{"index":0,"delta":{"content":" I"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"xYwawpnRk"}
+
+        data: {"id":"chatcmpl-CnMM0oFYQitzT43PYAvCrmNt6GIKs","object":"chat.completion.chunk","created":1765880036,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_644f11dd4d","choices":[{"index":0,"delta":{"content":" assist"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"Swpx"}
+
+        data: {"id":"chatcmpl-CnMM0oFYQitzT43PYAvCrmNt6GIKs","object":"chat.completion.chunk","created":1765880036,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_644f11dd4d","choices":[{"index":0,"delta":{"content":" you"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"L6Pd0pV"}
+
+        data: {"id":"chatcmpl-CnMM0oFYQitzT43PYAvCrmNt6GIKs","object":"chat.completion.chunk","created":1765880036,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_644f11dd4d","choices":[{"index":0,"delta":{"content":" today"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"Viytd"}
+
+        data: {"id":"chatcmpl-CnMM0oFYQitzT43PYAvCrmNt6GIKs","object":"chat.completion.chunk","created":1765880036,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_644f11dd4d","choices":[{"index":0,"delta":{"content":"?"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"LqmsdvgjP8"}
+
+        data: {"id":"chatcmpl-CnMM0oFYQitzT43PYAvCrmNt6GIKs","object":"chat.completion.chunk","created":1765880036,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_644f11dd4d","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"usage":null,"obfuscation":"vbpp9"}
+
+        data: {"id":"chatcmpl-CnMM0oFYQitzT43PYAvCrmNt6GIKs","object":"chat.completion.chunk","created":1765880036,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_644f11dd4d","choices":[],"usage":{"prompt_tokens":12,"completion_tokens":12,"total_tokens":24,"prompt_tokens_details":{"cached_tokens":7,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}},"obfuscation":"xEbQODa0Ga"}
+
+        data: [DONE]
+
+    headers:
+      CF-RAY:
+      - 9aed6932dfb8ed9e-MXP
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Tue, 16 Dec 2025 10:13:56 GMT
+      Server:
+      - cloudflare
+      Set-Cookie: test_set_cookie
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      access-control-expose-headers:
+      - X-Request-ID
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      openai-organization: test_openai_org_id
+      openai-processing-ms:
+      - '228'
+      openai-project:
+      - test_openai_project_id
+      openai-version:
+      - '2020-10-01'
+      x-envoy-upstream-service-time:
+      - '241'
+      x-openai-proxy-wasm:
+      - v0.1
+      x-ratelimit-limit-requests:
+      - '10000'
+      x-ratelimit-limit-tokens:
+      - '10000000'
+      x-ratelimit-remaining-requests:
+      - '9999'
+      x-ratelimit-remaining-tokens:
+      - '9999993'
+      x-ratelimit-reset-requests:
+      - 6ms
+      x-ratelimit-reset-tokens:
+      - 0s
+      x-request-id:
+      - req_279d1848f0cf450dbffc9d7776f157f7
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/instrumentation/opentelemetry-instrumentation-genai-openai/tests/test_chat_completions.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-openai/tests/test_chat_completions.py
@@ -1811,3 +1811,70 @@ def chat_completion_multiple_tools_streaming(
 
 def assert_no_invalid_type_warning(caplog):
     assert "Invalid type" not in caplog.text
+
+
+def test_chat_completion_reports_cached_tokens(
+    span_exporter, log_exporter, openai_client, instrument_no_content, vcr
+):
+    latest_experimental_enabled = is_experimental_mode()
+    with vcr.use_cassette("test_chat_completion_reports_cached_tokens.yaml"):
+        response = openai_client.chat.completions.create(
+            messages=USER_ONLY_PROMPT, model=DEFAULT_MODEL, stream=False
+        )
+
+    spans = span_exporter.get_finished_spans()
+    assert_all_attributes(
+        spans[0],
+        DEFAULT_MODEL,
+        latest_experimental_enabled,
+        response.id,
+        response.model,
+        response.usage.prompt_tokens,
+        response.usage.completion_tokens,
+    )
+
+    assert response.usage.prompt_tokens_details.cached_tokens == 9
+    assert (
+        spans[0].attributes["gen_ai.usage.cache_read.input_tokens"]
+        == response.usage.prompt_tokens_details.cached_tokens
+    )
+
+
+def test_chat_completion_streaming_reports_cached_tokens(
+    span_exporter, log_exporter, openai_client, instrument_no_content, vcr
+):
+    latest_experimental_enabled = is_experimental_mode()
+    with vcr.use_cassette("test_chat_completion_streaming_reports_cached_tokens.yaml"):
+        response = openai_client.chat.completions.create(
+            messages=USER_ONLY_PROMPT,
+            model=DEFAULT_MODEL,
+            stream=True,
+            stream_options={"include_usage": True},
+        )
+
+        stream_usage = None
+        stream_usage_id = None
+        stream_usage_model = None
+        for chunk in response:
+            if getattr(chunk, "usage", None):
+                stream_usage = chunk.usage
+                stream_usage_id = chunk.id
+                stream_usage_model = chunk.model
+
+    spans = span_exporter.get_finished_spans()
+    assert_all_attributes(
+        spans[0],
+        DEFAULT_MODEL,
+        latest_experimental_enabled,
+        stream_usage_id,
+        stream_usage_model,
+        stream_usage.prompt_tokens,
+        stream_usage.completion_tokens,
+        response_service_tier="default",
+    )
+
+    assert stream_usage.prompt_tokens_details.cached_tokens == 7
+    assert (
+        spans[0].attributes["gen_ai.usage.cache_read.input_tokens"]
+        == stream_usage.prompt_tokens_details.cached_tokens
+    )


### PR DESCRIPTION
## Description

The chat completions path of `opentelemetry-instrumentation-genai-openai` drops
the cached-token count that OpenAI reports in `usage.prompt_tokens_details.cached_tokens`,
so `gen_ai.usage.cache_read.input_tokens` is never emitted for
`chat.completions.create` — neither streaming nor non-streaming — even when the
API response contains it.

The Responses API path in the same package already maps this field
(`response_extractors.py:592-602` reads `input_tokens_details`), so today two
calls that hit the same prompt cache produce inconsistent telemetry depending on
which API surface they used. This also matches the Bedrock gap tracked in
opentelemetry-python-contrib#4614 for a different instrumentation.

Per the GenAI semantic conventions, `gen_ai.usage.cache_read.input_tokens` is
"The number of input tokens served from a provider-managed cache" and its value
SHOULD be included in `gen_ai.usage.input_tokens` — which holds here, since
OpenAI's `prompt_tokens` already includes cached tokens. The fix therefore only
adds the cache breakdown attribute; `gen_ai.usage.input_tokens` is unchanged.

This PR:

- `_set_chat_completion_response_properties` (`patch.py`): also read
  `usage.prompt_tokens_details.cached_tokens` (guarded with `getattr` since
  `prompt_tokens_details` is optional on some SDK versions) and set it on the
  invocation as `cache_read_input_tokens`.
- `_ChatStreamMixin` (`chat_wrappers.py`): capture the same field from the
  final usage chunk and apply it to the invocation at stream cleanup.

Verified against commit ea7fdf6d8b12c3f6b43531c697ad0b84337f3396.

## Testing

Added two VCR-based tests with synthetic cassettes derived from the existing
ones (only `cached_tokens` changed to a non-zero value):

- `test_chat_completion_reports_cached_tokens` (non-streaming, cached_tokens=9)
- `test_chat_completion_streaming_reports_cached_tokens` (streaming with
  `include_usage`, cached_tokens=7)

Before this change both tests fail (`gen_ai.usage.cache_read.input_tokens`
missing from span attributes); after the change both pass:

```
$ pytest tests/test_chat_completions.py -k cached_tokens -q
2 passed, 31 deselected
```

Example span attributes after the fix (streaming):
`gen_ai.usage.input_tokens: 12, gen_ai.usage.output_tokens: 12,
gen_ai.usage.cache_read.input_tokens: 7`
---

<sub>Repro fixtures: [AgentMeasure conformance pack](https://github.com/roy-tong/AgentMeasure/tree/main/conformance/pack) — plain JSONL + expected totals, no runtime install. Found during an [open ecosystem audit](https://github.com/roy-tong/AgentMeasure/blob/main/campaigns/measurement-casebook.md#ecosystem-audit-33-verified-usage-accounting-findings-2026-09-0607) of usage-accounting tools.</sub>
