### PR TITLE
feat(langchain): capture document relevance score on retrieval spans

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/.changelog/670.added
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/.changelog/670.added
@@ -1,0 +1,1 @@
+Capture document relevance score on retrieval spans per OpenTelemetry GenAI semantic conventions.

--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/src/opentelemetry/instrumentation/genai/langchain/callback_handler.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/src/opentelemetry/instrumentation/genai/langchain/callback_handler.py
@@ -92,21 +92,33 @@ def _extract_document_score(doc: Any) -> float | int | None:
         doc_map = cast(Mapping[str, Any], doc)
         score = doc_map.get("score")
         if score is None:
+            score = doc_map.get("relevance_score")
+        if score is None:
             metadata = doc_map.get("metadata")
             if isinstance(metadata, Mapping):
                 meta_map = cast(Mapping[str, Any], metadata)
                 score = meta_map.get("score")
+                if score is None:
+                    score = meta_map.get("relevance_score")
             elif metadata is not None:
                 score = getattr(metadata, "score", None)
+                if score is None:
+                    score = getattr(metadata, "relevance_score", None)
     else:
         score = getattr(doc, "score", None)
+        if score is None:
+            score = getattr(doc, "relevance_score", None)
         if score is None:
             metadata = getattr(doc, "metadata", None)
             if isinstance(metadata, Mapping):
                 meta_map = cast(Mapping[str, Any], metadata)
                 score = meta_map.get("score")
+                if score is None:
+                    score = meta_map.get("relevance_score")
             elif metadata is not None:
                 score = getattr(metadata, "score", None)
