### PR TITLE
feat(langchain): extract cache_write and modality token usage attributes

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/.changelog/671.added
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/.changelog/671.added
@@ -1,0 +1,1 @@
+Record `cache_write_input_tokens` and modality token breakdown attributes (`text`, `image`, `audio`) from LangChain usage metadata on `InferenceInvocation`.

--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/src/opentelemetry/instrumentation/genai/langchain/callback_handler.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/src/opentelemetry/instrumentation/genai/langchain/callback_handler.py
@@ -536,29 +536,60 @@ class OpenTelemetryLangChainCallbackHandler(BaseCallbackHandler):
                         ):
                             output_tokens = 0
 
-                        # Cache/reasoning break-downs (Anthropic, OpenAI
-                        # reasoning models, Bedrock). Audio tokens are dropped
-                        # (no GenAI semconv attribute).
+                        # Cache, reasoning, and modality token break-downs
                         token_details = extract_token_details(
                             cast(dict[str, Any], usage_metadata)
                         )
-                        cache_creation = token_details.get(
-                            "cache_creation_input_tokens"
-                        )
-                        if cache_creation is not None:
-                            llm_invocation.cache_creation_input_tokens = (
-                                cache_creation
+                        if (
+                            cache_write := token_details.get(
+                                "cache_write_input_tokens"
                             )
-                        cache_read = token_details.get(
-                            "cache_read_input_tokens"
-                        )
-                        if cache_read is not None:
+                        ) is not None:
+                            llm_invocation.cache_write_input_tokens = (
+                                cache_write
+                            )
+                        if (
+                            cache_read := token_details.get(
+                                "cache_read_input_tokens"
+                            )
+                        ) is not None:
                             llm_invocation.cache_read_input_tokens = cache_read
-                        reasoning_tokens = token_details.get(
-                            "reasoning_tokens"
-                        )
-                        if reasoning_tokens is not None:
+                        if (
+                            reasoning_tokens := token_details.get(
+                                "reasoning_tokens"
+                            )
+                        ) is not None:
                             llm_invocation.thinking_tokens = reasoning_tokens
+
+                        if (
+                            text_in := token_details.get("text_input_tokens")
+                        ) is not None:
+                            llm_invocation.text_input_tokens = text_in
+                        if (
+                            image_in := token_details.get("image_input_tokens")
+                        ) is not None:
+                            llm_invocation.image_input_tokens = image_in
+                        if (
+                            audio_in := token_details.get("audio_input_tokens")
+                        ) is not None:
+                            llm_invocation.audio_input_tokens = audio_in
+
+                        if (
+                            text_out := token_details.get("text_output_tokens")
+                        ) is not None:
+                            llm_invocation.text_output_tokens = text_out
+                        if (
+                            image_out := token_details.get(
+                                "image_output_tokens"
+                            )
+                        ) is not None:
+                            llm_invocation.image_output_tokens = image_out
+                        if (
+                            audio_out := token_details.get(
+                                "audio_output_tokens"
+                            )
+                        ) is not None:
+                            llm_invocation.audio_output_tokens = audio_out
 
                         llm_invocation.output_tokens = output_tokens
 

--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/src/opentelemetry/instrumentation/genai/langchain/utils.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/src/opentelemetry/instrumentation/genai/langchain/utils.py
@@ -617,7 +617,7 @@ def resolve_response_model_and_id(
 
 
 def extract_token_details(usage_metadata: dict[str, Any]) -> dict[str, int]:
-    """Extract cache/reasoning token break-downs from LangChain usage metadata."""
+    """Extract cache, reasoning, and modality token break-downs from LangChain usage metadata."""
 
     token_details: dict[str, int] = {}
     raw_input_details = usage_metadata.get("input_token_details")
@@ -633,16 +633,42 @@ def extract_token_details(usage_metadata: dict[str, Any]) -> dict[str, int]:
         else {}
     )
 
-    cache_creation = input_details.get("cache_creation")
-    if isinstance(cache_creation, int) and cache_creation:
-        token_details["cache_creation_input_tokens"] = cache_creation
+    def _get_positive_int(d: dict[str, Any], key: str) -> int | None:
+        val = d.get(key)
+        if isinstance(val, int) and not isinstance(val, bool) and val > 0:
+            return val
+        return None
 
-    cache_read = input_details.get("cache_read")
-    if isinstance(cache_read, int) and cache_read:
+    cache_write = _get_positive_int(input_details, "cache_write")
+    if cache_write is None:
+        cache_write = _get_positive_int(input_details, "cache_creation")
+    if cache_write is not None:
+        token_details["cache_write_input_tokens"] = cache_write
+
+    if (
+        cache_read := _get_positive_int(input_details, "cache_read")
+    ) is not None:
         token_details["cache_read_input_tokens"] = cache_read
 
-    reasoning = output_details.get("reasoning")
-    if isinstance(reasoning, int) and reasoning:
+    if (
+        reasoning := _get_positive_int(output_details, "reasoning")
+    ) is not None:
         token_details["reasoning_tokens"] = reasoning
+
+    # Input modality breakdowns
+    if (text_in := _get_positive_int(input_details, "text")) is not None:
+        token_details["text_input_tokens"] = text_in
+    if (image_in := _get_positive_int(input_details, "image")) is not None:
+        token_details["image_input_tokens"] = image_in
+    if (audio_in := _get_positive_int(input_details, "audio")) is not None:
+        token_details["audio_input_tokens"] = audio_in
+
+    # Output modality breakdowns
+    if (text_out := _get_positive_int(output_details, "text")) is not None:
+        token_details["text_output_tokens"] = text_out
+    if (image_out := _get_positive_int(output_details, "image")) is not None:
+        token_details["image_output_tokens"] = image_out
+    if (audio_out := _get_positive_int(output_details, "audio")) is not None:
+        token_details["audio_output_tokens"] = audio_out
 
     return token_details

--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/tests/test_callback_handler.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/tests/test_callback_handler.py
@@ -1601,23 +1601,25 @@ class TestOnLlmEndTokenDetails:
         handler.on_llm_end(response=response, run_id=run_id)
 
         assert llm_inv.input_tokens == 10
-        assert llm_inv.cache_creation_input_tokens == 3
+        assert llm_inv.cache_write_input_tokens == 3
         assert llm_inv.cache_read_input_tokens == 2
         assert llm_inv.thinking_tokens == 5
         assert llm_inv.output_tokens == 20
 
-    def test_audio_tokens_ignored(self):
+    def test_cache_write_tokens_set_on_invocation(self):
         run_id = _run_id()
         handler, _, llm_inv = _make_handler_with_llm_invocation(run_id)
 
         ai_msg = AIMessage(
-            content="hi",
+            content="hi there",
             usage_metadata={
-                "input_tokens": 10,
-                "output_tokens": 20,
-                "total_tokens": 30,
-                "input_token_details": {"audio": 5},
-                "output_token_details": {"audio": 4},
+                "input_tokens": 15,
+                "output_tokens": 25,
+                "total_tokens": 40,
+                "input_token_details": {
+                    "cache_write": 7,
+                    "cache_read": 3,
+                },
             },
         )
         gen = ChatGeneration(
@@ -1627,8 +1629,48 @@ class TestOnLlmEndTokenDetails:
 
         handler.on_llm_end(response=response, run_id=run_id)
 
-        assert llm_inv.input_tokens == 10
-        assert llm_inv.output_tokens == 20
+        assert llm_inv.input_tokens == 15
+        assert llm_inv.cache_write_input_tokens == 7
+        assert llm_inv.cache_read_input_tokens == 3
+        assert llm_inv.output_tokens == 25
+
+    def test_modality_tokens_set_on_invocation(self):
+        run_id = _run_id()
+        handler, _, llm_inv = _make_handler_with_llm_invocation(run_id)
+
+        ai_msg = AIMessage(
+            content="hi",
+            usage_metadata={
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "total_tokens": 150,
+                "input_token_details": {
+                    "text": 70,
+                    "image": 20,
+                    "audio": 10,
+                },
+                "output_token_details": {
+                    "text": 35,
+                    "image": 10,
+                    "audio": 5,
+                },
+            },
+        )
+        gen = ChatGeneration(
+            message=ai_msg, generation_info={"finish_reason": "stop"}
+        )
+        response = LLMResult(generations=[[gen]])
+
+        handler.on_llm_end(response=response, run_id=run_id)
+
+        assert llm_inv.input_tokens == 100
+        assert llm_inv.text_input_tokens == 70
+        assert llm_inv.image_input_tokens == 20
+        assert llm_inv.audio_input_tokens == 10
+        assert llm_inv.output_tokens == 50
+        assert llm_inv.text_output_tokens == 35
+        assert llm_inv.image_output_tokens == 10
+        assert llm_inv.audio_output_tokens == 5
 
 
 # ---------------------------------------------------------------------------
@@ -1646,27 +1688,78 @@ def test_extract_token_details_cache_and_reasoning():
     }
     details = extract_token_details(usage)
     assert details == {
-        "cache_creation_input_tokens": 3,
+        "cache_write_input_tokens": 3,
         "cache_read_input_tokens": 2,
         "reasoning_tokens": 5,
     }
 
 
-def test_extract_token_details_ignores_audio_tokens():
+def test_extract_token_details_cache_write_key():
     usage = {
         "input_tokens": 10,
         "output_tokens": 20,
-        "input_token_details": {"audio": 5},
-        "output_token_details": {"audio": 4},
+        "total_tokens": 30,
+        "input_token_details": {"cache_write": 4, "cache_read": 2},
+        "output_token_details": {"reasoning": 5},
     }
-    assert extract_token_details(usage) == {}
+    details = extract_token_details(usage)
+    assert details == {
+        "cache_write_input_tokens": 4,
+        "cache_read_input_tokens": 2,
+        "reasoning_tokens": 5,
+    }
+
+
+def test_extract_token_details_modalities():
+    usage = {
+        "input_tokens": 100,
+        "output_tokens": 50,
+        "input_token_details": {
+            "text": 70,
+            "image": 20,
+            "audio": 10,
+            "cache_write": 15,
+            "cache_read": 25,
+        },
+        "output_token_details": {
+            "text": 30,
+            "image": 15,
+            "audio": 5,
+            "reasoning": 10,
+        },
+    }
+    details = extract_token_details(usage)
+    assert details == {
+        "cache_write_input_tokens": 15,
+        "cache_read_input_tokens": 25,
+        "text_input_tokens": 70,
+        "image_input_tokens": 20,
+        "audio_input_tokens": 10,
+        "reasoning_tokens": 10,
+        "text_output_tokens": 30,
+        "image_output_tokens": 15,
+        "audio_output_tokens": 5,
+    }
 
 
 def test_extract_token_details_zero_values_omitted():
     usage = {
         "input_tokens": 10,
         "output_tokens": 20,
-        "input_token_details": {"cache_creation": 0, "cache_read": 0},
+        "input_token_details": {
+            "cache_creation": 0,
+            "cache_write": 0,
+            "cache_read": 0,
+            "text": 0,
+            "image": 0,
+            "audio": 0,
+        },
+        "output_token_details": {
+            "reasoning": 0,
+            "text": 0,
+            "image": 0,
+            "audio": 0,
+        },
     }
     assert extract_token_details(usage) == {}
 
@@ -1674,37 +1767,54 @@ def test_extract_token_details_zero_values_omitted():
 def test_extract_token_details_no_details_key():
     assert extract_token_details({"input_tokens": 1, "output_tokens": 2}) == {}
 
-    def test_legacy_function_call_finish_reason_produces_tool_call_request(
-        self,
-    ):
-        """Pre-tools OpenAI ``function_call`` must surface as a ToolCallRequestPart."""
-        run_id = _run_id()
-        handler, _, llm_inv = _make_handler_with_llm_invocation(run_id)
 
-        ai_msg = AIMessage(
-            content="",
-            additional_kwargs={
-                "function_call": {
-                    "name": "get_weather",
-                    "arguments": '{"city": "Paris"}',
-                }
-            },
-        )
-        gen = ChatGeneration(
-            message=ai_msg,
-            generation_info={"finish_reason": "function_call"},
-        )
-        response = LLMResult(generations=[[gen]])
+def test_extract_token_details_boolean_and_non_int_omitted():
+    usage = {
+        "input_token_details": {
+            "cache_write": True,
+            "cache_read": False,
+            "text": "10",
+            "image": None,
+            "audio": -5,
+        },
+        "output_token_details": {
+            "reasoning": True,
+            "text": [10],
+            "image": 0,
+        },
+    }
+    assert extract_token_details(usage) == {}
 
-        handler.on_llm_end(response=response, run_id=run_id)
 
-        assigned: list[OutputMessage] = llm_inv.output_messages
-        assert len(assigned) == 1
-        assert len(assigned[0].parts) == 1
-        part = assigned[0].parts[0]
-        assert isinstance(part, ToolCallRequestPart)
-        assert part.name == "get_weather"
-        assert part.arguments == {"city": "Paris"}
+def test_legacy_function_call_finish_reason_produces_tool_call_request():
+    """Pre-tools OpenAI ``function_call`` must surface as a ToolCallRequestPart."""
+    run_id = _run_id()
+    handler, _, llm_inv = _make_handler_with_llm_invocation(run_id)
+
+    ai_msg = AIMessage(
+        content="",
+        additional_kwargs={
+            "function_call": {
+                "name": "get_weather",
+                "arguments": '{"city": "Paris"}',
+            }
+        },
+    )
+    gen = ChatGeneration(
+        message=ai_msg,
+        generation_info={"finish_reason": "function_call"},
+    )
+    response = LLMResult(generations=[[gen]])
+
+    handler.on_llm_end(response=response, run_id=run_id)
+
+    assigned: list[OutputMessage] = llm_inv.output_messages
+    assert len(assigned) == 1
+    assert len(assigned[0].parts) == 1
+    part = assigned[0].parts[0]
+    assert isinstance(part, ToolCallRequestPart)
+    assert part.name == "get_weather"
+    assert part.arguments == {"city": "Paris"}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# Description

Extracts and records `gen_ai.usage.cache_write.input_tokens` and modality breakdown attributes (`gen_ai.usage.{text,image,audio}.{input,output}_tokens`) on `InferenceInvocation` spans from LangChain `usage_metadata`. It supports both `cache_write` and legacy `cache_creation` keys while omitting `0`, negative, boolean, and non-integer values.

This aligns the LangChain instrumentation with the latest GenAI semantic conventions following the updates in #613.

Fixes #609

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How has this been tested?

Added unit tests in `test_callback_handler.py` verifying cache write/read, reasoning, and multimodal token breakdowns (`text`, `image`, `audio`), as well as ensuring invalid/zero values are filtered out.

Run all tests and linting locally:

- `uv run tox -e py312-test-instrumentation-genai-langchain-latest`
- `uv run pre-commit run --all-files`

# Checklist

- [x] Followed the style guidelines of this project
- [x] Changelog updated if the change requires an entry (`609.added`)
- [x] Unit tests added
- [x] Documentation updated