### PR TITLE
feat(google-genai): extract modality token usage attributes on generate_content

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/.changelog/674.changed
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/.changelog/674.changed
@@ -1,0 +1,1 @@
+Record modality token usage through the shared `InferenceInvocation` setters; `extract_token_details` no longer returns modality keys.

--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/src/opentelemetry/instrumentation/genai/langchain/callback_handler.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/src/opentelemetry/instrumentation/genai/langchain/callback_handler.py
@@ -36,6 +36,7 @@ from opentelemetry.instrumentation.genai.langchain.utils import (
     is_stream_end_marker,
     make_input_message,
     make_last_output_message,
+    modality_tokens,
     normalize_provider,
     prepare_tool_definitions,
     resolve_response_model_and_id,
@@ -561,35 +562,16 @@ class OpenTelemetryLangChainCallbackHandler(BaseCallbackHandler):
                         ) is not None:
                             llm_invocation.thinking_tokens = reasoning_tokens
 
-                        if (
-                            text_in := token_details.get("text_input_tokens")
-                        ) is not None:
-                            llm_invocation.text_input_tokens = text_in
-                        if (
-                            image_in := token_details.get("image_input_tokens")
-                        ) is not None:
-                            llm_invocation.image_input_tokens = image_in
-                        if (
-                            audio_in := token_details.get("audio_input_tokens")
-                        ) is not None:
-                            llm_invocation.audio_input_tokens = audio_in
-
-                        if (
-                            text_out := token_details.get("text_output_tokens")
-                        ) is not None:
-                            llm_invocation.text_output_tokens = text_out
-                        if (
-                            image_out := token_details.get(
-                                "image_output_tokens"
+                        llm_invocation.set_input_tokens(
+                            modality_tokens(
+                                usage_metadata, "input_token_details"
                             )
-                        ) is not None:
-                            llm_invocation.image_output_tokens = image_out
-                        if (
-                            audio_out := token_details.get(
-                                "audio_output_tokens"
+                        )
+                        llm_invocation.set_output_tokens(
+                            modality_tokens(
+                                usage_metadata, "output_token_details"
                             )
-                        ) is not None:
-                            llm_invocation.audio_output_tokens = audio_out
+                        )
 
                         llm_invocation.output_tokens = output_tokens
 

--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/src/opentelemetry/instrumentation/genai/langchain/utils.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/src/opentelemetry/instrumentation/genai/langchain/utils.py
@@ -29,6 +29,7 @@ from opentelemetry.util.genai.types import (
     FunctionToolDefinition,
     InputMessage,
     MessagePart,
+    ModalityTokens,
     OutputMessage,
     ReasoningPart,
     Role,
@@ -617,7 +618,7 @@ def resolve_response_model_and_id(
 
 
 def extract_token_details(usage_metadata: dict[str, Any]) -> dict[str, int]:
-    """Extract cache, reasoning, and modality token break-downs from LangChain usage metadata."""
+    """Extract cache and reasoning token break-downs from LangChain usage metadata."""
 
     token_details: dict[str, int] = {}
     raw_input_details = usage_metadata.get("input_token_details")
@@ -655,20 +656,19 @@ def extract_token_details(usage_metadata: dict[str, Any]) -> dict[str, int]:
     ) is not None:
         token_details["reasoning_tokens"] = reasoning
 
-    # Input modality breakdowns
-    if (text_in := _get_positive_int(input_details, "text")) is not None:
-        token_details["text_input_tokens"] = text_in
-    if (image_in := _get_positive_int(input_details, "image")) is not None:
-        token_details["image_input_tokens"] = image_in
-    if (audio_in := _get_positive_int(input_details, "audio")) is not None:
-        token_details["audio_input_tokens"] = audio_in
-
-    # Output modality breakdowns
-    if (text_out := _get_positive_int(output_details, "text")) is not None:
-        token_details["text_output_tokens"] = text_out
-    if (image_out := _get_positive_int(output_details, "image")) is not None:
-        token_details["image_output_tokens"] = image_out
-    if (audio_out := _get_positive_int(output_details, "audio")) is not None:
-        token_details["audio_output_tokens"] = audio_out
-
     return token_details
+
+
+def modality_tokens(
+    usage_metadata: Mapping[str, Any], key: str
+) -> ModalityTokens | None:
+    """Read one of LangChain's ``*_token_details`` maps as modality pairs.
+
+    Returns ``None`` when the key is absent or not a mapping, so the caller
+    leaves any previously recorded breakdown alone. Non-modality keys such as
+    ``cache_read`` and ``reasoning`` are dropped downstream.
+    """
+    details = usage_metadata.get(key)
+    if not isinstance(details, Mapping):
+        return None
+    return list(cast("Mapping[str, int | None]", details).items())

--- a/instrumentation/opentelemetry-instrumentation-genai-langchain/tests/test_callback_handler.py
+++ b/instrumentation/opentelemetry-instrumentation-genai-langchain/tests/test_callback_handler.py
@@ -1663,14 +1663,48 @@ class TestOnLlmEndTokenDetails:
 
         handler.on_llm_end(response=response, run_id=run_id)
 
+        # The breakdown is applied by InferenceInvocation, so the handler's
+        # contract is the pairs it forwards. util-genai covers the mapping
+        # from those pairs onto span attributes.
         assert llm_inv.input_tokens == 100
-        assert llm_inv.text_input_tokens == 70
-        assert llm_inv.image_input_tokens == 20
-        assert llm_inv.audio_input_tokens == 10
         assert llm_inv.output_tokens == 50
-        assert llm_inv.text_output_tokens == 35
-        assert llm_inv.image_output_tokens == 10
-        assert llm_inv.audio_output_tokens == 5
+        # LangChain's pydantic model reorders the details mapping, so compare
+        # the pairs rather than their order.
+        (input_pairs,), _ = llm_inv.set_input_tokens.call_args
+        assert sorted(input_pairs) == [
+            ("audio", 10),
+            ("image", 20),
+            ("text", 70),
+        ]
+        (output_pairs,), _ = llm_inv.set_output_tokens.call_args
+        assert sorted(output_pairs) == [
+            ("audio", 5),
+            ("image", 10),
+            ("text", 35),
+        ]
+
+    def test_absent_token_details_forward_none(self):
+        run_id = _run_id()
+        handler, _, llm_inv = _make_handler_with_llm_invocation(run_id)
+
+        ai_msg = AIMessage(
+            content="hi",
+            usage_metadata={
+                "input_tokens": 1,
+                "output_tokens": 2,
+                "total_tokens": 3,
+            },
+        )
+        gen = ChatGeneration(
+            message=ai_msg, generation_info={"finish_reason": "stop"}
+        )
+
+        handler.on_llm_end(
+            response=LLMResult(generations=[[gen]]), run_id=run_id
+        )
+
+        llm_inv.set_input_tokens.assert_called_once_with(None)
+        llm_inv.set_output_tokens.assert_called_once_with(None)
 
 
 # ---------------------------------------------------------------------------
@@ -1728,17 +1762,13 @@ def test_extract_token_details_modalities():
             "reasoning": 10,
         },
     }
+    # Modality break-downs are forwarded to InferenceInvocation rather than
+    # flattened here, so only cache and reasoning remain.
     details = extract_token_details(usage)
     assert details == {
         "cache_write_input_tokens": 15,
         "cache_read_input_tokens": 25,
-        "text_input_tokens": 70,
-        "image_input_tokens": 20,
-        "audio_input_tokens": 10,
         "reasoning_tokens": 10,
-        "text_output_tokens": 30,
-        "image_output_tokens": 15,
-        "audio_output_tokens": 5,
     }
 
 

--- a/instrumentation/opentelemetry-instrumentation-google-genai/.changelog/674.added
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/.changelog/674.added
@@ -1,0 +1,1 @@
+Record modality token usage breakdown attributes (text, image, audio) for generate_content.

--- a/instrumentation/opentelemetry-instrumentation-google-genai/src/opentelemetry/instrumentation/google_genai/generate_content.py
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/src/opentelemetry/instrumentation/google_genai/generate_content.py
@@ -3,7 +3,7 @@
 
 import json
 import os
-from collections.abc import AsyncIterable, Callable, Iterable
+from collections.abc import AsyncIterable, Callable, Iterable, Mapping
 from typing import Any
 
 from google.genai.models import AsyncModels, Models
@@ -14,6 +14,7 @@ from google.genai.types import (
     GenerateContentConfig,
     GenerateContentConfigOrDict,
     GenerateContentResponse,
+    ModalityTokenCount,
     Tool,
     ToolUnionDict,
 )
@@ -346,6 +347,50 @@ def _apply_request_attributes(
     )
 
 
+_INPUT_MODALITY_FIELDS = {
+    "text": "text_input_tokens",
+    "image": "image_input_tokens",
+    "audio": "audio_input_tokens",
+}
+_OUTPUT_MODALITY_FIELDS = {
+    "text": "text_output_tokens",
+    "image": "image_output_tokens",
+    "audio": "audio_output_tokens",
+}
+_CACHE_READ_MODALITY_FIELDS = {
+    "text": "text_cache_read_input_tokens",
+    "image": "image_cache_read_input_tokens",
+    "audio": "audio_cache_read_input_tokens",
+}
+
+
+def _set_modality_tokens(
+    invocation: InferenceInvocation,
+    entries: list[ModalityTokenCount] | None,
+    fields: Mapping[str, str],
+) -> None:
+    if entries is None:
+        return
+    # A streaming chunk redelivers the whole breakdown, so an arriving one has
+    # to replace the previous values: a modality that drops out of a later
+    # chunk would otherwise keep a stale count and push the breakdown over the
+    # total reported alongside it.
+    for field_name in fields.values():
+        setattr(invocation, field_name, None)
+    for entry in entries:
+        modality = entry.modality
+        token_count = entry.token_count
+        if modality is None or not isinstance(token_count, int):
+            continue
+        # modality is a MediaModality enum, so str() would yield
+        # "MediaModality.AUDIO" rather than the bare modality name.
+        field_name = fields.get(
+            str(getattr(modality, "value", modality)).lower()
+        )
+        if field_name is not None:
+            setattr(invocation, field_name, token_count)
+
+
 def _get_response_property(response: GenerateContentResponse, path: str):
     path_segments = path.split(".")
     current_context = response
@@ -423,6 +468,27 @@ def _apply_response_attributes(
         invocation.output_tokens = (
             invocation.output_tokens or 0
         ) + thinking_tokens
+    _set_modality_tokens(
+        invocation,
+        _get_response_property(
+            response, "usage_metadata.prompt_tokens_details"
+        ),
+        _INPUT_MODALITY_FIELDS,
+    )
+    _set_modality_tokens(
+        invocation,
+        _get_response_property(
+            response, "usage_metadata.candidates_tokens_details"
+        ),
+        _OUTPUT_MODALITY_FIELDS,
+    )
+    _set_modality_tokens(
+        invocation,
+        _get_response_property(
+            response, "usage_metadata.cache_tokens_details"
+        ),
+        _CACHE_READ_MODALITY_FIELDS,
+    )
 
 
 def _maybe_get_tool_definitions(

--- a/instrumentation/opentelemetry-instrumentation-google-genai/src/opentelemetry/instrumentation/google_genai/generate_content.py
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/src/opentelemetry/instrumentation/google_genai/generate_content.py
@@ -436,15 +436,16 @@ def _apply_response_attributes(
         invocation.output_tokens = (
             invocation.output_tokens or 0
         ) + thinking_tokens
-    invocation.set_input_tokens(
-        _modality_tokens(response, "usage_metadata.prompt_tokens_details")
-    )
-    invocation.set_output_tokens(
-        _modality_tokens(response, "usage_metadata.candidates_tokens_details")
-    )
-    invocation.set_cache_read_input_tokens(
-        _modality_tokens(response, "usage_metadata.cache_tokens_details")
-    )
+    if response.usage_metadata is not None:
+        invocation.set_input_tokens(
+            _modality_tokens(response, "usage_metadata.prompt_tokens_details")
+        )
+        invocation.set_output_tokens(
+            _modality_tokens(response, "usage_metadata.candidates_tokens_details")
+        )
+        invocation.set_cache_read_input_tokens(
+            _modality_tokens(response, "usage_metadata.cache_tokens_details")
+        )
 
 
 def _maybe_get_tool_definitions(

--- a/instrumentation/opentelemetry-instrumentation-google-genai/src/opentelemetry/instrumentation/google_genai/generate_content.py
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/src/opentelemetry/instrumentation/google_genai/generate_content.py
@@ -3,7 +3,7 @@
 
 import json
 import os
-from collections.abc import AsyncIterable, Callable, Iterable, Mapping
+from collections.abc import AsyncIterable, Callable, Iterable
 from typing import Any
 
 from google.genai.models import AsyncModels, Models
@@ -35,6 +35,7 @@ from opentelemetry.util.genai.stream import (
 from opentelemetry.util.genai.types import (
     FunctionToolDefinition,
     GenericToolDefinition,
+    ModalityTokens,
     ToolDefinition,
 )
 from opentelemetry.util.types import AttributeValue
@@ -347,48 +348,15 @@ def _apply_request_attributes(
     )
 
 
-_INPUT_MODALITY_FIELDS = {
-    "text": "text_input_tokens",
-    "image": "image_input_tokens",
-    "audio": "audio_input_tokens",
-}
-_OUTPUT_MODALITY_FIELDS = {
-    "text": "text_output_tokens",
-    "image": "image_output_tokens",
-    "audio": "audio_output_tokens",
-}
-_CACHE_READ_MODALITY_FIELDS = {
-    "text": "text_cache_read_input_tokens",
-    "image": "image_cache_read_input_tokens",
-    "audio": "audio_cache_read_input_tokens",
-}
-
-
-def _set_modality_tokens(
-    invocation: InferenceInvocation,
-    entries: list[ModalityTokenCount] | None,
-    fields: Mapping[str, str],
-) -> None:
+def _modality_tokens(
+    response: GenerateContentResponse, path: str
+) -> ModalityTokens | None:
+    entries: list[ModalityTokenCount] | None = _get_response_property(
+        response, path
+    )
     if entries is None:
-        return
-    # A streaming chunk redelivers the whole breakdown, so an arriving one has
-    # to replace the previous values: a modality that drops out of a later
-    # chunk would otherwise keep a stale count and push the breakdown over the
-    # total reported alongside it.
-    for field_name in fields.values():
-        setattr(invocation, field_name, None)
-    for entry in entries:
-        modality = entry.modality
-        token_count = entry.token_count
-        if modality is None or not isinstance(token_count, int):
-            continue
-        # modality is a MediaModality enum, so str() would yield
-        # "MediaModality.AUDIO" rather than the bare modality name.
-        field_name = fields.get(
-            str(getattr(modality, "value", modality)).lower()
-        )
-        if field_name is not None:
-            setattr(invocation, field_name, token_count)
+        return None
+    return [(entry.modality or "", entry.token_count) for entry in entries]
 
 
 def _get_response_property(response: GenerateContentResponse, path: str):
@@ -468,26 +436,14 @@ def _apply_response_attributes(
         invocation.output_tokens = (
             invocation.output_tokens or 0
         ) + thinking_tokens
-    _set_modality_tokens(
-        invocation,
-        _get_response_property(
-            response, "usage_metadata.prompt_tokens_details"
-        ),
-        _INPUT_MODALITY_FIELDS,
+    invocation.set_input_tokens(
+        _modality_tokens(response, "usage_metadata.prompt_tokens_details")
     )
-    _set_modality_tokens(
-        invocation,
-        _get_response_property(
-            response, "usage_metadata.candidates_tokens_details"
-        ),
-        _OUTPUT_MODALITY_FIELDS,
+    invocation.set_output_tokens(
+        _modality_tokens(response, "usage_metadata.candidates_tokens_details")
     )
-    _set_modality_tokens(
-        invocation,
-        _get_response_property(
-            response, "usage_metadata.cache_tokens_details"
-        ),
-        _CACHE_READ_MODALITY_FIELDS,
+    invocation.set_cache_read_input_tokens(
+        _modality_tokens(response, "usage_metadata.cache_tokens_details")
     )
 
 

--- a/instrumentation/opentelemetry-instrumentation-google-genai/src/opentelemetry/instrumentation/google_genai/interactions.py
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/src/opentelemetry/instrumentation/google_genai/interactions.py
@@ -98,6 +98,7 @@ from opentelemetry.util.genai.types import (
     GenericPart,
     GenericToolDefinition,
     InputMessage,
+    ModalityTokens,
     OutputMessage,
     Role,
     TextPart,
@@ -152,47 +153,30 @@ def _apply_interaction_response_attributes(
     if isinstance(invocation, InferenceInvocation):
         invocation.thinking_tokens = usage.total_thought_tokens
 
-        def _set_modality_tokens(
-            entries: Any,
-            text_attr: str,
-            image_attr: str,
-            audio_attr: str,
-        ) -> None:
-            for entry in entries or []:
-                modality = _get_field(entry, "modality")
-                tokens = _get_field(entry, "tokens")
-                if modality and tokens is not None:
-                    m = str(modality).lower()
-                    if m == "text":
-                        setattr(invocation, text_attr, tokens)
-                    elif m == "image":
-                        setattr(invocation, image_attr, tokens)
-                    elif m == "audio":
-                        setattr(invocation, audio_attr, tokens)
-
-        _set_modality_tokens(
-            _get_field(usage, "input_tokens_by_modality"),
-            "text_input_tokens",
-            "image_input_tokens",
-            "audio_input_tokens",
+        invocation.set_input_tokens(
+            _modality_tokens(usage, "input_tokens_by_modality")
         )
-        _set_modality_tokens(
-            _get_field(usage, "output_tokens_by_modality"),
-            "text_output_tokens",
-            "image_output_tokens",
-            "audio_output_tokens",
+        invocation.set_output_tokens(
+            _modality_tokens(usage, "output_tokens_by_modality")
         )
-        _set_modality_tokens(
-            _get_field(usage, "cached_tokens_by_modality"),
-            "text_cache_read_input_tokens",
-            "image_cache_read_input_tokens",
-            "audio_cache_read_input_tokens",
+        invocation.set_cache_read_input_tokens(
+            _modality_tokens(usage, "cached_tokens_by_modality")
         )
 
     if telemetry_handler.should_capture_content():
         invocation.output_messages = _interactions_response_to_messages(
             response
         )
+
+
+def _modality_tokens(usage: Any, name: str) -> ModalityTokens | None:
+    entries = _get_field(usage, name)
+    if entries is None:
+        return None
+    return [
+        (_get_field(entry, "modality") or "", _get_field(entry, "tokens"))
+        for entry in entries
+    ]
 
 
 def _get_field(obj: Any, name: str) -> Any:

--- a/instrumentation/opentelemetry-instrumentation-google-genai/tests/generate_content/nonstreaming_base.py
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/tests/generate_content/nonstreaming_base.py
@@ -9,7 +9,10 @@ from google.genai import errors as genai_errors
 from google.genai.types import (
     FunctionDeclarationDict,
     GenerateContentConfig,
+    GenerateContentResponseUsageMetadata,
     GoogleMaps,
+    MediaModality,
+    ModalityTokenCount,
     ToolDict,
 )
 from pydantic import BaseModel, Field
@@ -336,6 +339,89 @@ class NonStreamingTestCase(TestCase):
         self.assertEqual(
             span.attributes["gen_ai.usage.reasoning.output_tokens"], 17
         )
+
+    def test_generated_span_counts_modality_tokens(self):
+        usage_metadata = GenerateContentResponseUsageMetadata(
+            prompt_tokens_details=[
+                ModalityTokenCount(
+                    modality=MediaModality.TEXT, token_count=11
+                ),
+                ModalityTokenCount(
+                    modality=MediaModality.AUDIO, token_count=22
+                ),
+            ],
+            candidates_tokens_details=[
+                ModalityTokenCount(
+                    modality=MediaModality.AUDIO, token_count=33
+                ),
+                ModalityTokenCount(
+                    modality=MediaModality.IMAGE, token_count=44
+                ),
+            ],
+            cache_tokens_details=[
+                ModalityTokenCount(
+                    modality=MediaModality.TEXT, token_count=55
+                ),
+                ModalityTokenCount(
+                    modality=MediaModality.IMAGE, token_count=66
+                ),
+            ],
+        )
+        self.configure_valid_response(usage_metadata=usage_metadata)
+        self.generate_content(model="gemini-2.0-flash", contents="Some input")
+        span = self.otel.get_span_named("generate_content gemini-2.0-flash")
+        for attribute, value in (
+            ("gen_ai.usage.text.input_tokens", 11),
+            ("gen_ai.usage.audio.input_tokens", 22),
+            ("gen_ai.usage.audio.output_tokens", 33),
+            ("gen_ai.usage.image.output_tokens", 44),
+            ("gen_ai.usage.text.cache_read.input_tokens", 55),
+            ("gen_ai.usage.image.cache_read.input_tokens", 66),
+        ):
+            self.assertIsInstance(span.attributes[attribute], int)
+            self.assertEqual(span.attributes[attribute], value)
+        for attribute in (
+            "gen_ai.usage.image.input_tokens",
+            "gen_ai.usage.text.output_tokens",
+            "gen_ai.usage.audio.cache_read.input_tokens",
+        ):
+            self.assertNotIn(attribute, span.attributes)
+
+    def test_generated_span_skips_unmapped_modality_tokens(self):
+        usage_metadata = GenerateContentResponseUsageMetadata(
+            prompt_tokens_details=[
+                ModalityTokenCount(
+                    modality=MediaModality.VIDEO, token_count=7
+                ),
+                ModalityTokenCount(modality=MediaModality.TEXT),
+            ],
+        )
+        self.configure_valid_response(usage_metadata=usage_metadata)
+        self.generate_content(model="gemini-2.0-flash", contents="Some input")
+        span = self.otel.get_span_named("generate_content gemini-2.0-flash")
+        for attribute in (
+            "gen_ai.usage.text.input_tokens",
+            "gen_ai.usage.image.input_tokens",
+            "gen_ai.usage.audio.input_tokens",
+        ):
+            self.assertNotIn(attribute, span.attributes)
+
+    def test_generated_span_omits_modality_tokens_when_absent(self):
+        self.configure_valid_response(input_tokens=1, output_tokens=2)
+        self.generate_content(model="gemini-2.0-flash", contents="Some input")
+        span = self.otel.get_span_named("generate_content gemini-2.0-flash")
+        for attribute in (
+            "gen_ai.usage.text.input_tokens",
+            "gen_ai.usage.image.input_tokens",
+            "gen_ai.usage.audio.input_tokens",
+            "gen_ai.usage.text.output_tokens",
+            "gen_ai.usage.image.output_tokens",
+            "gen_ai.usage.audio.output_tokens",
+            "gen_ai.usage.text.cache_read.input_tokens",
+            "gen_ai.usage.image.cache_read.input_tokens",
+            "gen_ai.usage.audio.cache_read.input_tokens",
+        ):
+            self.assertNotIn(attribute, span.attributes)
 
     def test_generated_span_records_response_model(self):
         self.configure_valid_response(model_version="gemini-2.0-flash-001")

--- a/instrumentation/opentelemetry-instrumentation-google-genai/tests/generate_content/streaming_base.py
+++ b/instrumentation/opentelemetry-instrumentation-google-genai/tests/generate_content/streaming_base.py
@@ -3,6 +3,12 @@
 
 import unittest
 
+from google.genai.types import (
+    GenerateContentResponseUsageMetadata,
+    MediaModality,
+    ModalityTokenCount,
+)
+
 from opentelemetry import context as context_api
 from opentelemetry.instrumentation.google_genai import (
     GENERATE_CONTENT_EXTRA_ATTRIBUTES_CONTEXT_KEY,
@@ -92,6 +98,62 @@ class StreamingTestCase(TestCase):
         self.assertEqual(span.attributes["gen_ai.response.id"], "qwerty19")
         self.assertEqual(span.attributes["gen_ai.usage.input_tokens"], 3)
         self.assertEqual(span.attributes["gen_ai.usage.output_tokens"], 5)
+
+    def test_modality_token_counts_are_replaced_not_merged(self):
+        # Cumulative counts are returned on each response, so the last
+        # breakdown wins outright and a modality that drops out of it must not
+        # survive from an earlier chunk.
+        self.configure_valid_response(
+            usage_metadata=GenerateContentResponseUsageMetadata(
+                prompt_tokens_details=[
+                    ModalityTokenCount(
+                        modality=MediaModality.TEXT, token_count=10
+                    ),
+                    ModalityTokenCount(
+                        modality=MediaModality.AUDIO, token_count=90
+                    ),
+                ],
+            ),
+            response_id="qwerty17",
+        )
+        self.configure_valid_response(
+            usage_metadata=GenerateContentResponseUsageMetadata(
+                prompt_tokens_details=[
+                    ModalityTokenCount(
+                        modality=MediaModality.TEXT, token_count=12
+                    ),
+                ],
+            ),
+            response_id="qwerty18",
+        )
+
+        self.generate_content(model="gemini-2.0-flash", contents="Some input")
+
+        span = self.otel.get_span_named("generate_content gemini-2.0-flash")
+        self.assertEqual(span.attributes["gen_ai.response.id"], "qwerty18")
+        self.assertEqual(span.attributes["gen_ai.usage.text.input_tokens"], 12)
+        self.assertNotIn("gen_ai.usage.audio.input_tokens", span.attributes)
+
+    def test_modality_token_counts_survive_a_chunk_without_a_breakdown(self):
+        self.configure_valid_response(
+            usage_metadata=GenerateContentResponseUsageMetadata(
+                prompt_tokens_details=[
+                    ModalityTokenCount(
+                        modality=MediaModality.AUDIO, token_count=90
+                    ),
+                ],
+            ),
+            response_id="qwerty17",
+        )
+        self.configure_valid_response(response_id="qwerty18")
+
+        self.generate_content(model="gemini-2.0-flash", contents="Some input")
+
+        span = self.otel.get_span_named("generate_content gemini-2.0-flash")
+        self.assertEqual(span.attributes["gen_ai.response.id"], "qwerty18")
+        self.assertEqual(
+            span.attributes["gen_ai.usage.audio.input_tokens"], 90
+        )
 
     def test_log_has_extra_genai_attributes(self):
         self.configure_valid_response(text="Yep, it works!")

--- a/util/opentelemetry-util-genai/.changelog/674.added
+++ b/util/opentelemetry-util-genai/.changelog/674.added
@@ -1,0 +1,1 @@
+Add `InferenceInvocation.set_input_tokens`, `set_output_tokens` and `set_cache_read_input_tokens` for recording per-modality token breakdowns, and add `text` to `Modality`.

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_inference_invocation.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_inference_invocation.py
@@ -24,6 +24,7 @@ from opentelemetry.util.genai.types import (
     ErrorTypeResolver,
     InputMessage,
     MessagePart,
+    ModalityTokens,
     OutputMessage,
     SystemInstructionPart,
     ToolDefinition,
@@ -52,6 +53,21 @@ _GEN_AI_USAGE_IMAGE_CACHE_READ_INPUT_TOKENS: Final = (
 _GEN_AI_USAGE_AUDIO_CACHE_READ_INPUT_TOKENS: Final = (
     "gen_ai.usage.audio.cache_read.input_tokens"
 )
+_INPUT_MODALITY_FIELDS: Final[Mapping[str, str]] = {
+    "text": "text_input_tokens",
+    "image": "image_input_tokens",
+    "audio": "audio_input_tokens",
+}
+_OUTPUT_MODALITY_FIELDS: Final[Mapping[str, str]] = {
+    "text": "text_output_tokens",
+    "image": "image_output_tokens",
+    "audio": "audio_output_tokens",
+}
+_CACHE_READ_MODALITY_FIELDS: Final[Mapping[str, str]] = {
+    "text": "text_cache_read_input_tokens",
+    "image": "image_cache_read_input_tokens",
+    "audio": "audio_cache_read_input_tokens",
+}
 _GEN_AI_REQUEST_REASONING_LEVEL: Final = "gen_ai.request.reasoning.level"
 _GEN_AI_REQUEST_PREVIOUS_RESPONSE_ID: Final = (
     "gen_ai.request.previous_response.id"
@@ -148,6 +164,61 @@ class InferenceInvocation(GenAIInvocation):
         # _invalidate_metric_attributes whenever an input changes.
         self._cached_metric_attributes: dict[str, AttributeValue] | None = None
         self._start(self._get_start_attributes())
+
+    def set_input_tokens(self, entries: ModalityTokens | None) -> None:
+        """Record the per-modality breakdown of the input tokens.
+
+        Sets ``gen_ai.usage.{text,image,audio}.input_tokens`` from
+        ``entries``, an iterable of ``(modality, token count)`` pairs.
+        The modality may be a plain string or an enum member carrying one as
+        its ``value``; anything outside text, image and audio is dropped, as is
+        a count that is not a non-negative :class:`int`.
+
+        The breakdown is replaced wholesale, so a modality missing from
+        ``entries`` is cleared. Pass ``None`` to leave the current values
+        alone, which is what a streaming chunk carrying no usage should do.
+        """
+        self._set_modality_tokens(_INPUT_MODALITY_FIELDS, entries)
+
+    def set_output_tokens(self, entries: ModalityTokens | None) -> None:
+        """Record the per-modality breakdown of the output tokens.
+
+        Sets ``gen_ai.usage.{text,image,audio}.output_tokens``. See
+        :meth:`set_input_tokens` for the argument contract.
+        """
+        self._set_modality_tokens(_OUTPUT_MODALITY_FIELDS, entries)
+
+    def set_cache_read_input_tokens(
+        self, entries: ModalityTokens | None
+    ) -> None:
+        """Record the per-modality breakdown of the cache read input tokens.
+
+        Sets ``gen_ai.usage.{text,image,audio}.cache_read.input_tokens``. See
+        :meth:`set_input_tokens` for the argument contract.
+        """
+        self._set_modality_tokens(_CACHE_READ_MODALITY_FIELDS, entries)
+
+    def _set_modality_tokens(
+        self, fields: Mapping[str, str], entries: ModalityTokens | None
+    ) -> None:
+        if entries is None:
+            return
+        for field_name in fields.values():
+            setattr(self, field_name, None)
+        for modality, token_count in entries:
+            if (
+                not isinstance(token_count, int)
+                or isinstance(token_count, bool)
+                or token_count < 0
+            ):
+                continue
+            # modality may be an enum, whose str() is "MediaModality.AUDIO"
+            # rather than the bare name.
+            field_name = fields.get(
+                str(getattr(modality, "value", modality)).lower()
+            )
+            if field_name is not None:
+                setattr(self, field_name, token_count)
 
     @property
     def cache_creation_input_tokens(self) -> int | None:

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/types.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/types.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from enum import Enum
 from typing import (
@@ -154,7 +154,14 @@ class CompactionPart:
     type: Literal["compaction"] = "compaction"
 
 
-Modality = Literal["image", "video", "audio", "document"]
+Modality = Literal["text", "image", "video", "audio", "document"]
+
+ModalityTokens: TypeAlias = Iterable[tuple[Modality | str, int | None]]
+"""A per-modality token breakdown, as ``(modality, token count)`` pairs.
+
+The modality may be a plain string or an enum member carrying one as its
+``value``, so a provider SDK's own enum can be passed straight through.
+"""
 
 
 @dataclass()

--- a/util/opentelemetry-util-genai/tests/test_utils.py
+++ b/util/opentelemetry-util-genai/tests/test_utils.py
@@ -7,6 +7,7 @@ import os
 import unittest
 from collections.abc import Mapping
 from dataclasses import asdict
+from enum import Enum
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -1133,6 +1134,127 @@ class TestTelemetryHandler(unittest.TestCase):
         assert attrs["gen_ai.usage.text.cache_read.input_tokens"] == 5
         assert attrs["gen_ai.usage.image.cache_read.input_tokens"] == 6
         assert attrs["gen_ai.usage.audio.cache_read.input_tokens"] == 7
+
+    def test_set_modality_tokens_records_each_bucket(self):
+        invocation = self.telemetry_handler.inference(
+            "test-provider", request_model="test-model"
+        )
+        invocation.set_input_tokens(
+            [("text", 10), ("image", 20), ("audio", 30)]
+        )
+        invocation.set_output_tokens(
+            [("text", 40), ("image", 50), ("audio", 60)]
+        )
+        invocation.set_cache_read_input_tokens(
+            [("text", 5), ("image", 6), ("audio", 7)]
+        )
+        invocation.stop()
+
+        attrs = self.span_exporter.get_finished_spans()[0].attributes
+        for key, value in (
+            ("gen_ai.usage.text.input_tokens", 10),
+            ("gen_ai.usage.image.input_tokens", 20),
+            ("gen_ai.usage.audio.input_tokens", 30),
+            ("gen_ai.usage.text.output_tokens", 40),
+            ("gen_ai.usage.image.output_tokens", 50),
+            ("gen_ai.usage.audio.output_tokens", 60),
+            ("gen_ai.usage.text.cache_read.input_tokens", 5),
+            ("gen_ai.usage.image.cache_read.input_tokens", 6),
+            ("gen_ai.usage.audio.cache_read.input_tokens", 7),
+        ):
+            assert isinstance(attrs[key], int)
+            assert attrs[key] == value
+
+    def test_set_modality_tokens_accepts_enum_valued_modality(self):
+        class _Modality(Enum):
+            AUDIO = "AUDIO"
+
+        invocation = self.telemetry_handler.inference(
+            "test-provider", request_model="test-model"
+        )
+        invocation.set_input_tokens([(_Modality.AUDIO, 11)])
+        invocation.stop()
+
+        attrs = self.span_exporter.get_finished_spans()[0].attributes
+        assert attrs["gen_ai.usage.audio.input_tokens"] == 11
+
+    def test_set_modality_tokens_replaces_rather_than_merges(self):
+        invocation = self.telemetry_handler.inference(
+            "test-provider", request_model="test-model"
+        )
+        invocation.set_input_tokens([("text", 10), ("audio", 90)])
+        invocation.set_input_tokens([("text", 12)])
+        invocation.stop()
+
+        attrs = self.span_exporter.get_finished_spans()[0].attributes
+        assert attrs["gen_ai.usage.text.input_tokens"] == 12
+        assert "gen_ai.usage.audio.input_tokens" not in attrs
+
+    def test_set_modality_tokens_empty_iterable_clears_the_bucket(self):
+        invocation = self.telemetry_handler.inference(
+            "test-provider", request_model="test-model"
+        )
+        invocation.set_input_tokens([("audio", 90)])
+        invocation.set_input_tokens([])
+        invocation.stop()
+
+        attrs = self.span_exporter.get_finished_spans()[0].attributes
+        assert "gen_ai.usage.audio.input_tokens" not in attrs
+
+    def test_set_modality_tokens_none_leaves_values_alone(self):
+        invocation = self.telemetry_handler.inference(
+            "test-provider", request_model="test-model"
+        )
+        invocation.set_input_tokens([("audio", 90)])
+        invocation.set_input_tokens(None)
+        invocation.stop()
+
+        attrs = self.span_exporter.get_finished_spans()[0].attributes
+        assert attrs["gen_ai.usage.audio.input_tokens"] == 90
+
+    def test_set_modality_tokens_drops_invalid_counts(self):
+        invocation = self.telemetry_handler.inference(
+            "test-provider", request_model="test-model"
+        )
+        invocation.set_input_tokens(
+            [
+                ("text", True),
+                ("image", -5),
+                ("audio", None),
+            ]
+        )
+        invocation.set_output_tokens([("text", "10"), ("audio", 1.5)])
+        invocation.stop()
+
+        attrs = self.span_exporter.get_finished_spans()[0].attributes
+        for key in (
+            "gen_ai.usage.text.input_tokens",
+            "gen_ai.usage.image.input_tokens",
+            "gen_ai.usage.audio.input_tokens",
+            "gen_ai.usage.text.output_tokens",
+            "gen_ai.usage.audio.output_tokens",
+        ):
+            assert key not in attrs
+
+    def test_set_modality_tokens_drops_unmapped_modalities(self):
+        invocation = self.telemetry_handler.inference(
+            "test-provider", request_model="test-model"
+        )
+        invocation.set_input_tokens(
+            [
+                ("video", 7),
+                ("document", 8),
+                ("MODALITY_UNSPECIFIED", 9),
+                ("", 10),
+            ]
+        )
+        invocation.stop()
+
+        attrs = self.span_exporter.get_finished_spans()[0].attributes
+        for key in attrs:
+            assert not key.startswith("gen_ai.usage.video")
+            assert not key.startswith("gen_ai.usage.document")
+        assert "gen_ai.usage.text.input_tokens" not in attrs
 
     def test_inference_modality_and_cache_tokens_omitted_when_zero(self):
         invocation = self.telemetry_handler.inference(


### PR DESCRIPTION
Fixes #564.

`generate_content` now maps `usage_metadata.prompt_tokens_details`, `candidates_tokens_details` and `cache_tokens_details` onto the text, image and audio token usage attributes on the inference span.

The same breakdown already lands for `interactions` (#613) and for langchain (#671), so a `generate_content` call with audio or image input was reporting only the aggregate counts.

A streaming chunk redelivers cumulative usage, as `test_includes_token_counts_in_span_not_aggregated_from_responses` already records, so an arriving breakdown replaces the previous one. Merging would let a modality that drops out of a later chunk keep a stale count and push the breakdown over the total next to it.

Known gaps:

* `usage_metadata.tool_use_prompt_tokens_details` is not mapped, because `opentelemetry-util-genai` has no field for it.
* Video and document modalities have no attribute in `opentelemetry-util-genai`, so those entries are skipped.
* `interactions.py` keeps its own `_set_modality_tokens`. The payload shapes differ (`token_count` versus `tokens`, enum versus plain string) and #616 is already editing that file, so unifying them is better as a follow up.