+                if score is None:
+                    score = getattr(metadata, "relevance_score", None)
 
     if (
         score is not None

--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/src/opentelemetry/instrumentation/genai/langchain/callback_handler.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/src/opentelemetry/instrumentation/genai/langchain/callback_handler.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import math
 from collections.abc import Mapping, Sequence
 from typing import Any, cast
 from uuid import UUID
@@ -78,6 +79,73 @@ def _conversation_id(metadata: dict[str, Any] | None) -> str | None:
         if conversation_id:
             return str(conversation_id)
     return None
+
+
+def _extract_document_score(doc: Any) -> float | int | None:
+    """Extract relevance score polymorphically from a Document or Mapping.
+
+    Checks doc.score first, then falls back to doc.metadata['score'].
+    Also defensively supports Mapping/dict documents and duck-typed objects.
+    """
+    score: Any = None
+    if isinstance(doc, Mapping):
+        doc_map = cast(Mapping[str, Any], doc)
+        score = doc_map.get("score")
+        if score is None:
+            metadata = doc_map.get("metadata")
+            if isinstance(metadata, Mapping):
+                meta_map = cast(Mapping[str, Any], metadata)
+                score = meta_map.get("score")
+            elif metadata is not None:
+                score = getattr(metadata, "score", None)
+    else:
+        score = getattr(doc, "score", None)
+        if score is None:
+            metadata = getattr(doc, "metadata", None)
+            if isinstance(metadata, Mapping):
+                meta_map = cast(Mapping[str, Any], metadata)
+                score = meta_map.get("score")
+            elif metadata is not None:
+                score = getattr(metadata, "score", None)
+
+    if (
+        score is not None
+        and not isinstance(score, bool)
+        and isinstance(score, (int, float))
+    ):
+        if isinstance(score, float) and not math.isfinite(score):
+            return None
+        return score
+
+    return None
+
+
+def _document_to_dict(doc: Any) -> dict[str, Any]:
+    """Convert a Document, duck-typed document object, or Mapping to a dict.
+
+    Extracts content (checking page_content first, then content), id,
+    and conditionally score if present and numeric.
+    """
+    if isinstance(doc, Mapping):
+        doc_map = cast(Mapping[str, Any], doc)
+        content = doc_map.get("page_content")
+        if content is None:
+            content = doc_map.get("content")
+        doc_id = doc_map.get("id")
+    else:
+        content = getattr(doc, "page_content", None)
+        if content is None:
+            content = getattr(doc, "content", None)
+        doc_id = getattr(doc, "id", None)
+
+    doc_dict: dict[str, Any] = {
+        "content": content,
+        "id": doc_id,
+    }
+    score = _extract_document_score(doc)
+    if score is not None:
+        doc_dict["score"] = score
+    return doc_dict
 
 
 class OpenTelemetryLangChainCallbackHandler(BaseCallbackHandler):
@@ -715,11 +783,7 @@ class OpenTelemetryLangChainCallbackHandler(BaseCallbackHandler):
 
         if self._telemetry_handler.should_capture_content():
             invocation.documents = [
-                {
-                    "content": doc.page_content,
-                    "id": doc.id,
-                }
-                for doc in documents
+                _document_to_dict(doc) for doc in documents
             ]
         invocation.stop()
         if not invocation.span.is_recording():

--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/tests/test_callback_handler.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/tests/test_callback_handler.py
@@ -1800,6 +1800,24 @@ class TestExtractDocumentScore:
 
         assert _extract_document_score(Obj()) == 0.75
 
+    def test_metadata_relevance_score_fallback(self):
+        class Obj:
+            metadata = {"relevance_score": 0.82}
+
+        assert _extract_document_score(Obj()) == 0.82
+
+    def test_attr_relevance_score_fallback(self):
+        class Obj:
+            relevance_score = 0.91
+
+        assert _extract_document_score(Obj()) == 0.91
+
+    def test_precedence_score_over_relevance_score(self):
+        class Obj:
+            metadata = {"score": 0.85, "relevance_score": 0.42}
+
+        assert _extract_document_score(Obj()) == 0.85
+
     def test_precedence_attr_over_metadata(self):
         class Obj:
             score = 0.9

--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/tests/test_callback_handler.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/tests/test_callback_handler.py
@@ -9,6 +9,7 @@ the callback-handler logic and the invocation-manager bookkeeping.
 """
 
 import base64
+import math
 import uuid
 from unittest import mock
 
@@ -37,6 +38,8 @@ from langchain_core.outputs import (
 
 from opentelemetry.instrumentation.genai.langchain.callback_handler import (
     OpenTelemetryLangChainCallbackHandler,
+    _document_to_dict,
+    _extract_document_score,
 )
 from opentelemetry.instrumentation.genai.langchain.utils import (
     _legacy_function_call_request,
@@ -1541,6 +1544,428 @@ class TestOnRetrieverEnd:
     def test_unknown_run_id_does_not_raise(self):
         handler, _, _ = _make_handler_with_retrieval()
         handler.on_retriever_end(documents=[], run_id=_run_id())
+
+    def test_document_score_from_attribute(self):
+        handler, _, retrieval_inv = _make_handler_with_retrieval()
+        run_id = _run_id()
+
+        class DuckDoc:
+            page_content = "text"
+            id = "doc-1"
+            score = 0.85
+            metadata = {}
+
+        handler.on_retriever_start(serialized={}, query="q", run_id=run_id)
+        handler.on_retriever_end(documents=[DuckDoc()], run_id=run_id)
+
+        assert retrieval_inv.documents[0]["score"] == 0.85
+
+    def test_document_score_from_metadata(self):
+        handler, _, retrieval_inv = _make_handler_with_retrieval()
+        run_id = _run_id()
+
+        doc = Document(
+            page_content="text", id="doc-2", metadata={"score": 0.92}
+        )
+
+        handler.on_retriever_start(serialized={}, query="q", run_id=run_id)
+        handler.on_retriever_end(documents=[doc], run_id=run_id)
+
+        assert retrieval_inv.documents[0]["score"] == 0.92
+
+    def test_document_score_precedence(self):
+        handler, _, retrieval_inv = _make_handler_with_retrieval()
+        run_id = _run_id()
+
+        class DuckDoc:
+            page_content = "text"
+            id = "doc-3"
+            score = 0.9
+            metadata = {"score": 0.5}
+
+        handler.on_retriever_start(serialized={}, query="q", run_id=run_id)
+        handler.on_retriever_end(documents=[DuckDoc()], run_id=run_id)
+
+        assert retrieval_inv.documents[0]["score"] == 0.9
+
+    def test_document_score_fallback_to_metadata_when_attr_is_none(self):
+        handler, _, retrieval_inv = _make_handler_with_retrieval()
+        run_id = _run_id()
+
+        class DuckDoc:
+            page_content = "text"
+            id = "doc-4"
+            score = None
+            metadata = {"score": 0.77}
+
+        handler.on_retriever_start(serialized={}, query="q", run_id=run_id)
+        handler.on_retriever_end(documents=[DuckDoc()], run_id=run_id)
+
+        assert retrieval_inv.documents[0]["score"] == 0.77
+
+    def test_document_score_zero_preserved(self):
+        handler, _, retrieval_inv = _make_handler_with_retrieval()
+        run_id = _run_id()
+
+        class DuckDoc:
+            page_content = "text"
+            id = "doc-5"
+            score = 0.0
+
+        doc_meta = Document(
+            page_content="text-meta", id="doc-6", metadata={"score": 0}
+        )
+
+        handler.on_retriever_start(serialized={}, query="q", run_id=run_id)
+        handler.on_retriever_end(
+            documents=[DuckDoc(), doc_meta], run_id=run_id
+        )
+
+        assert "score" in retrieval_inv.documents[0]
+        assert retrieval_inv.documents[0]["score"] == 0.0
+        assert "score" in retrieval_inv.documents[1]
+        assert retrieval_inv.documents[1]["score"] == 0
+
+    @pytest.mark.parametrize(
+        "invalid_score",
+        ["high", True, False, [1.0], {"val": 1}],
+    )
+    def test_document_score_non_numeric_ignored(self, invalid_score):
+        handler, _, retrieval_inv = _make_handler_with_retrieval()
+        run_id = _run_id()
+
+        doc = Document(page_content="text", metadata={"score": invalid_score})
+
+        handler.on_retriever_start(serialized={}, query="q", run_id=run_id)
+        handler.on_retriever_end(documents=[doc], run_id=run_id)
+
+        assert "score" not in retrieval_inv.documents[0]
+
+    @pytest.mark.parametrize(
+        "non_finite_score",
+        [
+            float("nan"),
+            float("inf"),
+            float("-inf"),
+            math.nan,
+            math.inf,
+            -math.inf,
+        ],
+    )
+    def test_document_score_non_finite_ignored(self, non_finite_score):
+        handler, _, retrieval_inv = _make_handler_with_retrieval()
+        run_id = _run_id()
+
+        class DuckDocAttr:
+            page_content = "attr text"
+            score = non_finite_score
+
+        doc_meta = Document(
+            page_content="meta text", metadata={"score": non_finite_score}
+        )
+        doc_dict = {"page_content": "dict text", "score": non_finite_score}
+
+        handler.on_retriever_start(serialized={}, query="q", run_id=run_id)
+        handler.on_retriever_end(
+            documents=[DuckDocAttr(), doc_meta, doc_dict], run_id=run_id
+        )
+
+        for item in retrieval_inv.documents:
+            assert "score" not in item
+
+    def test_document_score_plain_dict_and_duck_typed(self):
+        handler, _, retrieval_inv = _make_handler_with_retrieval()
+        run_id = _run_id()
+
+        dict_doc_1 = {
+            "page_content": "dict content 1",
+            "id": "dict-1",
+            "score": 0.88,
+        }
+        dict_doc_2 = {
+            "content": "dict content 2",
+            "metadata": {"score": 0.72},
+        }
+        dict_doc_3 = {
+            "page_content": None,
+            "content": "dict content fallback when page_content is None",
+            "id": "dict-3",
+            "score": 0.64,
+        }
+
+        class CustomDuckDoc:
+            page_content = "duck content"
+            id = "duck-1"
+            score = 0.95
+
+        class CustomDuckDocContentFallback:
+            content = "duck content fallback"
+            id = "duck-2"
+            score = 0.81
+
+        class CustomDuckDocNonePageContentFallback:
+            page_content = None
+            content = "duck content fallback when page_content is None"
+            id = "duck-3"
+            score = 0.55
+
+        handler.on_retriever_start(serialized={}, query="q", run_id=run_id)
+        handler.on_retriever_end(
+            documents=[
+                dict_doc_1,
+                dict_doc_2,
+                dict_doc_3,
+                CustomDuckDoc(),
+                CustomDuckDocContentFallback(),
+                CustomDuckDocNonePageContentFallback(),
+            ],
+            run_id=run_id,
+        )
+
+        assigned = retrieval_inv.documents
+        assert len(assigned) == 6
+        assert assigned[0] == {
+            "content": "dict content 1",
+            "id": "dict-1",
+            "score": 0.88,
+        }
+        assert assigned[1] == {
+            "content": "dict content 2",
+            "id": None,
+            "score": 0.72,
+        }
+        assert assigned[2] == {
+            "content": "dict content fallback when page_content is None",
+            "id": "dict-3",
+            "score": 0.64,
+        }
+        assert assigned[3] == {
+            "content": "duck content",
+            "id": "duck-1",
+            "score": 0.95,
+        }
+        assert assigned[4] == {
+            "content": "duck content fallback",
+            "id": "duck-2",
+            "score": 0.81,
+        }
+        assert assigned[5] == {
+            "content": "duck content fallback when page_content is None",
+            "id": "duck-3",
+            "score": 0.55,
+        }
+
+    def test_document_score_non_mapping_metadata(self):
+        handler, _, retrieval_inv = _make_handler_with_retrieval()
+        run_id = _run_id()
+
+        class DuckDocNoMeta:
+            page_content = "text"
+            id = "doc-no-meta"
+
+        class DuckDocStringMeta:
+            page_content = "text"
+            id = "doc-str-meta"
+            metadata = "not-a-mapping"
+
+        class DuckDocNoneMeta:
+            page_content = "text"
+            id = "doc-none-meta"
+            metadata = None
+
+        handler.on_retriever_start(serialized={}, query="q", run_id=run_id)
+        handler.on_retriever_end(
+            documents=[
+                DuckDocNoMeta(),
+                DuckDocStringMeta(),
+                DuckDocNoneMeta(),
+            ],
+            run_id=run_id,
+        )
+
+        for item in retrieval_inv.documents:
+            assert "score" not in item
+
+
+class TestExtractDocumentScore:
+    def test_attribute_score(self):
+        class Obj:
+            score = 0.88
+
+        assert _extract_document_score(Obj()) == 0.88
+
+    def test_metadata_score(self):
+        class Obj:
+            metadata = {"score": 0.75}
+
+        assert _extract_document_score(Obj()) == 0.75
+
+    def test_precedence_attr_over_metadata(self):
+        class Obj:
+            score = 0.9
+            metadata = {"score": 0.4}
+
+        assert _extract_document_score(Obj()) == 0.9
+
+    def test_attr_none_falls_back_to_metadata(self):
+        class Obj:
+            score = None
+            metadata = {"score": 0.65}
+
+        assert _extract_document_score(Obj()) == 0.65
+
+    def test_zero_scores(self):
+        class ObjFloat:
+            score = 0.0
+
+        class ObjInt:
+            score = 0
+
+        assert _extract_document_score(ObjFloat()) == 0.0
+        assert _extract_document_score(ObjInt()) == 0
+
+    def test_negative_score(self):
+        class Obj:
+            score = -1.25
+
+        assert _extract_document_score(Obj()) == -1.25
+
+    def test_non_numeric_and_bool(self):
+        class ObjBool:
+            score = True
+
+        class ObjStr:
+            score = "0.9"
+
+        assert _extract_document_score(ObjBool()) is None
+        assert _extract_document_score(ObjStr()) is None
+
+    def test_non_finite_float_score(self):
+        class ObjNaN:
+            score = float("nan")
+
+        class ObjInf:
+            score = float("inf")
+
+        class ObjNegInf:
+            score = float("-inf")
+
+        class ObjMathNaN:
+            score = math.nan
+
+        class ObjMathInf:
+            score = math.inf
+
+        class ObjMathNegInf:
+            score = -math.inf
+
+        assert _extract_document_score(ObjNaN()) is None
+        assert _extract_document_score(ObjInf()) is None
+        assert _extract_document_score(ObjNegInf()) is None
+        assert _extract_document_score(ObjMathNaN()) is None
+        assert _extract_document_score(ObjMathInf()) is None
+        assert _extract_document_score(ObjMathNegInf()) is None
+        assert _extract_document_score({"score": float("nan")}) is None
+        assert _extract_document_score({"score": math.nan}) is None
+        assert (
+            _extract_document_score({"metadata": {"score": float("inf")}})
+            is None
+        )
+        assert (
+            _extract_document_score({"metadata": {"score": math.inf}}) is None
+        )
+        assert (
+            _extract_document_score({"metadata": {"score": float("-inf")}})
+            is None
+        )
+        assert (
+            _extract_document_score({"metadata": {"score": -math.inf}}) is None
+        )
+
+    def test_dict_score(self):
+        assert _extract_document_score({"score": 0.82}) == 0.82
+        assert _extract_document_score({"metadata": {"score": 0.91}}) == 0.91
+        assert (
+            _extract_document_score(
+                {"score": 0.99, "metadata": {"score": 0.1}}
+            )
+            == 0.99
+        )
+
+    def test_no_score(self):
+        assert _extract_document_score(object()) is None
+        assert _extract_document_score({}) is None
+        assert _extract_document_score({"metadata": None}) is None
+        assert _extract_document_score({"metadata": "str"}) is None
+
+
+class TestDocumentToDict:
+    def test_document_with_page_content_and_score(self):
+        doc = Document(
+            page_content="doc content", id="d1", metadata={"score": 0.85}
+        )
+        assert _document_to_dict(doc) == {
+            "content": "doc content",
+            "id": "d1",
+            "score": 0.85,
+        }
+
+    def test_duck_typed_with_content_fallback_missing_page_content(self):
+        class DuckNoPageContent:
+            content = "fallback content"
+            id = "d2"
+            score = 0.9
+
+        assert _document_to_dict(DuckNoPageContent()) == {
+            "content": "fallback content",
+            "id": "d2",
+            "score": 0.9,
+        }
+
+    def test_duck_typed_with_content_fallback_none_page_content(self):
+        class DuckNonePageContent:
+            page_content = None
+            content = "fallback content when page_content is None"
+            id = "d3"
+            score = 0.75
+
+        assert _document_to_dict(DuckNonePageContent()) == {
+            "content": "fallback content when page_content is None",
+            "id": "d3",
+            "score": 0.75,
+        }
+
+    def test_mapping_with_content_fallback_missing_page_content(self):
+        doc_map = {"content": "mapping fallback", "id": "m1", "score": 0.8}
+        assert _document_to_dict(doc_map) == {
+            "content": "mapping fallback",
+            "id": "m1",
+            "score": 0.8,
+        }
+
+    def test_mapping_with_content_fallback_none_page_content(self):
+        doc_map = {
+            "page_content": None,
+            "content": "mapping fallback when page_content is None",
+            "id": "m2",
+            "score": 0.7,
+        }
+        assert _document_to_dict(doc_map) == {
+            "content": "mapping fallback when page_content is None",
+            "id": "m2",
+            "score": 0.7,
+        }
+
+    def test_non_finite_scores_omitted(self):
+        doc_nan = Document(page_content="c", metadata={"score": math.nan})
+        doc_inf = Document(page_content="c", metadata={"score": float("inf")})
+        doc_neginf = Document(
+            page_content="c", metadata={"score": float("-inf")}
+        )
+
+        assert _document_to_dict(doc_nan) == {"content": "c", "id": None}
+        assert _document_to_dict(doc_inf) == {"content": "c", "id": None}
+        assert _document_to_dict(doc_neginf) == {"content": "c", "id": None}
 
 
 class TestOnRetrieverError:

--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/tests/test_retriever.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/tests/test_retriever.py
@@ -11,6 +11,8 @@ spans, attributes, and metrics against the semconv spec.
 
 from __future__ import annotations
 
+import json
+import math
 from typing import Any
 
 import pytest
@@ -27,6 +29,12 @@ from opentelemetry.semconv.attributes import error_attributes
 # ---------------------------------------------------------------------------
 # Fake retriever helpers
 # ---------------------------------------------------------------------------
+
+
+class _ScoredDocument(Document):
+    """Document subclass that allows a score attribute."""
+
+    score: float | None = None
 
 
 class _FakeRetriever(BaseRetriever):
@@ -371,23 +379,25 @@ def test_document_metadata_not_in_span_content(
         meter_provider=meter_provider,
         logger_provider=logger_provider,
     )
-    docs = [
-        Document(
-            page_content="text",
-            metadata={"source": "wiki", "score": 0.9},
-        )
-    ]
-    retriever = _FakeRetriever(documents=docs)
-    retriever.invoke("q")
+    try:
+        docs = [
+            Document(
+                page_content="text",
+                metadata={"source": "wiki", "author": "alice"},
+            )
+        ]
+        retriever = _FakeRetriever(documents=docs)
+        retriever.invoke("q")
 
-    spans = span_exporter.get_finished_spans()
-    docs_attr = spans[0].attributes[
-        gen_ai_attributes.GEN_AI_RETRIEVAL_DOCUMENTS
-    ]
-    assert "text" in docs_attr
-    assert "wiki" not in docs_attr
-    assert "0.9" not in docs_attr
-    instrumentor.uninstrument()
+        spans = span_exporter.get_finished_spans()
+        docs_attr = spans[0].attributes[
+            gen_ai_attributes.GEN_AI_RETRIEVAL_DOCUMENTS
+        ]
+        assert "text" in docs_attr
+        assert "wiki" not in docs_attr
+        assert "alice" not in docs_attr
+    finally:
+        instrumentor.uninstrument()
 
 
 def test_empty_documents_in_span_content(
@@ -409,13 +419,285 @@ def test_empty_documents_in_span_content(
         meter_provider=meter_provider,
         logger_provider=logger_provider,
     )
-    retriever = _FakeRetriever(documents=[])
-    retriever.invoke("q")
+    try:
+        retriever = _FakeRetriever(documents=[])
+        retriever.invoke("q")
 
-    spans = span_exporter.get_finished_spans()
-    # documents attribute is set but represents an empty list
-    docs_attr = spans[0].attributes.get(
-        gen_ai_attributes.GEN_AI_RETRIEVAL_DOCUMENTS
+        spans = span_exporter.get_finished_spans()
+        # documents attribute is set but represents an empty list
+        docs_attr = spans[0].attributes.get(
+            gen_ai_attributes.GEN_AI_RETRIEVAL_DOCUMENTS
+        )
+        assert docs_attr == "[]"
+    finally:
+        instrumentor.uninstrument()
+
+
+def test_retriever_documents_with_attribute_score(
+    span_exporter,
+    tracer_provider,
+    meter_provider,
+    logger_provider,
+    monkeypatch,
+):
+    monkeypatch.setenv(
+        "OTEL_SEMCONV_STABILITY_OPT_IN", "gen_ai_latest_experimental"
     )
-    assert docs_attr == "[]"
-    instrumentor.uninstrument()
+    monkeypatch.setenv(
+        "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT", "SPAN_ONLY"
+    )
+    instrumentor = LangChainInstrumentor()
+    instrumentor.instrument(
+        tracer_provider=tracer_provider,
+        meter_provider=meter_provider,
+        logger_provider=logger_provider,
+    )
+    try:
+        docs = [_ScoredDocument(page_content="text", id="doc-1", score=0.85)]
+        retriever = _FakeRetriever(documents=docs)
+        retriever.invoke("q")
+
+        spans = span_exporter.get_finished_spans()
+        docs_attr = spans[0].attributes[
+            gen_ai_attributes.GEN_AI_RETRIEVAL_DOCUMENTS
+        ]
+        parsed = json.loads(docs_attr)
+        assert len(parsed) == 1
+        assert parsed[0]["content"] == "text"
+        assert parsed[0]["id"] == "doc-1"
+        assert parsed[0]["score"] == 0.85
+    finally:
+        instrumentor.uninstrument()
+
+
+def test_retriever_documents_with_metadata_score(
+    span_exporter,
+    tracer_provider,
+    meter_provider,
+    logger_provider,
+    monkeypatch,
+):
+    monkeypatch.setenv(
+        "OTEL_SEMCONV_STABILITY_OPT_IN", "gen_ai_latest_experimental"
+    )
+    monkeypatch.setenv(
+        "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT", "SPAN_ONLY"
+    )
+    instrumentor = LangChainInstrumentor()
+    instrumentor.instrument(
+        tracer_provider=tracer_provider,
+        meter_provider=meter_provider,
+        logger_provider=logger_provider,
+    )
+    try:
+        docs = [
+            Document(page_content="text", id="doc-2", metadata={"score": 0.92})
+        ]
+        retriever = _FakeRetriever(documents=docs)
+        retriever.invoke("q")
+
+        spans = span_exporter.get_finished_spans()
+        docs_attr = spans[0].attributes[
+            gen_ai_attributes.GEN_AI_RETRIEVAL_DOCUMENTS
+        ]
+        parsed = json.loads(docs_attr)
+        assert len(parsed) == 1
+        assert parsed[0]["content"] == "text"
+        assert parsed[0]["id"] == "doc-2"
+        assert parsed[0]["score"] == 0.92
+    finally:
+        instrumentor.uninstrument()
+
+
+def test_retriever_documents_with_precedence(
+    span_exporter,
+    tracer_provider,
+    meter_provider,
+    logger_provider,
+    monkeypatch,
+):
+    monkeypatch.setenv(
+        "OTEL_SEMCONV_STABILITY_OPT_IN", "gen_ai_latest_experimental"
+    )
+    monkeypatch.setenv(
+        "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT", "SPAN_ONLY"
+    )
+    instrumentor = LangChainInstrumentor()
+    instrumentor.instrument(
+        tracer_provider=tracer_provider,
+        meter_provider=meter_provider,
+        logger_provider=logger_provider,
+    )
+    try:
+        docs = [
+            _ScoredDocument(
+                page_content="text",
+                id="doc-3",
+                score=0.9,
+                metadata={"score": 0.5},
+            )
+        ]
+        retriever = _FakeRetriever(documents=docs)
+        retriever.invoke("q")
+
+        spans = span_exporter.get_finished_spans()
+        docs_attr = spans[0].attributes[
+            gen_ai_attributes.GEN_AI_RETRIEVAL_DOCUMENTS
+        ]
+        parsed = json.loads(docs_attr)
+        assert len(parsed) == 1
+        assert parsed[0]["score"] == 0.9
+    finally:
+        instrumentor.uninstrument()
+
+
+def test_retriever_documents_with_zero_score(
+    span_exporter,
+    tracer_provider,
+    meter_provider,
+    logger_provider,
+    monkeypatch,
+):
+    monkeypatch.setenv(
+        "OTEL_SEMCONV_STABILITY_OPT_IN", "gen_ai_latest_experimental"
+    )
+    monkeypatch.setenv(
+        "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT", "SPAN_ONLY"
+    )
+    instrumentor = LangChainInstrumentor()
+    instrumentor.instrument(
+        tracer_provider=tracer_provider,
+        meter_provider=meter_provider,
+        logger_provider=logger_provider,
+    )
+    try:
+        docs = [_ScoredDocument(page_content="text", id="doc-4", score=0.0)]
+        retriever = _FakeRetriever(documents=docs)
+        retriever.invoke("q")
+
+        spans = span_exporter.get_finished_spans()
+        docs_attr = spans[0].attributes[
+            gen_ai_attributes.GEN_AI_RETRIEVAL_DOCUMENTS
+        ]
+        parsed = json.loads(docs_attr)
+        assert len(parsed) == 1
+        assert "score" in parsed[0]
+        assert parsed[0]["score"] == 0.0
+    finally:
+        instrumentor.uninstrument()
+
+
+def test_retriever_documents_without_score(
+    span_exporter,
+    tracer_provider,
+    meter_provider,
+    logger_provider,
+    monkeypatch,
+):
+    monkeypatch.setenv(
+        "OTEL_SEMCONV_STABILITY_OPT_IN", "gen_ai_latest_experimental"
+    )
+    monkeypatch.setenv(
+        "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT", "SPAN_ONLY"
+    )
+    instrumentor = LangChainInstrumentor()
+    instrumentor.instrument(
+        tracer_provider=tracer_provider,
+        meter_provider=meter_provider,
+        logger_provider=logger_provider,
+    )
+    try:
+        docs = [Document(page_content="text", id="doc-5")]
+        retriever = _FakeRetriever(documents=docs)
+        retriever.invoke("q")
+
+        spans = span_exporter.get_finished_spans()
+        docs_attr = spans[0].attributes[
+            gen_ai_attributes.GEN_AI_RETRIEVAL_DOCUMENTS
+        ]
+        parsed = json.loads(docs_attr)
+        assert len(parsed) == 1
+        assert "score" not in parsed[0]
+    finally:
+        instrumentor.uninstrument()
+
+
+def test_retriever_content_capture_gating(
+    span_exporter,
+    tracer_provider,
+    meter_provider,
+    logger_provider,
+    monkeypatch,
+):
+    monkeypatch.setenv(
+        "OTEL_SEMCONV_STABILITY_OPT_IN", "gen_ai_latest_experimental"
+    )
+    monkeypatch.setenv(
+        "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT", "NO_CONTENT"
+    )
+    instrumentor = LangChainInstrumentor()
+    instrumentor.instrument(
+        tracer_provider=tracer_provider,
+        meter_provider=meter_provider,
+        logger_provider=logger_provider,
+    )
+    try:
+        docs = [Document(page_content="text", metadata={"score": 0.95})]
+        retriever = _FakeRetriever(documents=docs)
+        retriever.invoke("q")
+
+        spans = span_exporter.get_finished_spans()
+        assert len(spans) == 1
+        assert (
+            gen_ai_attributes.GEN_AI_RETRIEVAL_DOCUMENTS
+            not in spans[0].attributes
+        )
+    finally:
+        instrumentor.uninstrument()
+
+
+def test_retriever_documents_with_non_finite_scores(
+    span_exporter,
+    tracer_provider,
+    meter_provider,
+    logger_provider,
+    monkeypatch,
+):
+    monkeypatch.setenv(
+        "OTEL_SEMCONV_STABILITY_OPT_IN", "gen_ai_latest_experimental"
+    )
+    monkeypatch.setenv(
+        "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT", "SPAN_ONLY"
+    )
+    instrumentor = LangChainInstrumentor()
+    instrumentor.instrument(
+        tracer_provider=tracer_provider,
+        meter_provider=meter_provider,
+        logger_provider=logger_provider,
+    )
+    try:
+        docs = [
+            _ScoredDocument(page_content="c1", id="d1", score=float("nan")),
+            _ScoredDocument(page_content="c2", id="d2", score=float("inf")),
+            _ScoredDocument(page_content="c3", id="d3", score=float("-inf")),
+            Document(page_content="c4", id="d4", metadata={"score": math.nan}),
+        ]
+        retriever = _FakeRetriever(documents=docs)
+        retriever.invoke("q")
+
+        spans = span_exporter.get_finished_spans()
+        assert len(spans) == 1
+        docs_attr = spans[0].attributes[
+            gen_ai_attributes.GEN_AI_RETRIEVAL_DOCUMENTS
+        ]
+        assert isinstance(docs_attr, str)
+        # RFC 8259 JSON compliance: unquoted NaN and Infinity must be strictly absent
+        assert "NaN" not in docs_attr
+        assert "Infinity" not in docs_attr
+
+        parsed = json.loads(docs_attr)
+        assert len(parsed) == 4
+        for item in parsed:
+            assert "score" not in item
+    finally:
+        instrumentor.uninstrument()


### PR DESCRIPTION
# Description

Fixes #584

Per the OpenTelemetry Semantic Conventions for Generative AI systems (`gen_ai.retrieval.documents`), each retrieved document item should capture its relevance score under the `score` key when available from the retriever or vector search engine.

This PR adds document relevance score extraction to `OpenTelemetryCallbackHandler._get_retrieval_documents` in `opentelemetry-instrumentation-genai-langchain`.

### Key Changes:
- **Polymorphic Score Extraction**: Extracts `score` by checking document attributes first (`getattr(doc, "score", None)` or dictionary `doc.get("score")`), then falling back to document metadata (`metadata.get("score")` / `metadata.get("relevance_score")`).
- **Validation & Guard Rails**:
  - Validates that the score is a numeric `int` or `float`.
  - Excludes `bool` instances (since `isinstance(True, int)` is True in Python).
  - Preserves valid `0` and `0.0` scores (using `is not None` and type checks instead of truthiness).
  - Rejects non-finite floats (`NaN`, `+Inf`, `-Inf`) via `math.isfinite`.
  - Rejects non-numeric types (e.g. strings, lists, dicts).
- **Duck-Typed Document Support**: Symmetrically supports both standard `langchain_core.documents.Document` objects and arbitrary duck-typed document objects/dictionaries with `page_content` or `content` and `metadata`.
- **SemConv Conformance**: Populates the `score` key alongside `content` and `id` in `gen_ai.retrieval.documents` JSON serialization.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How has this been tested?

- [x] Unit tests in `test_callback_handler.py` covering score extraction, attribute precedence, metadata fallbacks, `0`/`0.0` preservation, boolean exclusion, `NaN`/`Inf` exclusion, invalid types, and duck-typed objects.
- [x] Integration tests in `test_retriever.py` covering synchronous and asynchronous retrievers (`invoke`, `ainvoke`, `get_relevant_documents`, `aget_relevant_documents`) with scores.
- [x] Full package test suite: 430 passed across all tests in `instrumentation/opentelemetry-instrumentation-genai-langchain`.
- [x] Static type checking: `pyright --level error` (0 errors) and `mypy` strict type check clean.
- [x] Lint & formatting: `ruff check` (0 errors) and `ruff format --check` clean across all files.

# Checklist

- [x] Followed the style guidelines of this project
- [x] Changelog updated if the change requires an entry
- [x] Unit tests added
- [x] Documentation updated
