### PR TITLE
Fix Anthropic streaming with anthropic>=1.5.0

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/.changelog/672.fixed
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/.changelog/672.fixed
@@ -1,0 +1,1 @@
+Fix streaming message accumulation with ``anthropic>=1.5.0`` and gracefully suppress future accumulation on signature mismatches.

--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/src/opentelemetry/instrumentation/genai/anthropic/wrappers.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/src/opentelemetry/instrumentation/genai/anthropic/wrappers.py
@@ -3,9 +3,12 @@
 
 from __future__ import annotations
 
+import inspect
+import logging
 from collections.abc import Callable
 from typing import (
     TYPE_CHECKING,
+    Any,
     Generic,
     Protocol,
     TypeVar,
@@ -27,6 +30,8 @@ from opentelemetry.util.genai.stream import (
 )
 
 from .messages_extractors import set_invocation_response_attributes
+
+_logger = logging.getLogger(__name__)
 
 try:
     from anthropic.lib.streaming._messages import (  # pylint: disable=no-name-in-module
@@ -57,6 +62,17 @@ if TYPE_CHECKING:
 
 ResponseFormatT = TypeVar("ResponseFormatT")
 accumulate_event = cast("Callable[..., Message] | None", _sdk_accumulate_event)
+
+_accumulate_takes_json_bufs = False
+if accumulate_event is not None:
+    try:
+        _accumulate_takes_json_bufs = (
+            "json_bufs" in inspect.signature(accumulate_event).parameters
+        )
+    except (ValueError, TypeError):
+        _accumulate_takes_json_bufs = False
+
+_accumulation_disabled = False
 
 
 class _StreamWrapperWithStream(Protocol):
@@ -96,6 +112,7 @@ class _MessagesStreamMixin(Generic[ResponseFormatT]):
     _self_message: Message | ParsedMessage[ResponseFormatT] | None
     _self_capture_content: bool
     _self_message_telemetry_finalized: bool
+    _self_json_bufs: dict[int, bytes]
 
     def _stop(self) -> None:
         if self._self_message_telemetry_finalized:
@@ -126,6 +143,7 @@ class _MessagesStreamMixin(Generic[ResponseFormatT]):
         | ParsedMessageStreamEvent[ResponseFormatT],
     ) -> None:
         """Accumulate a final message snapshot from a streaming chunk."""
+        global _accumulation_disabled
         stream = cast(_StreamWrapperWithStream, self).stream
         snapshot = cast(
             "ParsedMessage[ResponseFormatT] | None",
@@ -134,14 +152,29 @@ class _MessagesStreamMixin(Generic[ResponseFormatT]):
         if snapshot is not None:
             self._self_message = snapshot
             return
-        if accumulate_event is None:
+        if accumulate_event is None or _accumulation_disabled:
             return
-        self._self_message = accumulate_event(
-            event=cast("RawMessageStreamEvent", chunk),
-            current_snapshot=cast(
+
+        kwargs: dict[str, Any] = {
+            "event": cast("RawMessageStreamEvent", chunk),
+            "current_snapshot": cast(
                 "ParsedMessage[ResponseFormatT] | None", self._self_message
             ),
-        )
+        }
+        if _accumulate_takes_json_bufs:
+            kwargs["json_bufs"] = self._self_json_bufs
+
+        try:
+            self._self_message = accumulate_event(**kwargs)
+        except Exception:
+            _accumulation_disabled = True
+            _logger.warning(
+                "Failed to accumulate streaming content; this Anthropic SDK "
+                "version is not supported. Future content accumulation is "
+                "suppressed; please upgrade opentelemetry-instrumentation-genai-anthropic "
+                "or report an issue.",
+                exc_info=True,
+            )
 
 
 class MessagesStreamWrapper(
@@ -164,6 +197,7 @@ class MessagesStreamWrapper(
         self._self_message = None
         self._self_capture_content = capture_content
         self._self_message_telemetry_finalized = False
+        self._self_json_bufs = {}
 
     @property
     def response(self) -> _http_lib.Response:
@@ -204,6 +238,7 @@ class AsyncMessagesStreamWrapper(
         self._self_message = None
         self._self_capture_content = capture_content
         self._self_message_telemetry_finalized = False
+        self._self_json_bufs = {}
 
     @property
     def response(self) -> _http_lib.Response:

--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/src/opentelemetry/instrumentation/genai/anthropic/wrappers.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/src/opentelemetry/instrumentation/genai/anthropic/wrappers.py
@@ -166,7 +166,7 @@ class _MessagesStreamMixin(Generic[ResponseFormatT]):
 
         try:
             self._self_message = accumulate_event(**kwargs)
-        except Exception:
+        except BaseException:
             _accumulation_disabled = True
             _logger.warning(
                 "Failed to accumulate streaming content; this Anthropic SDK "

--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/src/opentelemetry/instrumentation/genai/anthropic/wrappers.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/src/opentelemetry/instrumentation/genai/anthropic/wrappers.py
@@ -166,8 +166,10 @@ class _MessagesStreamMixin(Generic[ResponseFormatT]):
 
         try:
             self._self_message = accumulate_event(**kwargs)
-        except BaseException:
+        except BaseException as exc:
             _accumulation_disabled = True
+            if not isinstance(exc, Exception):
+                raise
             _logger.warning(
                 "Failed to accumulate streaming content; this Anthropic SDK "
                 "version is not supported. Future content accumulation is "

--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/test_async_wrappers.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/test_async_wrappers.py
@@ -572,3 +572,103 @@ def test_stream_wrapper_does_not_pass_json_bufs_when_unsupported(monkeypatch):
 
     assert len(captured_kwargs) == 1
     assert "json_bufs" not in captured_kwargs[0]
+
+
+@pytest.mark.asyncio
+async def test_async_stream_wrapper_accumulate_event_failure_logs_warning_and_disables(
+    monkeypatch, caplog
+):
+    import logging
+
+    from opentelemetry.instrumentation.genai.anthropic import wrappers
+
+    monkeypatch.setattr(wrappers, "_accumulation_disabled", False)
+
+    calls = []
+
+    def mock_accumulate(**kwargs):
+        calls.append(kwargs)
+        raise BaseException("Unexpected failure")
+
+    monkeypatch.setattr(wrappers, "accumulate_event", mock_accumulate)
+
+    stream = _FakeAsyncStream(events=["chunk1", "chunk2"])
+    wrapper = _make_async_stream_wrapper(stream)
+
+    with caplog.at_level(logging.WARNING):
+        async for _ in wrapper:
+            pass
+
+    assert len(calls) == 1
+    assert wrappers._accumulation_disabled is True
+    assert (
+        "Failed to accumulate streaming content; this Anthropic SDK version is not supported."
+        in caplog.text
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_stream_wrapper_passes_json_bufs_when_supported(
+    monkeypatch,
+):
+    from opentelemetry.instrumentation.genai.anthropic import wrappers
+
+    monkeypatch.setattr(wrappers, "_accumulation_disabled", False)
+    monkeypatch.setattr(wrappers, "_accumulate_takes_json_bufs", True)
+
+    captured_kwargs = []
+
+    def mock_accumulate(**kwargs):
+        captured_kwargs.append(kwargs)
+        return SimpleNamespace(
+            model="claude-test",
+            id="msg_1",
+            usage=None,
+            content=[],
+            stop_reason=None,
+        )
+
+    monkeypatch.setattr(wrappers, "accumulate_event", mock_accumulate)
+
+    stream = _FakeAsyncStream(events=["chunk1"])
+    wrapper = _make_async_stream_wrapper(stream)
+
+    async for _ in wrapper:
+        pass
+
+    assert len(captured_kwargs) == 1
+    assert "json_bufs" in captured_kwargs[0]
+    assert captured_kwargs[0]["json_bufs"] is wrapper._self_json_bufs
+
+
+@pytest.mark.asyncio
+async def test_async_stream_wrapper_does_not_pass_json_bufs_when_unsupported(
+    monkeypatch,
+):
+    from opentelemetry.instrumentation.genai.anthropic import wrappers
+
+    monkeypatch.setattr(wrappers, "_accumulation_disabled", False)
+    monkeypatch.setattr(wrappers, "_accumulate_takes_json_bufs", False)
+
+    captured_kwargs = []
+
+    def mock_accumulate(**kwargs):
+        captured_kwargs.append(kwargs)
+        return SimpleNamespace(
+            model="claude-test",
+            id="msg_1",
+            usage=None,
+            content=[],
+            stop_reason=None,
+        )
+
+    monkeypatch.setattr(wrappers, "accumulate_event", mock_accumulate)
+
+    stream = _FakeAsyncStream(events=["chunk1"])
+    wrapper = _make_async_stream_wrapper(stream)
+
+    async for _ in wrapper:
+        pass
+
+    assert len(captured_kwargs) == 1
+    assert "json_bufs" not in captured_kwargs[0]

--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/test_async_wrappers.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/test_async_wrappers.py
@@ -482,3 +482,93 @@ async def test_async_manager_enter_constructs_async_stream_wrapper():
     async with wrapper as result:
         assert isinstance(result, AsyncMessagesStreamWrapper)
         assert result.stream is stream
+
+
+def test_stream_wrapper_accumulate_event_failure_logs_warning_and_disables(
+    monkeypatch, caplog
+):
+    import logging
+
+    from opentelemetry.instrumentation.genai.anthropic import wrappers
+
+    monkeypatch.setattr(wrappers, "_accumulation_disabled", False)
+
+    calls = []
+
+    def mock_accumulate(**kwargs):
+        calls.append(kwargs)
+        raise TypeError("Unexpected argument in new SDK version")
+
+    monkeypatch.setattr(wrappers, "accumulate_event", mock_accumulate)
+
+    stream = _FakeSyncStream(events=["chunk1", "chunk2"])
+    wrapper = _make_stream_wrapper(stream)
+
+    with caplog.at_level(logging.WARNING):
+        list(wrapper)
+
+    assert len(calls) == 1
+    assert wrappers._accumulation_disabled is True
+    assert (
+        "Failed to accumulate streaming content; this Anthropic SDK version is not supported."
+        in caplog.text
+    )
+
+
+def test_stream_wrapper_passes_json_bufs_when_supported(monkeypatch):
+    from opentelemetry.instrumentation.genai.anthropic import wrappers
+
+    monkeypatch.setattr(wrappers, "_accumulation_disabled", False)
+    monkeypatch.setattr(wrappers, "_accumulate_takes_json_bufs", True)
+
+    captured_kwargs = []
+
+    def mock_accumulate(**kwargs):
+        captured_kwargs.append(kwargs)
+        return SimpleNamespace(
+            model="claude-test",
+            id="msg_1",
+            usage=None,
+            content=[],
+            stop_reason=None,
+        )
+
+    monkeypatch.setattr(wrappers, "accumulate_event", mock_accumulate)
+
+    stream = _FakeSyncStream(events=["chunk1"])
+    wrapper = _make_stream_wrapper(stream)
+
+    list(wrapper)
+
+    assert len(captured_kwargs) == 1
+    assert "json_bufs" in captured_kwargs[0]
+    assert captured_kwargs[0]["json_bufs"] is wrapper._self_json_bufs
+
+
+def test_stream_wrapper_does_not_pass_json_bufs_when_unsupported(monkeypatch):
+    from opentelemetry.instrumentation.genai.anthropic import wrappers
+
+    monkeypatch.setattr(wrappers, "_accumulation_disabled", False)
+    monkeypatch.setattr(wrappers, "_accumulate_takes_json_bufs", False)
+
+    captured_kwargs = []
+
+    def mock_accumulate(**kwargs):
+        captured_kwargs.append(kwargs)
+        return SimpleNamespace(
+            model="claude-test",
+            id="msg_1",
+            usage=None,
+            content=[],
+            stop_reason=None,
+        )
+
+    monkeypatch.setattr(wrappers, "accumulate_event", mock_accumulate)
+
+    stream = _FakeSyncStream(events=["chunk1"])
+    wrapper = _make_stream_wrapper(stream)
+
+    list(wrapper)
+
+    assert len(captured_kwargs) == 1
+    assert "json_bufs" not in captured_kwargs[0]

--- a/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/test_async_wrappers.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-anthropic/tests/test_async_wrappers.py
@@ -588,7 +588,7 @@ async def test_async_stream_wrapper_accumulate_event_failure_logs_warning_and_di
 
     def mock_accumulate(**kwargs):
         calls.append(kwargs)
-        raise BaseException("Unexpected failure")
+        raise TypeError("Unexpected argument in new SDK version")
 
     monkeypatch.setattr(wrappers, "accumulate_event", mock_accumulate)
 
@@ -605,6 +605,46 @@ async def test_async_stream_wrapper_accumulate_event_failure_logs_warning_and_di
         "Failed to accumulate streaming content; this Anthropic SDK version is not supported."
         in caplog.text
     )
+
+
+def test_stream_wrapper_reraises_non_exception(monkeypatch):
+    from opentelemetry.instrumentation.genai.anthropic import wrappers
+
+    monkeypatch.setattr(wrappers, "_accumulation_disabled", False)
+
+    def mock_accumulate(**kwargs):
+        raise KeyboardInterrupt()
+
+    monkeypatch.setattr(wrappers, "accumulate_event", mock_accumulate)
+
+    stream = _FakeSyncStream(events=["chunk1"])
+    wrapper = _make_stream_wrapper(stream)
+
+    with pytest.raises(KeyboardInterrupt):
+        list(wrapper)
+
+    assert wrappers._accumulation_disabled is True
+
+
+@pytest.mark.asyncio
+async def test_async_stream_wrapper_reraises_non_exception(monkeypatch):
+    from opentelemetry.instrumentation.genai.anthropic import wrappers
+
+    monkeypatch.setattr(wrappers, "_accumulation_disabled", False)
+
+    def mock_accumulate(**kwargs):
+        raise KeyboardInterrupt()
+
+    monkeypatch.setattr(wrappers, "accumulate_event", mock_accumulate)
+
+    stream = _FakeAsyncStream(events=["chunk1"])
+    wrapper = _make_async_stream_wrapper(stream)
+
+    with pytest.raises(KeyboardInterrupt):
+        async for _ in wrapper:
+            pass
+
+    assert wrappers._accumulation_disabled is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes streaming message accumulation failure with Anthropic SDK >=1.5.0 caused by the added json_bufs parameter on accumulate_event. Also gracefully disables future content accumulation with a warning if accumulate_event fails unexpectedly.